### PR TITLE
[context] Make Context#resultFuture() result non-null

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -368,7 +368,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     }
 
     /** Gets the current context result as a [CompletableFuture] (if set). */
-    fun resultFuture(): CompletableFuture<*>? = resultReference.get().future
+    fun resultFuture(): CompletableFuture<*> = resultReference.get().future
 
     /** Sets response content type to specified [String] value. */
     fun contentType(contentType: String): Context {


### PR DESCRIPTION
Small change, but since 4.6 `resultFuture()` never returns null, so we can cleanup the signature in 5.x