### PR TITLE
[websocket] Add enableAutomaticPings & disableAutomaticPings

### DIFF
--- a/javalin/src/main/java/io/javalin/websocket/WsAutomaticPing.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsAutomaticPing.kt
@@ -1,0 +1,24 @@
+package io.javalin.websocket
+
+import java.nio.ByteBuffer
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+
+var executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+
+fun enableAutomaticPings(ctx: WsContext, interval: Long, unit: TimeUnit, applicationData: ByteBuffer?) {
+    synchronized(ctx) {
+        disableAutomaticPings(ctx);
+        ctx.pingFuture = executor.scheduleAtFixedRate({
+            ctx.sendPing(applicationData);
+        }, interval, interval, unit);
+    }
+}
+fun disableAutomaticPings(ctx: WsContext) {
+    synchronized(ctx) {
+        ctx.pingFuture?.cancel(false)
+        ctx.pingFuture = null;
+    }
+}

--- a/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
@@ -54,6 +54,7 @@ class WsConnection(val matcher: WsPathMatcher, val exceptionMapper: WsExceptionM
         tryBeforeAndEndpointHandlers(ctx) { it.wsConfig.wsCloseHandler?.handleClose(ctx) }
         tryAfterHandlers(ctx) { it.wsConfig.wsCloseHandler?.handleClose(ctx) }
         wsLogger?.wsCloseHandler?.handleClose(ctx)
+        ctx.disableAutomaticPings()
     }
 
     @OnWebSocketError

--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -29,9 +29,6 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
     internal val sessionAttributes by lazy { upgradeReq.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as Map<String, Any>? }
     internal var pingFuture : ScheduledFuture<*>? = null;
 
-    companion object {
-        var executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
-    }
 
     fun matchedPath() = upgradeCtx.matchedPath
 
@@ -41,14 +38,10 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
 
     @JvmOverloads fun sendPing(applicationData: ByteBuffer? = null) = session.remote.sendPing(applicationData ?: ByteBuffer.allocate(0))
     @JvmOverloads fun enableAutomaticPings(interval: Long = 1, unit: TimeUnit = TimeUnit.MINUTES, applicationData: ByteBuffer? = null) {
-        disableAutomaticPings();
-        pingFuture = executor.scheduleAtFixedRate({
-            sendPing(applicationData);
-        }, interval, interval, unit);
+        enableAutomaticPings(this, interval, unit, applicationData)
     }
     fun disableAutomaticPings() {
-        pingFuture?.cancel(false)
-        pingFuture = null;
+        disableAutomaticPings(this)
     }
 
     fun queryString(): String? = upgradeCtx.queryString()


### PR DESCRIPTION
This refers to issue #1567 and adds methods for enabling & disabling automatic websocket pings.

I'm not entirely sure on how synchronization works with the used methods, to we need a mutex or similar? Is there a race somewhere in the code if two threads call enableAutomaticPings/disableAutomaticPings at the same time? Is that even possible? 

Maybe some sort of locking mechanism is required, but as a first prototype this patch does seem to work.