### PR TITLE
Expose OkHttpClient via TestConfig

### DIFF
--- a/javalin-testtools/src/main/java/io/javalin/testtools/HttpClient.kt
+++ b/javalin-testtools/src/main/java/io/javalin/testtools/HttpClient.kt
@@ -11,9 +11,8 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import java.util.function.Consumer
 
-class HttpClient(val app: Javalin) {
+class HttpClient(val app: Javalin, val okHttp: OkHttpClient) {
 
-    var okHttp = OkHttpClient()
     var origin: String = "http://localhost:${app.port()}"
 
     fun request(request: Request) = okHttp.newCall(request).execute()

--- a/javalin-testtools/src/main/java/io/javalin/testtools/JavalinTest.kt
+++ b/javalin-testtools/src/main/java/io/javalin/testtools/JavalinTest.kt
@@ -2,6 +2,7 @@ package io.javalin.testtools
 
 import io.javalin.Javalin
 import io.javalin.core.util.JavalinLogger
+import okhttp3.OkHttpClient
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.*
@@ -10,14 +11,18 @@ object JavalinTest {
 
     class RunResult(val logs: String?, val exception: Exception?)
 
-    data class TestConfig(val clearCookies: Boolean = true, val captureLogs: Boolean = true)
+    data class TestConfig(
+        val clearCookies: Boolean = true,
+        val captureLogs: Boolean = true,
+        val okHttpClient: OkHttpClient = OkHttpClient()
+    )
 
     @JvmStatic
     @JvmOverloads
     fun test(app: Javalin = Javalin.create(), config: TestConfig = TestConfig(), testCase: TestCase) {
         val result: RunResult = runAndCaptureLogs(config) {
             app.start(0)
-            val http = HttpClient(app)
+            val http = HttpClient(app, config.okHttpClient)
             testCase.accept(app, http) // this is where the user's test happens
             if (config.clearCookies) {
                 val endpointUrl = "/clear-cookies-${UUID.randomUUID()}"


### PR DESCRIPTION
Implements https://github.com/javalin/javalin/issues/1582
@tipsy I decided to go for exposing `OkHttpClient` as it is much easier and fulfils my needs (currently `HttpClient` is coupled not only to `OkHttpClient` class but also `okhttp3.Request`- providing some abstraction over building request (e.g. adding header) looks like a overkill for me).

You also asked for making `JavalinTest` instantiable, I will do that in next PR :)

Signed-off-by: Mikolaj Matuszewski <mikolaj.matuszewski@digitalnewagency.com>