### PR TITLE
[testing] Add test cases for exception handling in JavalinTest

### DIFF
--- a/javalin-testtools/src/test/java/io/javalin/testtools/JavaTest.java
+++ b/javalin-testtools/src/test/java/io/javalin/testtools/JavaTest.java
@@ -175,15 +175,21 @@ public class JavaTest {
     }
 
     @Test
-    public void exception_in_handler_code_is_printed_to_std_out() {
-        JavalinTest.test( (server, client) -> {
-            server.get("/hello", ctx -> {
-                throw new Exception("Error in handler code");
+    public void exception_in_handler_code_is_included_in_test_logs() {
+        Javalin app = Javalin.create();
+
+        try {
+            JavalinTest.test(app, (server, client) -> {
+                server.get("/hello", ctx -> {
+                    throw new Exception("Error in handler code");
+                });
+
+                assertThat(client.get("/hello").code()).isEqualTo(200);
             });
+        } catch (Throwable t) {
+            // Ignore
+        }
 
-            client.get("/hello");
-
-            // TODO: Test that log contains "JavalinTest#test failed - full log output below"
-        });
+        assertThat((String) app.attribute("testlogs")).contains("Error in handler code");
     }
 }

--- a/javalin-testtools/src/test/java/io/javalin/testtools/JavaTest.java
+++ b/javalin-testtools/src/test/java/io/javalin/testtools/JavaTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class JavaTest {
@@ -151,4 +153,37 @@ public class JavaTest {
         });
     }
 
+    public void exceptions_in_test_code_get_rethrown() {
+        assertThatExceptionOfType(Exception.class).isThrownBy(() ->
+            JavalinTest.test((server, client) -> {
+                throw new Exception("Error in test code");
+            })
+        ).withMessageMatching("Error in test code");
+    }
+
+    @Test
+    public void exceptions_in_handler_code_are_caught_by_exception_handler_and_not_thrown() {
+        assertThatNoException().isThrownBy(() ->
+            JavalinTest.test( (server, client) -> {
+                server.get("/hello", ctx -> {
+                    throw new Exception("Error in handler code");
+                });
+
+                assertThat(client.get("/hello").code()).isEqualTo(500);
+            })
+        );
+    }
+
+    @Test
+    public void exception_in_handler_code_is_printed_to_std_out() {
+        JavalinTest.test( (server, client) -> {
+            server.get("/hello", ctx -> {
+                throw new Exception("Error in handler code");
+            });
+
+            client.get("/hello");
+
+            // TODO: Test that log contains "JavalinTest#test failed - full log output below"
+        });
+    }
 }


### PR DESCRIPTION
Related to https://github.com/tipsy/javalin/pull/1565

Adds test cases to verify the behaviour of the exception handling.

Looking for a way to test the added logging behaviour in [PR 1565](https://github.com/tipsy/javalin/pull/1565): https://github.com/tipsy/javalin/pull/1566/files#diff-8213d57a28ef5ab05d803ccc0057eee4f193bcdafd136d0f57c31db7cdaca044R127
Any ideas?