### PR TITLE
Limit Snapshot Job to the main repository

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    if: github.repository == 'javalin/javalin'
     name: Publish snapshot
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Syncing my fork causes a github action failure as my fork (rightfully) does not have the credentials.
This change limits the job to only run on the main repository.

Ref: https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution