### PR TITLE
[context] Support async task delegation through `Context.async()` method

### DIFF
--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -232,7 +232,7 @@ public class JavalinConfig {
 
         config.inner.appAttributes.putIfAbsent(JSON_MAPPER_KEY, new JavalinJackson());
         config.inner.appAttributes.putIfAbsent(CONTEXT_RESOLVER_KEY, new ContextResolver());
-        config.inner.appAttributes.putIfAbsent(ASYNC_EXECUTOR_KEY, Executors.newCachedThreadPool(new NamedThreadFactory("JettyServerThreadPool")));
+        config.inner.appAttributes.putIfAbsent(ASYNC_EXECUTOR_KEY, Executors.newCachedThreadPool(new NamedThreadFactory("JavalinDefaultAsyncThreadPool")));
 
         app.attribute(maxRequestSizeKey, config.maxRequestSize);
     }

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -38,6 +38,7 @@ import io.javalin.websocket.WsConfig;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -48,6 +49,8 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static io.javalin.http.ContextKt.ASYNC_EXECUTOR_KEY;
 import static io.javalin.http.ContextResolverKt.CONTEXT_RESOLVER_KEY;
 import static io.javalin.http.util.ContextUtil.maxRequestSizeKey;
 import static io.javalin.plugin.json.JsonMapperKt.JSON_MAPPER_KEY;
@@ -226,10 +229,12 @@ public class JavalinConfig {
         if (config.enforceSsl) {
             app.before(SecurityUtil::sslRedirect);
         }
-        config.inner.appAttributes.putIfAbsent(JSON_MAPPER_KEY, new JavalinJackson());
-        app.attribute(maxRequestSizeKey, config.maxRequestSize);
 
+        config.inner.appAttributes.putIfAbsent(JSON_MAPPER_KEY, new JavalinJackson());
         config.inner.appAttributes.putIfAbsent(CONTEXT_RESOLVER_KEY, new ContextResolver());
+        config.inner.appAttributes.putIfAbsent(ASYNC_EXECUTOR_KEY, Executors.newCachedThreadPool());
+
+        app.attribute(maxRequestSizeKey, config.maxRequestSize);
     }
 
     private <T> Stream<? extends T> getPluginsExtending(Class<T> clazz) {

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -232,7 +232,7 @@ public class JavalinConfig {
 
         config.inner.appAttributes.putIfAbsent(JSON_MAPPER_KEY, new JavalinJackson());
         config.inner.appAttributes.putIfAbsent(CONTEXT_RESOLVER_KEY, new ContextResolver());
-        config.inner.appAttributes.putIfAbsent(ASYNC_EXECUTOR_KEY, Executors.newCachedThreadPool());
+        config.inner.appAttributes.putIfAbsent(ASYNC_EXECUTOR_KEY, Executors.newCachedThreadPool(new NamedThreadFactory("JettyServerThreadPool")));
 
         app.attribute(maxRequestSizeKey, config.maxRequestSize);
     }

--- a/javalin/src/main/java/io/javalin/core/JavalinConfigExt.kt
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfigExt.kt
@@ -1,6 +1,18 @@
 package io.javalin.core
 
 import io.javalin.core.plugin.Plugin
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
 
 @JvmSynthetic
 inline fun <reified T : Plugin> JavalinConfig.getPlugin(): T = getPlugin(T::class.java)
+
+class NamedThreadFactory(private val prefix: String) : ThreadFactory {
+
+    private val group = Thread.currentThread().threadGroup
+    private val threadCount = AtomicInteger(0)
+
+    override fun newThread(runnalbe: Runnable): Thread =
+        Thread(group, runnalbe, "$prefix - ${threadCount.getAndIncrement()}", 0)
+
+}

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -391,18 +391,20 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     ): CompletableFuture<*> {
         var await = CompletableFuture.runAsync(task, executor)
 
-        if (timeout > 0)
+        if (timeout > 0) {
             await = await.orTimeout(timeout, MILLISECONDS)
+        }
 
-        if (onTimeout != null)
+        if (onTimeout != null) {
             await = await.exceptionally {
                 when (it) {
                     is TimeoutException -> onTimeout().let { null }
                     else -> throw it
                 }
             }
+        }
 
-        future(await) { /* do not process the result value */ }
+        future(await, callback = { /* noop */ })
         return await
     }
 

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -363,7 +363,25 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
         result.future?.takeIf { it.isDone }?.get() as InputStream? ?: result.previous
     }
 
