### PR TITLE
New config option treatMultipleSlashesAsSingleSlash - fixes #1528

### DIFF
--- a/javalin-testtools/src/test/java/io/javalin/testtools/JavaApp.java
+++ b/javalin-testtools/src/test/java/io/javalin/testtools/JavaApp.java
@@ -9,7 +9,7 @@ import static io.javalin.apibuilder.ApiBuilder.get;
 public class JavaApp {
 
     public static Javalin app = Javalin.create(javalin -> {
-        javalin.ignoreTrailingSlashes = false;
+        javalin.routing.ignoreTrailingSlashes = false;
     }).routes(() -> {
         get("/hello", HelloController::hello);
     });

--- a/javalin-testtools/src/test/kotlin/io/javalin/testtools/KotlinApp.kt
+++ b/javalin-testtools/src/test/kotlin/io/javalin/testtools/KotlinApp.kt
@@ -8,7 +8,7 @@ import io.javalin.http.Context
 // make it classes and do dependency injection or whatever
 object KotlinApp {
     var app = Javalin.create { javalin ->
-        javalin.ignoreTrailingSlashes = false
+        javalin.routing.ignoreTrailingSlashes = false
     }.routes {
         ApiBuilder.get("/hello", HelloController::hello)
     }

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -60,6 +60,7 @@ public class JavalinConfig {
     public boolean enforceSsl = false;
     public boolean showJavalinBanner = true;
     public boolean ignoreTrailingSlashes = true;
+    public boolean treatMultipleSlashesAsSingleSlash = false;
     @NotNull public String defaultContentType = ContentType.PLAIN;
     @NotNull public String contextPath = "/";
     public Long maxRequestSize = 1_000_000L; // either increase this or use inputstream to handle large requests

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -59,13 +59,17 @@ public class JavalinConfig {
     public boolean prefer405over404 = false;
     public boolean enforceSsl = false;
     public boolean showJavalinBanner = true;
-    public boolean ignoreTrailingSlashes = true;
-    public boolean treatMultipleSlashesAsSingleSlash = false;
     @NotNull public String defaultContentType = ContentType.PLAIN;
     @NotNull public String contextPath = "/";
     public Long maxRequestSize = 1_000_000L; // either increase this or use inputstream to handle large requests
     @NotNull public Long asyncRequestTimeout = 0L;
+    @NotNull public RoutingConfig routing = new RoutingConfig();
     @NotNull public Inner inner = new Inner();
+
+    public static class RoutingConfig {
+        public boolean ignoreTrailingSlashes = true;
+        public boolean treatMultipleSlashesAsSingleSlash = false;
+    }
 
     // it's not bad to access this, the main reason it's hidden
     // is to provide a cleaner API with dedicated setters

--- a/javalin/src/main/java/io/javalin/core/PathParser.kt
+++ b/javalin/src/main/java/io/javalin/core/PathParser.kt
@@ -8,7 +8,13 @@ import io.javalin.core.routing.pathParamNames
 import io.javalin.core.routing.values
 import io.javalin.http.util.ContextUtil
 
-class PathParser(private val rawPath: String, ignoreTrailingSlashes: Boolean) {
+data class PathParserOptions(val ignoreTrailingSlashes: Boolean, val treatMultipleSlashesAsSingleSlash: Boolean)
+
+fun createPathParserOptionsFromConfig(config: JavalinConfig) = PathParserOptions(config.ignoreTrailingSlashes, false)
+
+class PathParser(private val rawPath: String, options: PathParserOptions) {
+
+    constructor(rawPath: String, config: JavalinConfig): this(rawPath, createPathParserOptionsFromConfig(config))
 
     init {
         if (rawPath.contains("/:")) {
@@ -32,7 +38,7 @@ class PathParser(private val rawPath: String, ignoreTrailingSlashes: Boolean) {
 
     //compute matchRegex suffix : if ignoreTrailingSlashes config is set we keep /?, else we use the true path trailing slash : present or absent
     private val regexSuffix = when {
-        ignoreTrailingSlashes -> "/?"
+        options.ignoreTrailingSlashes -> "/?"
         rawPath.endsWith("/") -> "/"
         else -> ""
     }

--- a/javalin/src/main/java/io/javalin/core/PathParser.kt
+++ b/javalin/src/main/java/io/javalin/core/PathParser.kt
@@ -1,5 +1,6 @@
 package io.javalin.core
 
+import io.javalin.core.JavalinConfig.RoutingConfig
 import io.javalin.core.routing.ParameterNamesNotUniqueException
 import io.javalin.core.routing.PathSegment
 import io.javalin.core.routing.constructRegexList
@@ -8,27 +9,7 @@ import io.javalin.core.routing.pathParamNames
 import io.javalin.core.routing.values
 import io.javalin.http.util.ContextUtil
 
-data class PathParserOptions(val ignoreTrailingSlashes: Boolean, val treatMultipleSlashesAsSingleSlash: Boolean)
-
-fun createPathParserOptionsFromConfig(config: JavalinConfig) = PathParserOptions(
-    ignoreTrailingSlashes = config.ignoreTrailingSlashes,
-    treatMultipleSlashesAsSingleSlash = config.treatMultipleSlashesAsSingleSlash
-)
-
-internal data class CombinedOptions constructor(
-    val ignoreTrailingSlashes: Boolean = false,
-    val treatMultipleSlashesAsSingleSlash: Boolean = false,
-    val matchPathAndEverySubPath: Boolean = false
-) {
-    constructor(options: PathParserOptions) : this(
-        ignoreTrailingSlashes = options.ignoreTrailingSlashes,
-        treatMultipleSlashesAsSingleSlash = options.treatMultipleSlashesAsSingleSlash
-    )
-}
-
-class PathParser(private val rawPath: String, options: PathParserOptions) {
-
-    constructor(rawPath: String, config: JavalinConfig): this(rawPath, createPathParserOptionsFromConfig(config))
+class PathParser(private val rawPath: String, routingConfig: RoutingConfig) {
 
     init {
         if (rawPath.contains("/:")) {
@@ -36,10 +17,8 @@ class PathParser(private val rawPath: String, options: PathParserOptions) {
         }
     }
 
-    private val combinedOptions: CombinedOptions = CombinedOptions(options).copy(
-        matchPathAndEverySubPath = rawPath.endsWith(">*") || rawPath.endsWith("}*")
-    )
-    private val path: String = if (combinedOptions.matchPathAndEverySubPath) rawPath.removeSuffix("*") else rawPath
+    private val matchPathAndEverySubPath = rawPath.endsWith(">*") || rawPath.endsWith("}*")
+    private val path: String = if (matchPathAndEverySubPath) rawPath.removeSuffix("*") else rawPath
 
     val segments: List<PathSegment> = path.split("/")
         .filter { it.isNotEmpty() }
@@ -53,26 +32,26 @@ class PathParser(private val rawPath: String, options: PathParserOptions) {
     }
 
     //compute matchRegex suffix :
-    private val regexSuffix = if(combinedOptions.treatMultipleSlashesAsSingleSlash) {
+    private val regexSuffix = if(routingConfig.treatMultipleSlashesAsSingleSlash) {
         // when multiple slashes are accepted we have to allow 0-n slashes when using ignoreTrailingSlashes
         // otherwise we also have to allow multiple slashes when only one slash is specified
         when {
-            options.ignoreTrailingSlashes -> "/*"
+            routingConfig.ignoreTrailingSlashes -> "/*"
             rawPath.endsWith("/") -> "/+"
             else -> ""
         }
     } else {
         // if ignoreTrailingSlashes config is set we keep /?, else we use the true path trailing slash : present or absent
         when {
-            options.ignoreTrailingSlashes -> "/?"
+            routingConfig.ignoreTrailingSlashes -> "/?"
             rawPath.endsWith("/") -> "/"
             else -> ""
         }
     }
 
-    private val matchRegex = constructRegexList(combinedOptions, segments, regexSuffix) { it.asRegexString() }
+    private val matchRegex = constructRegexList(routingConfig, matchPathAndEverySubPath, segments, regexSuffix) { it.asRegexString() }
     private val pathParamRegex =
-        constructRegexList(combinedOptions, segments, regexSuffix) { it.asGroupedRegexString() }
+        constructRegexList(routingConfig, matchPathAndEverySubPath, segments, regexSuffix) { it.asGroupedRegexString() }
 
     fun matches(url: String): Boolean = matchRegex.any { url matches it }
 

--- a/javalin/src/main/java/io/javalin/core/PathParser.kt
+++ b/javalin/src/main/java/io/javalin/core/PathParser.kt
@@ -10,7 +10,21 @@ import io.javalin.http.util.ContextUtil
 
 data class PathParserOptions(val ignoreTrailingSlashes: Boolean, val treatMultipleSlashesAsSingleSlash: Boolean)
 
-fun createPathParserOptionsFromConfig(config: JavalinConfig) = PathParserOptions(config.ignoreTrailingSlashes, false)
+fun createPathParserOptionsFromConfig(config: JavalinConfig) = PathParserOptions(
+    ignoreTrailingSlashes = config.ignoreTrailingSlashes,
+    treatMultipleSlashesAsSingleSlash = config.treatMultipleSlashesAsSingleSlash
+)
+
+internal data class CombinedOptions constructor(
+    val ignoreTrailingSlashes: Boolean = false,
+    val treatMultipleSlashesAsSingleSlash: Boolean = false,
+    val matchPathAndEverySubPath: Boolean = false
+) {
+    constructor(options: PathParserOptions) : this(
+        ignoreTrailingSlashes = options.ignoreTrailingSlashes,
+        treatMultipleSlashesAsSingleSlash = options.treatMultipleSlashesAsSingleSlash
+    )
+}
 
 class PathParser(private val rawPath: String, options: PathParserOptions) {
 
@@ -22,8 +36,10 @@ class PathParser(private val rawPath: String, options: PathParserOptions) {
         }
     }
 
-    private val matchPathAndEverySubPath: Boolean = rawPath.endsWith(">*") || rawPath.endsWith("}*")
-    private val path: String = if (matchPathAndEverySubPath) rawPath.removeSuffix("*") else rawPath
+    private val combinedOptions: CombinedOptions = CombinedOptions(options).copy(
+        matchPathAndEverySubPath = rawPath.endsWith(">*") || rawPath.endsWith("}*")
+    )
+    private val path: String = if (combinedOptions.matchPathAndEverySubPath) rawPath.removeSuffix("*") else rawPath
 
     val segments: List<PathSegment> = path.split("/")
         .filter { it.isNotEmpty() }
@@ -36,16 +52,27 @@ class PathParser(private val rawPath: String, options: PathParserOptions) {
         }
     }
 
-    //compute matchRegex suffix : if ignoreTrailingSlashes config is set we keep /?, else we use the true path trailing slash : present or absent
-    private val regexSuffix = when {
-        options.ignoreTrailingSlashes -> "/?"
-        rawPath.endsWith("/") -> "/"
-        else -> ""
+    //compute matchRegex suffix :
+    private val regexSuffix = if(combinedOptions.treatMultipleSlashesAsSingleSlash) {
+        // when multiple slashes are accepted we have to allow 0-n slashes when using ignoreTrailingSlashes
+        // otherwise we also have to allow multiple slashes when only one slash is specified
+        when {
+            options.ignoreTrailingSlashes -> "/*"
+            rawPath.endsWith("/") -> "/+"
+            else -> ""
+        }
+    } else {
+        // if ignoreTrailingSlashes config is set we keep /?, else we use the true path trailing slash : present or absent
+        when {
+            options.ignoreTrailingSlashes -> "/?"
+            rawPath.endsWith("/") -> "/"
+            else -> ""
+        }
     }
 
-    private val matchRegex = constructRegexList(matchPathAndEverySubPath, segments, regexSuffix) { it.asRegexString() }
+    private val matchRegex = constructRegexList(combinedOptions, segments, regexSuffix) { it.asRegexString() }
     private val pathParamRegex =
-        constructRegexList(matchPathAndEverySubPath, segments, regexSuffix) { it.asGroupedRegexString() }
+        constructRegexList(combinedOptions, segments, regexSuffix) { it.asGroupedRegexString() }
 
     fun matches(url: String): Boolean = matchRegex.any { url matches it }
 

--- a/javalin/src/main/java/io/javalin/core/routing/RoutingRegexes.kt
+++ b/javalin/src/main/java/io/javalin/core/routing/RoutingRegexes.kt
@@ -1,16 +1,17 @@
 package io.javalin.core.routing
 
-import io.javalin.core.CombinedOptions
+import io.javalin.core.JavalinConfig.RoutingConfig
 
 internal fun constructRegexList(
-    options: CombinedOptions,
+    options: RoutingConfig,
+    matchEverySubPath: Boolean,
     segments: List<PathSegment>,
     regexSuffix: String,
     regexOptions: Set<RegexOption> = emptySet(),
     mapper: (PathSegment) -> String
 ): List<Regex> {
     fun addRegexForExtraWildcard(): List<Regex> {
-        return if (options.matchPathAndEverySubPath) {
+        return if (matchEverySubPath) {
             listOf(constructRegex(options, segments + PathSegment.Wildcard, regexSuffix, regexOptions, mapper))
         } else {
             emptyList()
@@ -21,7 +22,7 @@ internal fun constructRegexList(
 }
 
 internal fun constructRegex(
-    options: CombinedOptions,
+    options: RoutingConfig,
     segments: List<PathSegment>,
     regexSuffix: String,
     regexOptions: Set<RegexOption> = emptySet(),

--- a/javalin/src/main/java/io/javalin/http/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinServlet.kt
@@ -94,7 +94,7 @@ class JavalinServlet(val config: JavalinConfig) : HttpServlet() {
 
     fun addHandler(handlerType: HandlerType, path: String, handler: Handler, roles: Set<RouteRole>) {
         val protectedHandler = if (handlerType.isHttpMethod()) Handler { ctx -> config.inner.accessManager.manage(handler, ctx, roles) } else handler
-        matcher.add(HandlerEntry(handlerType, path, config, protectedHandler, handler))
+        matcher.add(HandlerEntry(handlerType, path, config.routing, protectedHandler, handler))
     }
 
     private fun JavalinConfig.isCorsEnabled() = this.inner.plugins[CorsPlugin::class.java] != null

--- a/javalin/src/main/java/io/javalin/http/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinServlet.kt
@@ -94,7 +94,7 @@ class JavalinServlet(val config: JavalinConfig) : HttpServlet() {
 
     fun addHandler(handlerType: HandlerType, path: String, handler: Handler, roles: Set<RouteRole>) {
         val protectedHandler = if (handlerType.isHttpMethod()) Handler { ctx -> config.inner.accessManager.manage(handler, ctx, roles) } else handler
-        matcher.add(HandlerEntry(handlerType, path, config.ignoreTrailingSlashes, protectedHandler, handler))
+        matcher.add(HandlerEntry(handlerType, path, config, protectedHandler, handler))
     }
 
     private fun JavalinConfig.isCorsEnabled() = this.inner.plugins[CorsPlugin::class.java] != null

--- a/javalin/src/main/java/io/javalin/http/PathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/http/PathMatcher.kt
@@ -6,17 +6,18 @@
 
 package io.javalin.http
 
+import io.javalin.core.JavalinConfig
 import io.javalin.core.PathParser
 import java.util.*
 
 data class HandlerEntry(
     val type: HandlerType,
     val path: String,
-    val ignoreTrailingSlashes: Boolean,
+    val javalinConfig: JavalinConfig,
     val handler: Handler,
     val rawHandler: Handler
 ) {
-    private val pathParser = PathParser(path, ignoreTrailingSlashes)
+    private val pathParser = PathParser(path, javalinConfig)
     fun matches(requestUri: String) = pathParser.matches(requestUri)
     fun extractPathParams(requestUri: String) = pathParser.extractPathParams(requestUri)
 }

--- a/javalin/src/main/java/io/javalin/http/PathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/http/PathMatcher.kt
@@ -6,18 +6,18 @@
 
 package io.javalin.http
 
-import io.javalin.core.JavalinConfig
+import io.javalin.core.JavalinConfig.RoutingConfig
 import io.javalin.core.PathParser
 import java.util.*
 
 data class HandlerEntry(
     val type: HandlerType,
     val path: String,
-    val javalinConfig: JavalinConfig,
+    val routingConfig: RoutingConfig,
     val handler: Handler,
     val rawHandler: Handler
 ) {
-    private val pathParser = PathParser(path, javalinConfig)
+    private val pathParser = PathParser(path, routingConfig)
     fun matches(requestUri: String) = pathParser.matches(requestUri)
     fun extractPathParams(requestUri: String) = pathParser.extractPathParams(requestUri)
 }

--- a/javalin/src/main/java/io/javalin/http/util/RedirectToLowercasePathPlugin.kt
+++ b/javalin/src/main/java/io/javalin/http/util/RedirectToLowercasePathPlugin.kt
@@ -26,7 +26,7 @@ class RedirectToLowercasePathPlugin : Plugin, PluginLifecycleInit {
     override fun init(app: Javalin) {
         app.events { e ->
             e.handlerAdded { h ->
-                val parser = PathParser(h.path, app._conf.ignoreTrailingSlashes)
+                val parser = PathParser(h.path, app._conf)
                 parser.segments.filterIsInstance<PathSegment.Normal>().map { it.content }.forEach {
                     if (it != it.lowercase(Locale.ROOT)) throw IllegalArgumentException("Paths must be lowercase when using RedirectToLowercasePathPlugin")
                 }
@@ -54,7 +54,7 @@ class RedirectToLowercasePathPlugin : Plugin, PluginLifecycleInit {
             }
             matcher.findEntries(type, requestUri.lowercase(Locale.ROOT)).firstOrNull()?.let { entry ->
                 val clientSegments = requestUri.split("/").filter { it.isNotEmpty() }.toTypedArray()
-                val serverSegments = PathParser(entry.path, app._conf.ignoreTrailingSlashes).segments
+                val serverSegments = PathParser(entry.path, app._conf).segments
                 serverSegments.forEachIndexed { i, serverSegment ->
                     if (serverSegment is PathSegment.Normal) {
                         clientSegments[i] = clientSegments[i].lowercase(Locale.ROOT) // this is also a "Normal" segment

--- a/javalin/src/main/java/io/javalin/http/util/RedirectToLowercasePathPlugin.kt
+++ b/javalin/src/main/java/io/javalin/http/util/RedirectToLowercasePathPlugin.kt
@@ -26,7 +26,7 @@ class RedirectToLowercasePathPlugin : Plugin, PluginLifecycleInit {
     override fun init(app: Javalin) {
         app.events { e ->
             e.handlerAdded { h ->
-                val parser = PathParser(h.path, app._conf)
+                val parser = PathParser(h.path, app._conf.routing)
                 parser.segments.filterIsInstance<PathSegment.Normal>().map { it.content }.forEach {
                     if (it != it.lowercase(Locale.ROOT)) throw IllegalArgumentException("Paths must be lowercase when using RedirectToLowercasePathPlugin")
                 }
@@ -54,7 +54,7 @@ class RedirectToLowercasePathPlugin : Plugin, PluginLifecycleInit {
             }
             matcher.findEntries(type, requestUri.lowercase(Locale.ROOT)).firstOrNull()?.let { entry ->
                 val clientSegments = requestUri.split("/").filter { it.isNotEmpty() }.toTypedArray()
-                val serverSegments = PathParser(entry.path, app._conf).segments
+                val serverSegments = PathParser(entry.path, app._conf.routing).segments
                 serverSegments.forEachIndexed { i, serverSegment ->
                     if (serverSegment is PathSegment.Normal) {
                         clientSegments[i] = clientSegments[i].lowercase(Locale.ROOT) // this is also a "Normal" segment

--- a/javalin/src/main/java/io/javalin/jetty/JavalinJettyServlet.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JavalinJettyServlet.kt
@@ -40,7 +40,7 @@ class JavalinJettyServlet(val config: JavalinConfig, private val httpServlet: Ja
     val wsPathMatcher = WsPathMatcher()
 
     fun addHandler(handlerType: WsHandlerType, path: String, ws: Consumer<WsConfig>, roles: Set<RouteRole>) {
-        wsPathMatcher.add(WsEntry(handlerType, path, config, WsConfig().apply { ws.accept(this) }, roles))
+        wsPathMatcher.add(WsEntry(handlerType, path, config.routing, WsConfig().apply { ws.accept(this) }, roles))
     }
 
     override fun configure(factory: WebSocketServletFactory) { // this is called once, before everything

--- a/javalin/src/main/java/io/javalin/jetty/JavalinJettyServlet.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JavalinJettyServlet.kt
@@ -40,7 +40,7 @@ class JavalinJettyServlet(val config: JavalinConfig, private val httpServlet: Ja
     val wsPathMatcher = WsPathMatcher()
 
     fun addHandler(handlerType: WsHandlerType, path: String, ws: Consumer<WsConfig>, roles: Set<RouteRole>) {
-        wsPathMatcher.add(WsEntry(handlerType, path, config.ignoreTrailingSlashes, WsConfig().apply { ws.accept(this) }, roles))
+        wsPathMatcher.add(WsEntry(handlerType, path, config, WsConfig().apply { ws.accept(this) }, roles))
     }
 
     override fun configure(factory: WebSocketServletFactory) { // this is called once, before everything

--- a/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
@@ -6,6 +6,7 @@
 
 package io.javalin.websocket
 
+import io.javalin.core.JavalinConfig
 import io.javalin.core.PathParser
 import io.javalin.core.security.RouteRole
 import java.util.*
@@ -13,11 +14,11 @@ import java.util.*
 data class WsEntry(
     val type: WsHandlerType,
     val path: String,
-    val ignoreTrailingSlashes: Boolean,
+    val javalinConfig: JavalinConfig,
     val wsConfig: WsConfig,
     val roles: Set<RouteRole>
 ) {
-    private val pathParser = PathParser(path, ignoreTrailingSlashes)
+    private val pathParser = PathParser(path, javalinConfig)
     fun matches(path: String) = pathParser.matches(path)
     fun extractPathParams(path: String) = pathParser.extractPathParams(path)
 }

--- a/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
@@ -6,7 +6,7 @@
 
 package io.javalin.websocket
 
-import io.javalin.core.JavalinConfig
+import io.javalin.core.JavalinConfig.RoutingConfig
 import io.javalin.core.PathParser
 import io.javalin.core.security.RouteRole
 import java.util.*
@@ -14,11 +14,11 @@ import java.util.*
 data class WsEntry(
     val type: WsHandlerType,
     val path: String,
-    val javalinConfig: JavalinConfig,
+    val routingConfig: RoutingConfig,
     val wsConfig: WsConfig,
     val roles: Set<RouteRole>
 ) {
-    private val pathParser = PathParser(path, javalinConfig)
+    private val pathParser = PathParser(path, routingConfig)
     fun matches(path: String) = pathParser.matches(path)
     fun extractPathParams(path: String) = pathParser.extractPathParams(path)
 }

--- a/javalin/src/test/java/io/javalin/TestMultipleSlashes.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipleSlashes.kt
@@ -1,0 +1,93 @@
+package io.javalin
+
+import io.javalin.http.HttpCode
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TestMultipleSlashes {
+    private val multipleSlashesApp = Javalin.create {
+        it.treatMultipleSlashesAsSingleSlash = true
+    }
+
+    private val multipleSlashesWithSignificantTrailingSlashesApp = Javalin.create {
+        it.treatMultipleSlashesAsSingleSlash = true
+        it.ignoreTrailingSlashes = false
+    }.get("/a") {
+        it.result("a")
+    }.get("/a/") {
+        it.result("a/")
+    }.get("/a/b") {
+        it.result("b")
+    }.get("/a/b/") {
+        it.result("b/")
+    }
+
+    @Test
+    fun `multiple slashes at the start are okay when multipleSlashes is enabled`() =
+        TestUtil.test(multipleSlashesApp) { app, http ->
+            app.get("/hello") { it.result("ok") }
+            val res = http.get("//hello")
+            assertThat(res.status).isEqualTo(200)
+            assertThat(res.body).isEqualTo("ok")
+        }
+
+    @Test
+    fun `multiple slashes in the middle are okay when multipleSlashes is enabled`() =
+        TestUtil.test(multipleSlashesApp) { app, http ->
+            app.get("/hello/world") { it.result("ok") }
+            val res = http.get("/hello//world")
+            assertThat(res.status).isEqualTo(200)
+            assertThat(res.body).isEqualTo("ok")
+        }
+
+    @Test
+    fun `multiple slashes at the end are okay when multipleSlashes is enabled`() =
+        TestUtil.test(multipleSlashesApp) { app, http ->
+            app.get("/hello") { it.result("ok") }
+            val res = http.get("/hello//")
+            assertThat(res.status).isEqualTo(200)
+            assertThat(res.body).isEqualTo("ok")
+        }
+
+    @Test
+    fun `multiple slashes together with match sub path`() =
+        TestUtil.test(multipleSlashesApp) { app, http ->
+            app.get("/{name}*") { it.result(it.pathParam("name")) }
+            assertThat(http.getBody("/text")).isEqualTo("text")
+            assertThat(http.getBody("/text//two")).isEqualTo("text")
+        }
+
+    @Test
+    fun `multiple slashes at the start work with significant trailing slashes`() =
+        TestUtil.test(multipleSlashesWithSignificantTrailingSlashesApp) { _, http ->
+            assertThat(http.getBody("//a")).isEqualTo("a")
+            assertThat(http.getBody("//a/")).isEqualTo("a/")
+        }
+
+    @Test
+    fun `multiple slashes in the middle work with significant trailing slashes`() =
+        TestUtil.test(multipleSlashesWithSignificantTrailingSlashesApp) { _, http ->
+            assertThat(http.getBody("/a//b")).isEqualTo("b")
+            assertThat(http.getBody("/a//b/")).isEqualTo("b/")
+        }
+
+    @Test
+    fun `multiple slashes at the end work with significant trailing slashes`() =
+        TestUtil.test(multipleSlashesWithSignificantTrailingSlashesApp) { _, http ->
+            assertThat(http.getBody("/a")).isEqualTo("a")
+            assertThat(http.getBody("/a//")).isEqualTo("a/")
+        }
+
+    @Test
+    fun `multiple slashes are not accepted when not enabled`() = TestUtil.test { app, http ->
+        app.get("/hello/world") { it.result("ok") }
+        listOf(
+            "//hello/world",
+            "/hello//world",
+            "/hello/world//"
+        ).forEach {
+            assertThat(http.getStatus(it)).isNotNull.isEqualTo(HttpCode.NOT_FOUND)
+        }
+    }
+}

--- a/javalin/src/test/java/io/javalin/TestMultipleSlashes.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipleSlashes.kt
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test
 
 class TestMultipleSlashes {
     private val multipleSlashesApp = Javalin.create {
-        it.treatMultipleSlashesAsSingleSlash = true
+        it.routing.treatMultipleSlashesAsSingleSlash = true
     }
 
     private val multipleSlashesWithSignificantTrailingSlashesApp = Javalin.create {
-        it.treatMultipleSlashesAsSingleSlash = true
-        it.ignoreTrailingSlashes = false
+        it.routing.treatMultipleSlashesAsSingleSlash = true
+        it.routing.ignoreTrailingSlashes = false
     }.get("/a") {
         it.result("a")
     }.get("/a/") {

--- a/javalin/src/test/java/io/javalin/TestRouting.kt
+++ b/javalin/src/test/java/io/javalin/TestRouting.kt
@@ -280,40 +280,4 @@ class TestRouting {
             }
         }
     }
-
-    @Test
-    fun `multiple slashes at the start are okay when multipleSlashes is enabled`() = TestUtil.test { app, http ->
-        app.get("/hello") { it.result("ok") }
-        val res = http.get("//hello")
-        assertThat(res.status).isEqualTo(200)
-        assertThat(res.body).isEqualTo("ok")
-    }
-
-    @Test
-    fun `multiple slashes in the middle are okay when multipleSlashes is enabled`() = TestUtil.test { app, http ->
-        app.get("/hello/world") { it.result("ok") }
-        val res = http.get("/hello//world")
-        assertThat(res.status).isEqualTo(200)
-        assertThat(res.body).isEqualTo("ok")
-    }
-
-    @Test
-    fun `multiple slashes at the end are okay when multipleSlashes is enabled`() = TestUtil.test { app, http ->
-        app.get("/hello") { it.result("ok") }
-        val res = http.get("/hello//")
-        assertThat(res.status).isEqualTo(200)
-        assertThat(res.body).isEqualTo("ok")
-    }
-
-    @Test
-    fun `multiple slashes are not accepted when not enabled`() = TestUtil.test { app, http ->
-        app.get("/hello/world") { it.result("ok") }
-        listOf(
-            "//hello/world",
-            "/hello//world",
-            "/hello/world//"
-        ).forEach {
-            assertThat(http.get(it).status).isEqualTo(404)
-        }
-    }
 }

--- a/javalin/src/test/java/io/javalin/TestRouting.kt
+++ b/javalin/src/test/java/io/javalin/TestRouting.kt
@@ -281,4 +281,39 @@ class TestRouting {
         }
     }
 
+    @Test
+    fun `multiple slashes at the start are okay when multipleSlashes is enabled`() = TestUtil.test { app, http ->
+        app.get("/hello") { it.result("ok") }
+        val res = http.get("//hello")
+        assertThat(res.status).isEqualTo(200)
+        assertThat(res.body).isEqualTo("ok")
+    }
+
+    @Test
+    fun `multiple slashes in the middle are okay when multipleSlashes is enabled`() = TestUtil.test { app, http ->
+        app.get("/hello/world") { it.result("ok") }
+        val res = http.get("/hello//world")
+        assertThat(res.status).isEqualTo(200)
+        assertThat(res.body).isEqualTo("ok")
+    }
+
+    @Test
+    fun `multiple slashes at the end are okay when multipleSlashes is enabled`() = TestUtil.test { app, http ->
+        app.get("/hello") { it.result("ok") }
+        val res = http.get("/hello//")
+        assertThat(res.status).isEqualTo(200)
+        assertThat(res.body).isEqualTo("ok")
+    }
+
+    @Test
+    fun `multiple slashes are not accepted when not enabled`() = TestUtil.test { app, http ->
+        app.get("/hello/world") { it.result("ok") }
+        listOf(
+            "//hello/world",
+            "/hello//world",
+            "/hello/world//"
+        ).forEach {
+            assertThat(http.get(it).status).isEqualTo(404)
+        }
+    }
 }

--- a/javalin/src/test/java/io/javalin/TestTrailingSlashes.kt
+++ b/javalin/src/test/java/io/javalin/TestTrailingSlashes.kt
@@ -20,7 +20,7 @@ import java.net.URLEncoder
 class TestTrailingSlashes {
     private val okHttp = OkHttpClient().newBuilder().build()
     fun OkHttpClient.getBody(path: String) = this.newCall(Request.Builder().url(path).get().build()).execute().body!!.string()
-    val javalin = Javalin.create { it.ignoreTrailingSlashes = false; }
+    val javalin = Javalin.create { it.routing.ignoreTrailingSlashes = false; }
 
     @Test
     fun `trailing slashes are ignored by default`() = TestUtil.test { app, http ->


### PR DESCRIPTION
This change replaces all slashes in the regex construction with a matching equivalent accepting multiple slashes.
As I did not want to pass another boolean to the path parser, I modified the path parser to accept the JavalinConfig object.

I introduced some extra options objects to clarify what is actually needed from the config object. 
Last but not least are a ton of tests to verify the new behaviour.

Looking forward to feedback. :)

fixes #1528 