### PR TITLE
Avoid endless redirects when using RedirectToLowercasePathPlugin.kt

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/RedirectToLowercasePathPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/RedirectToLowercasePathPlugin.kt
@@ -75,7 +75,7 @@ class RedirectToLowercasePathPlugin : Plugin, PluginLifecycleInit {
 
                 // replace the non lowercased part of the segment with the lowercased version
                 if (serverSegment is PathSegment.MultipleSegments) {
-                    serverSegments
+                    serverSegment.innerSegments
                         .filterIsInstance<PathSegment.Normal>()
                         .forEach { innerServerSegment ->
                             clientSegments[index] = clientSegments[index].replace(

--- a/javalin/src/test/java/io/javalin/TestRedirectToLowercasePathPlugin.kt
+++ b/javalin/src/test/java/io/javalin/TestRedirectToLowercasePathPlugin.kt
@@ -11,7 +11,6 @@ import io.javalin.testing.TestUtil
 import kong.unirest.HttpResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Test
 
 class TestRedirectToLowercasePathPlugin {

--- a/javalin/src/test/java/io/javalin/TestRedirectToLowercasePathPlugin.kt
+++ b/javalin/src/test/java/io/javalin/TestRedirectToLowercasePathPlugin.kt
@@ -53,6 +53,7 @@ class TestRedirectToLowercasePathPlugin {
         app.get("/my-{endpoint}") { it.status(418).result(it.pathParam("endpoint")) }
         http.disableUnirestRedirects()
         http.get("/my-endpoint").assertStatusAndBodyMatch(418, "endpoint")
+        http.get("/my-ENDPOINT").assertStatusAndBodyMatch(418, "ENDPOINT")
         http.get("/MY-eNdPOinT").assertStatusAndBodyMatch(301, "Redirected")
         http.enableUnirestRedirects()
         http.get("/MY-eNdPOinT").assertStatusAndBodyMatch(418, "eNdPOinT")


### PR DESCRIPTION
This is only applicable to "complex" segments as defined by `PathSegment.MultipleSegments`.

This is the bug I found while looking at @dzikoysk 's refactor but it is actually a bug I created while creating the newer parser a while back.