### PR TITLE
1414 jackson ignore examplesetflag

### DIFF
--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -3,7 +3,11 @@ package io.javalin.plugin.openapi.jackson
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import io.javalin.plugin.openapi.utils.LazyDefaultValue
+import io.swagger.v3.core.jackson.mixin.MediaTypeMixin
+import io.swagger.v3.core.jackson.mixin.SchemaMixin
 import io.swagger.v3.core.util.Json
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
 
 /**
  * Default jackson mapper for creating the object api schema json.
@@ -19,6 +23,8 @@ class JacksonToJsonMapper(
     companion object {
         val defaultObjectMapper: ObjectMapper by LazyDefaultValue {
             Json.mapper().registerModule(kotlinModule())
+                    .addMixIn(Schema::class.java, SchemaMixin::class.java)
+                    .addMixIn(MediaType::class.java, MediaTypeMixin::class.java)
         }
     }
 

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiJson.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiJson.kt
@@ -1,0 +1,75 @@
+package io.javalin.plugin.openapi
+
+import io.javalin.Javalin
+import io.javalin.examples.addUserDocs
+import io.javalin.examples.addUserHandler
+import io.javalin.examples.getUserDocs
+import io.javalin.examples.getUserHandler
+import io.javalin.examples.getUsersDocs
+import io.javalin.examples.getUsersHandler
+import io.javalin.http.InternalServerErrorResponse
+import io.javalin.plugin.openapi.dsl.documented
+import io.javalin.plugin.openapi.ui.SwaggerOptions
+import io.javalin.testing.TestUtil
+import io.swagger.v3.oas.models.info.Info
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TestOpenApiJson {
+
+    companion object {
+        fun createDocumentedJavalin(): Javalin {
+            val app = Javalin.create {
+                val openApiOptions = OpenApiOptions(
+                        Info().version("1.0").description("My Application"))
+                        .path("/swagger-docs")
+                        .swagger(SwaggerOptions("/swagger").title("My Swagger Documentation"))
+                        .defaultDocumentation { documentation -> documentation.json<InternalServerErrorResponse>("500") }
+                it.registerPlugin(OpenApiPlugin(openApiOptions))
+            }
+
+            with(app) {
+                get("/users", documented(getUsersDocs, ::getUsersHandler))
+                get("/users/{id}", documented(getUserDocs, ::getUserHandler))
+                post("/users", documented(addUserDocs, ::addUserHandler))
+            }
+
+            return app
+        }
+    }
+
+    /**
+     * A minor test to verify, the OpenAPI Json was generated
+     */
+    @Test
+    fun testOpenApiJsonIsAvailable() = TestUtil.test(createDocumentedJavalin()){ app, http ->
+        val resp = http.get("/swagger")
+        // Generally: Is the openapi json available
+        Assertions.assertThat(resp.status == 200)
+        // Sanity check: JSON like?
+        Assertions.assertThat(resp.body.startsWith("{"))
+        Assertions.assertThat(resp.body.endsWith("}"))
+        // Basic assertions towards openapi json
+        Assertions.assertThat(resp.body.contains("My Application"))
+        Assertions.assertThat(resp.body.contains("openapi"))
+        Assertions.assertThat(resp.body.contains("paths"))
+        Assertions.assertThat(resp.body.contains("schema"))
+    }
+
+    /**
+     * Verifying that there is no exampleSetFlag in the json
+     */
+    @Test fun testOpenApiJsonNotContainsExampleSetFlag() = TestUtil.test(createDocumentedJavalin()){ app, http->
+        val resp = http.get("/swagger")
+        // Generally: Is the openapi json available
+        Assertions.assertThat(resp.status == 200)
+        // Sanity check: JSON like?
+        Assertions.assertThat(resp.body.startsWith("{"))
+        Assertions.assertThat(resp.body.endsWith("}"))
+
+        // No internal property exposed such as 'exampleFlagSet'
+        Assertions.assertThat(!resp.body.contains("exampleFlagSet"))
+    }
+
+
+}


### PR DESCRIPTION
Added the [SchemaMixin](https://javadoc.io/static/io.swagger.core.v3/swagger-core/2.1.10/io/swagger/v3/core/jackson/mixin/SchemaMixin.html) and [MediaTypeMixin](https://javadoc.io/static/io.swagger.core.v3/swagger-core/2.1.10/io/swagger/v3/core/jackson/mixin/SchemaMixin.html) to the default `Jackson2JsonMapper` in order to explicitely ignore `exampleFlagSet` property of Schema and MediaType.
This addresses #1414 and is more or less a re-adding of #1089 (the fix for #1079).

Additionally added end-to-end testing with respect to the openapi-json.

Any feedback is welcome. I plan to add more end-to-end tests as well as I'm thinking on using the openapi generator to verify the openapi-json