### PR TITLE
Provide a possibility to mute Javalin startup messages

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -168,10 +168,10 @@ public class Javalin {
         Util.printHelpfulMessageIfLoggerIsMissing();
         eventManager.fireEvent(JavalinEvent.SERVER_STARTING);
         try {
-            if(this._conf.showJavalinStartupMessages) JavalinLogger.info("Starting Javalin ...");
-            if(this._conf.showJavalinStartupMessages) Util.logJavalinVersion();
+            JavalinLogger.startup("Starting Javalin ...");
+            Util.logJavalinVersion();
             jettyServer.start(javalinJettyServlet);
-            if(this._conf.showJavalinStartupMessages) JavalinLogger.info("Javalin started in " + (System.currentTimeMillis() - startupTimer) + "ms \\o/");
+            JavalinLogger.startup("Javalin started in " + (System.currentTimeMillis() - startupTimer) + "ms \\o/");
             eventManager.fireEvent(JavalinEvent.SERVER_STARTED);
         } catch (Exception e) {
             JavalinLogger.error("Failed to start Javalin");

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -59,7 +59,6 @@ public class JavalinConfig {
     public boolean prefer405over404 = false;
     public boolean enforceSsl = false;
     public boolean showJavalinBanner = true;
-    public boolean showJavalinStartupMessages = true;
     public boolean ignoreTrailingSlashes = true;
     @NotNull public String defaultContentType = ContentType.PLAIN;
     @NotNull public String contextPath = "/";

--- a/javalin/src/main/java/io/javalin/core/util/JavalinLogger.kt
+++ b/javalin/src/main/java/io/javalin/core/util/JavalinLogger.kt
@@ -9,6 +9,13 @@ object JavalinLogger {
     private val log = LoggerFactory.getLogger(Javalin::class.java)!!
 
     @JvmField var enabled = true
+    @JvmField var startupInfo = true
+
+
+    @JvmOverloads @JvmStatic fun startup(message: String) {
+        if (!enabled) return
+        if (startupInfo) log.info(message)
+    }
 
     @JvmOverloads @JvmStatic fun info(message: String, throwable: Throwable? = null) {
         if (!enabled) return

--- a/javalin/src/main/java/io/javalin/core/util/Util.kt
+++ b/javalin/src/main/java/io/javalin/core/util/Util.kt
@@ -129,7 +129,7 @@ object Util {
             it.load(this.javaClass.classLoader.getResourceAsStream(propertiesPath))
         }
         val (version, buildTime) = listOf(properties.getProperty("version")!!, properties.getProperty("buildTime")!!)
-        JavalinLogger.info("You are running Javalin $version (released ${formatBuildTime(buildTime)}).")
+        JavalinLogger.startup("You are running Javalin $version (released ${formatBuildTime(buildTime)}).")
     } catch (e: Exception) {
         // it's not that important
     }

--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -39,7 +39,7 @@ class JettyServer(val config: JavalinConfig) {
     fun start(wsAndHttpServlet: JavalinJettyServlet) {
         if (serverPort == -1 && config.inner.server == null) {
             serverPort = 8080
-            if(config.showJavalinStartupMessages) JavalinLogger.info("No port specified, starting on port $serverPort. Call start(port) to change ports.")
+            JavalinLogger.startup("No port specified, starting on port $serverPort. Call start(port) to change ports.")
         }
 
         config.inner.sessionHandler = config.inner.sessionHandler ?: defaultSessionHandler()
@@ -65,11 +65,11 @@ class JettyServer(val config: JavalinConfig) {
         }.start()
 
         server().connectors.filterIsInstance<ServerConnector>().forEach {
-            if(config.showJavalinStartupMessages) JavalinLogger.info("Listening on ${it.protocol}://${it.host ?: "localhost"}:${it.localPort}${config.contextPath}")
+            JavalinLogger.startup("Listening on ${it.protocol}://${it.host ?: "localhost"}:${it.localPort}${config.contextPath}")
         }
 
         server().connectors.filter { it !is ServerConnector }.forEach {
-            JavalinLogger.info("Binding to: $it")
+            JavalinLogger.startup("Binding to: $it")
         }
 
         JettyUtil.reEnableJettyLogger()

--- a/javalin/src/test/java/io/javalin/TestConfiguration.kt
+++ b/javalin/src/test/java/io/javalin/TestConfiguration.kt
@@ -9,6 +9,7 @@ package io.javalin
 import io.javalin.core.compression.CompressionStrategy
 import io.javalin.core.compression.Gzip
 import io.javalin.core.util.Header
+import io.javalin.core.util.JavalinLogger
 import io.javalin.core.util.RouteOverviewPlugin
 import io.javalin.http.ContentType
 import io.javalin.http.Context
@@ -57,7 +58,6 @@ class TestConfiguration {
             // Misc
             it.accessManager { _, _, _ -> }
             it.showJavalinBanner = false
-            it.showJavalinStartupMessages = false
             it.configureServletContextHandler { handler ->
                 handler.addEventListener(object : HttpSessionListener {
                     override fun sessionCreated(e: HttpSessionEvent?) {


### PR DESCRIPTION
Enables javalin to supress the startup messages printed to the INFO log, as requested on #1376 by adding a config boolean called `showJavalinStartupMessages`

It effectively supresses the highlited messages: 
![Untitled](https://user-images.githubusercontent.com/23284823/138861418-066d4a5b-30a4-4647-8459-9c0e44b3b388.png)




This parameter is tested on the [TestConfiguration](https://github.com/tipsy/javalin/blob/3e3ca24283afd4d87ce4b725e936976060915e3b/javalin/src/test/java/io/javalin/TestConfiguration.kt#L60) class.