-    /** Utility function that allows to run async task on top of the [Context.future] method. */
+    /**
+     * Utility function that allows to run async task on top of the [Context.future] method.
+     * It means you should treat provided task as a result of this handler, and you can't use any other result function simultaneously.
+     *
+     * @param executor Thread-pool used to execute the given task,
+     * by default this method will use global predefined executor service stored in [appAttributes] as [ASYNC_EXECUTOR_KEY].
+     * You can change this default in [io.javalin.core.JavalinConfig].
+     *
+     * @param timeout Timeout in milliseconds,
+     * by default it's 0 which means timeout watcher is disabled.
+     *
+     * @param onTimeout Timeout listener executed when [TimeoutException] is thrown in specified task.
+     * This timeout listener is a part of request lifecycle, so you can still modify context here.
+     *
+     * @return As a result, function returns a new future that you can listen to.
+     * The limitation is that you can't modify context after such event,
+     * because it'll most likely be executed when the connection is already closed,
+     * so it's just not thread-safe.
+     */
     @JvmOverloads
     fun async(
         executor: ExecutorService = appAttribute(ASYNC_EXECUTOR_KEY),

--- a/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
@@ -14,7 +14,12 @@ class SseClient internal constructor(
     private var blockingFuture: CompletableFuture<*>? = null
     private var closeCallback = Runnable {}
 
-    fun block() {
+    /**
+     * By blocking SSE connection, you can share client outside the handler to notify it from other sources.
+     * Keep in mind that this function is based on top of the [Context.future],
+     * so you can't use any result function in this scope anymore.
+     */
+    fun await() {
         this.blockingFuture = ctx.future(
             future = CompletableFuture<Nothing?>(),
             callback = { /* noop */}

--- a/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
@@ -9,7 +9,7 @@ class SseClient internal constructor(
     @JvmField val ctx: Context
 ) : Closeable {
 
-    private val emitter = Emitter(ctx.req.asyncContext)
+    private val emitter = Emitter(ctx)
     private var closeCallback = Runnable {}
 
     fun onClose(closeCallback: Runnable) {
@@ -17,7 +17,6 @@ class SseClient internal constructor(
     }
 
     override fun close() {
-        ctx.req.asyncContext.complete()
         closeCallback.run()
     }
 

--- a/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
@@ -19,7 +19,7 @@ class SseClient internal constructor(
      * Keep in mind that this function is based on top of the [Context.future],
      * so you can't use any result function in this scope anymore.
      */
-    fun await() {
+    fun keepAlive() {
         this.blockingFuture = ctx.future(
             future = CompletableFuture<Nothing?>(),
             callback = { /* noop */}

--- a/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
@@ -9,7 +9,7 @@ class SseClient internal constructor(
     @JvmField val ctx: Context
 ) : Closeable {
 
-    private val emitter = Emitter(ctx)
+    private val emitter = Emitter(ctx.res)
     private var closeCallback = Runnable {}
 
     fun onClose(closeCallback: Runnable) {
@@ -29,14 +29,14 @@ class SseClient internal constructor(
             is String -> emitter.emit(event, data.byteInputStream(), id)
             else -> emitter.emit(event, ctx.jsonMapper().toJsonString(data).byteInputStream(), id)
         }
-        if (emitter.isClosed()) { // can't detect if closed before we try emitting?
+        if (emitter.closed) { // can't detect if closed before we try emitting?
             this.close()
         }
     }
 
     fun sendComment(comment: String) {
         emitter.emit(comment)
-        if (emitter.isClosed()) {
+        if (emitter.closed) {
             this.close()
         }
     }

--- a/javalin/src/main/java/io/javalin/http/sse/SseHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseHandler.kt
@@ -22,14 +22,9 @@ class SseHandler @JvmOverloads constructor(
                 addHeader(Header.X_ACCEL_BUFFERING, "no") // See https://serverfault.com/a/801629
                 flushBuffer()
             }
-            ctx.req.startAsync(ctx.req, ctx.res).let { asyncContext ->
-                asyncContext.timeout = timeout
-                asyncContext.addListener(
-                    onTimeout = { asyncContext.complete() },
-                    onError = { asyncContext.complete() }
-                )
+            ctx.async(timeout = timeout) {
+                clientConsumer.accept(SseClient(ctx))
             }
-            clientConsumer.accept(SseClient(ctx))
         }
     }
 

--- a/javalin/src/test/java/io/javalin/TestAsync.kt
+++ b/javalin/src/test/java/io/javalin/TestAsync.kt
@@ -19,13 +19,15 @@ internal class TestAsync {
 
     @Test
     fun `exception in async works`() = TestUtil.test { app, http ->
-        app.get("/") { ctx ->
-            ctx.async {
-                throw UnsupportedOperationException()
+        app
+            .get("/") { ctx ->
+                ctx.async { throw UnsupportedOperationException() }
             }
-        }
+            .exception(UnsupportedOperationException::class.java) { error, ctx ->
+                ctx.result("Unsupported")
+            }
 
-        assertThat(http.get("/").body).isEqualTo("Internal server error")
+        assertThat(http.get("/").body).isEqualTo("Unsupported")
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestAsync.kt
+++ b/javalin/src/test/java/io/javalin/TestAsync.kt
@@ -9,12 +9,14 @@ internal class TestAsync {
     @Test
     fun `async requests works`() = TestUtil.test { app, http ->
         app.get("/") { ctx ->
+            val httpThreadName = Thread.currentThread().name
+
             ctx.async {
-                ctx.result("Response")
+                ctx.result((Thread.currentThread().name != httpThreadName).toString())
             }
         }
 
-        assertThat(http.get("/").body).isEqualTo("Response")
+        assertThat(http.get("/").body).isEqualTo("true")
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestAsync.kt
+++ b/javalin/src/test/java/io/javalin/TestAsync.kt
@@ -1,0 +1,47 @@
+package io.javalin
+
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class TestAsync {
+
+    @Test
+    fun `async requests works`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            ctx.async {
+                ctx.result("Response")
+            }
+        }
+
+        assertThat(http.get("/").body).isEqualTo("Response")
+    }
+
+    @Test
+    fun `exception in async works`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            ctx.async {
+                throw UnsupportedOperationException()
+            }
+        }
+
+        assertThat(http.get("/").body).isEqualTo("Internal server error")
+    }
+
+    @Test
+    fun `timeout should work`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            ctx.async(
+                timeout = 10L,
+                onTimeout = { ctx.result("Timeout") },
+                task = {
+                    Thread.sleep(500L)
+                    ctx.result("Result")
+                }
+            )
+        }
+
+        assertThat(http.get("/").body).isEqualTo("Timeout")
+    }
+
+}

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -129,7 +129,7 @@ class TestSse {
     }
 
     @Test
-    fun `user can freeze sse handler to leak sse client`() = TestUtil.test { app, http ->
+    fun `user can freeze sse handler to leak sse client outside the handler`() = TestUtil.test { app, http ->
         val clients = mutableListOf<SseClient>()
 
         // some 3rd party service
@@ -142,7 +142,7 @@ class TestSse {
 
         app.sse("/sse") { client ->
             clients.add(client)
-            client.await()
+            client.keepAlive()
 
             CompletableFuture.runAsync {
                 Thread.sleep(500)

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -148,7 +148,6 @@ class TestSse {
         }
 
         assertThat(http.sse("/sse").get().body.trim()).isEqualTo(": Emitted and closed!")
-
     }
 
 }

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -4,9 +4,7 @@ import io.javalin.http.sse.SseClient
 import io.javalin.testing.SerializableObject
 import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
-import org.bouncycastle.crypto.tls.ConnectionEnd.client
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -129,7 +129,7 @@ class TestSse {
     }
 
     @Test
-    fun `user can block sse handler to leak sse client`() = TestUtil.test { app, http ->
+    fun `user can freeze sse handler to leak sse client`() = TestUtil.test { app, http ->
         val clients = mutableListOf<SseClient>()
 
         // some 3rd party service
@@ -142,7 +142,7 @@ class TestSse {
 
         app.sse("/sse") { client ->
             clients.add(client)
-            client.block()
+            client.await()
 
             CompletableFuture.runAsync {
                 Thread.sleep(500)

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -1,13 +1,10 @@
 package io.javalin
 
-import io.javalin.apibuilder.ApiBuilder.sse
-import io.javalin.http.Context
 import io.javalin.http.sse.SseClient
 import io.javalin.testing.SerializableObject
 import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CompletableFuture
 
 class TestSse {
 
@@ -130,20 +127,4 @@ class TestSse {
         )
     }
 
-}
-
-fun main() {
-    fun scheduleNextEvent(client: SseClient) {
-        println("Send")
-
-        client.ctx.async {
-            Thread.sleep(1000)
-            client.sendEvent("Test")
-            scheduleNextEvent(client)
-        }
-    }
-
-    Javalin.create()
-        .sse("/sse") { scheduleNextEvent(it) }
-        .start(8080)
 }


### PR DESCRIPTION
Benefits:
* Officially supported way to delegate logic to async contex without a need to wrap it manually with a stub future
* Uses cached execturor service by default, so most users should be happy with it - in case some specific task there's an option to provide a custom one
* Properly handles and emits exceptions from task to servlet
* Supports Jetty-free timeouts, so we can enforce timeout and register timeout listener that is still able to write to context just like the handler
* `ctx.async` also returns future, so user also can listen for completion (**but can't modify context**)
* For SSE:
  * All SSE connections are by default running in standalone executor, so we're not blocking Jetty's http thread by long-living connectins
  * (Change in behaviour) We don't have to call `client.close()`, sse client will be closed automatically when all tasks will finish execution (because we can nest ctx.async in ctx.async etc)

Further updates:
* Expose thread-pool configuration as a standalone property in JavalinConfig
* ?

Resolves #1589