### PR TITLE
[tests] Replace ineffective manual management of temp files with dedicated @TempDir directive

### DIFF
--- a/javalin/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/javalin/src/test/java/io/javalin/TestCustomJetty.kt
@@ -31,6 +31,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.util.*
 import java.util.concurrent.atomic.AtomicLong
@@ -44,8 +45,10 @@ import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-
 class TestCustomJetty {
+
+    @TempDir
+    lateinit var workingDirectory: File
 
     @Test
     fun `setting port works`() {
@@ -122,8 +125,7 @@ class TestCustomJetty {
             httpOnly = true
             sessionCache = DefaultSessionCache(this).apply {
                 sessionDataStore = FileSessionDataStore().apply {
-                    val baseDir = File(System.getProperty("java.io.tmpdir"))
-                    this.storeDir = File(baseDir, "javalin-session-store-for-test").apply { mkdir() }
+                    this.storeDir = workingDirectory
                 }
             }
         }
@@ -134,9 +136,6 @@ class TestCustomJetty {
         val httpHandler = (newServer.handlers[0] as ServletContextHandler)
         assertThat(httpHandler.sessionHandler).isEqualTo(fileSessionHandler)
         javalin.stop()
-
-        val baseDir = File(System.getProperty("java.io.tmpdir"))
-        File(baseDir, "javalin-session-store-for-test").deleteRecursively()
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestResponse.kt
+++ b/javalin/src/test/java/io/javalin/TestResponse.kt
@@ -18,12 +18,16 @@ import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.*
 
 class TestResponse {
+
+    @TempDir
+    lateinit var workingDirectory: File
 
     @Test
     fun `setting a String result works`() = TestUtil.test { app, http ->
@@ -70,15 +74,15 @@ class TestResponse {
 
     @Test
     fun `setting an InputStream result works and InputStream is closed`() = TestUtil.test { app, http ->
-        val path = "src/test/my-file.txt"
-        File(path).printWriter().use { out ->
-            out.print("Hello, World!")
-        }
         app.get("/file") { ctx ->
-            ctx.result(FileUtils.openInputStream(File(path)))
+            val file = File(workingDirectory, "my-file.txt").also {
+                it.printWriter().use { out ->
+                    out.print("Hello, World!")
+                }
+            }
+            ctx.result(FileUtils.openInputStream(file))
         }
         assertThat(http.getBody("/file")).isEqualTo("Hello, World!")
-        assertThat(File(path).delete()).isEqualTo(true)
     }
 
     @Disabled("https://github.com/tipsy/javalin/pull/1413")

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
@@ -12,9 +12,13 @@ import io.javalin.http.staticfiles.Location
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class TestStaticFilesEdgeCases {
+
+    @TempDir
+    lateinit var workingDirectory: File
 
     @Test
     fun `server doesn't start for non-existent classpath folder`() {
@@ -33,18 +37,14 @@ class TestStaticFilesEdgeCases {
     @Test
     fun `server doesn't start for empty classpath folder`() {
         assertThatExceptionOfType(RuntimeException::class.java)
-            .isThrownBy {
-                File("src/test/external/empty").mkdir()
-                Javalin.create { it.addStaticFiles("src/test/external/empty", Location.CLASSPATH) }.start()
-            }
-            .withMessageStartingWith("Static resource directory with path: 'src/test/external/empty' does not exist.")
+            .isThrownBy { Javalin.create { it.addStaticFiles(workingDirectory.absolutePath, Location.CLASSPATH) }.start() }
+            .withMessageStartingWith("Static resource directory with path: '${workingDirectory.absolutePath}' does not exist.")
             .withMessageEndingWith("Depending on your setup, empty folders might not get copied to classpath.")
     }
 
     @Test
     fun `server starts for empty external folder`() {
-        File("src/test/external/empty").mkdir()
-        Javalin.create { it.addStaticFiles("src/test/external/empty", Location.EXTERNAL) }.start(0).stop()
+        Javalin.create { it.addStaticFiles(workingDirectory.absolutePath, Location.EXTERNAL) }.start(0).stop()
     }
 
     @Test


### PR DESCRIPTION
It's kinda annoying when Javalin creates test-only files directly in sources during test phase. Despite of the fact that it's just a bad practice in general, it also can't clean it up whenever test is interrupted/failed during the execution.