### PR TITLE
[core] Remove hot-fix for backwards compatibility of `ctx.req.startAsync()` from Javalin 4.x

### DIFF
--- a/javalin/src/test/java/io/javalin/TestFuture.kt
+++ b/javalin/src/test/java/io/javalin/TestFuture.kt
@@ -207,20 +207,6 @@ class TestFuture {
         assertThat(http.get("/").body).isEqualTo("Processed value")
     }
 
-    @Test
-    fun `should support legacy usage of asyncStart`() = TestUtil.test(impatientServer) { app, http ->
-        app.get("/") { ctx ->
-            ctx.req.startAsync()
-
-            getFuture("response").thenAccept {
-                ctx.res.outputStream.write(it.toByteArray())
-                ctx.req.asyncContext.complete()
-            }
-        }
-
-        assertThat(http.get("/").body).isEqualTo("response")
-    }
-
     private fun getFuture(result: String?, delay: Long = 10): CompletableFuture<String> {
         val future = CompletableFuture<String>()
         Executors.newSingleThreadScheduledExecutor().schedule({

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -106,7 +106,7 @@ class TestSse {
     }
 
     @Test
-    fun `send async data is properly processed`() = TestUtil.test { app, http ->
+    fun `sending async data is properly processed`() = TestUtil.test { app, http ->
         app.sse("/sse") {
             it.sendEvent("Sync event")
             CompletableFuture.runAsync {


### PR DESCRIPTION
The hot-fix was meant to be removed in Javalin 5.x, having this fix we can start working on things like `ctx.async {}` proposal / sse reimplementation on top of threadpools etc. (#1517)