### PR TITLE
[core] Support a possibility to safely queue future

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -15,6 +15,7 @@ import io.javalin.http.util.SeekableWriter
 import io.javalin.plugin.json.jsonMapper
 import io.javalin.plugin.rendering.JavalinRenderer
 import io.javalin.security.BasicAuthCredentials
+import io.javalin.util.exceptionallyAccept
 import io.javalin.validation.BodyValidator
 import io.javalin.validation.Validator
 import jakarta.servlet.http.HttpServletRequest
@@ -385,18 +386,13 @@ open class Context(
                 CompletableFuture.runAsync(task, executor)
                     .thenAccept { await.complete(null) }
                     .let { if (timeout > 0) it.orTimeout(timeout, MILLISECONDS) else it }
-                    .exceptionally {
-                        if (onTimeout != null && it is TimeoutException) {
-                            onTimeout.invoke()
-                            await.complete(null)
-                            return@exceptionally null
+                    .exceptionallyAccept {
+                        when {
+                            onTimeout != null && it is TimeoutException -> onTimeout.invoke().run { await.complete(null) }
+                            else -> await.completeExceptionally(it) // catch standard exception
                         }
-                        throw it
                     }
-                    .exceptionally {
-                        await.completeExceptionally(it)
-                        null
-                    }
+                    .exceptionallyAccept { await.completeExceptionally(it) } // catch exception from timeout listener
             },
             callback = { /* noop */ }
         )
@@ -404,15 +400,27 @@ open class Context(
         return await
     }
 
+    /**
+     * See the main `future(CompletableFuture<T>, Runnable, Consumer<T>)` method for details.
+     */
     @JvmOverloads
     fun <T> future(future: CompletableFuture<T>, callback: Consumer<T>? = null): Context =
         future(future = future, launch = null, callback = callback)
 
     /**
-     * The default callback (used if no callback is provided) can be configured through [ContextResolver.defaultFutureCallback]
+     * The main entrypoint for all async related functionalities exposed by [Context].
+     *
+     * @param future Future represents any delayed in time result.
+     *  Upon this value Javalin will schedule further execution of this request.
+     *  When servlet will detect that the given future is completed, request will be executed synchronously,
+     *  otherwise request will be executed asynchronously by a thread which will complete the future.
+     * @param launch Optional callback that provides a possibility to launch any kind of async execution in a thread-safe way.
+     *  Any async task that will mutate [Context] should be submitted to the executor in this scope to eliminate race-conditions between threads.
+     * @param callback Optional callback used to process result from the specified future.
+     *  The default callback (used if no callback is provided) can be configured through [io.javalin.config.ContextResolver.defaultFutureCallback]
      * @throws IllegalStateException if result was already set
-     * */
-    fun <T> future(future: CompletableFuture<T>, launch: Runnable?, callback: Consumer<T>?): Context {
+     */
+    fun <T> future(future: CompletableFuture<T>, launch: Runnable?, callback: Consumer<T>? = null): Context = also {
         if (resultReference.get().future != null) {
             throw IllegalStateException("Cannot override result")
         }
@@ -425,7 +433,6 @@ open class Context(
                 callback = callback
             )
         }
-        return this
     }
 
     /** Gets the current context result as a [CompletableFuture] (if set). */

--- a/javalin/src/main/java/io/javalin/util/FutureUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/FutureUtil.kt
@@ -1,0 +1,18 @@
+package io.javalin.util
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.function.Consumer
+
+/** [CompletableFuture.thenAccept] alternative for [CompletableFuture.exceptionally] */
+fun CompletableFuture<*>.exceptionallyAccept(exceptionConsumer: Consumer<Throwable>): CompletableFuture<*> =
+    exceptionally {
+        exceptionConsumer.accept(it)
+        null
+    }
+
+/** [CompletableFuture.exceptionallyCompose] method is available since JDK12+, so we need a fallback for JDK11 */
+fun <T> CompletableFuture<T>.exceptionallyComposeFallback(mapping: (Throwable) -> CompletionStage<T>): CompletableFuture<T> =
+    thenApply { CompletableFuture.completedFuture(it) as CompletionStage<T> }
+        .exceptionally { mapping(it) }
+        .thenCompose { it }

--- a/javalin/src/test/java/io/javalin/TestAsync.kt
+++ b/javalin/src/test/java/io/javalin/TestAsync.kt
@@ -1,6 +1,11 @@
 package io.javalin
 
+import io.javalin.http.HttpCode
+import io.javalin.http.HttpCode.IM_A_TEAPOT
+import io.javalin.http.HttpCode.OK
+import io.javalin.http.HttpCode.UNAUTHORIZED
 import io.javalin.testing.TestUtil
+import io.javalin.testing.status
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -17,6 +22,19 @@ internal class TestAsync {
         }
 
         assertThat(http.get("/").body).isEqualTo("true")
+    }
+
+    @Test
+    fun `async request should not be overridden asynchronously`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            ctx.async {
+                ctx.status(OK)
+            }
+            Thread.sleep(500)
+            ctx.status(IM_A_TEAPOT)
+        }
+
+        assertThat(http.get("/").status()).isEqualTo(OK)
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestAsync.kt
+++ b/javalin/src/test/java/io/javalin/TestAsync.kt
@@ -1,9 +1,9 @@
 package io.javalin
 
+import io.javalin.http.HttpCode.ENHANCE_YOUR_CALM
 import io.javalin.http.HttpCode.IM_A_TEAPOT
 import io.javalin.http.HttpCode.OK
 import io.javalin.testing.TestUtil
-import io.javalin.testing.status
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -23,16 +23,20 @@ internal class TestAsync {
     }
 
     @Test
-    fun `async request should not be overridden asynchronously`() = TestUtil.test { app, http ->
+    fun `async tasks should start execution in a proper order`() = TestUtil.test { app, http ->
         app.get("/") { ctx ->
             ctx.async {
-                ctx.status(OK)
+                ctx.async {
+                    ctx.status(OK)
+                }
+                Thread.sleep(100)
+                ctx.status(ENHANCE_YOUR_CALM)
             }
-            Thread.sleep(500)
+            Thread.sleep(100)
             ctx.status(IM_A_TEAPOT)
         }
 
-        assertThat(http.get("/").status()).isEqualTo(OK)
+        assertThat(http.get("/").status).isEqualTo(OK.status)
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestAsync.kt
+++ b/javalin/src/test/java/io/javalin/TestAsync.kt
@@ -1,9 +1,7 @@
 package io.javalin
 
-import io.javalin.http.HttpCode
 import io.javalin.http.HttpCode.IM_A_TEAPOT
 import io.javalin.http.HttpCode.OK
-import io.javalin.http.HttpCode.UNAUTHORIZED
 import io.javalin.testing.TestUtil
 import io.javalin.testing.status
 import org.assertj.core.api.Assertions.assertThat

--- a/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
+++ b/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
@@ -34,6 +34,3 @@ class HttpUtil(port: Int) {
     fun sse(path: String) = Unirest.get(origin + path).header("Accept", "text/event-stream").header("Connection", "keep-alive").header("Cache-Control", "no-cache").asStringAsync()
 
 }
-
-fun HttpResponse<*>.status(): HttpCode? =
-    HttpCode.forStatus(this.status)

--- a/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
+++ b/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
@@ -9,7 +9,6 @@ package io.javalin.testing
 import io.javalin.http.ContentType
 import io.javalin.http.HttpCode
 import kong.unirest.HttpMethod
-import kong.unirest.HttpResponse
 import kong.unirest.Unirest
 
 class HttpUtil(port: Int) {

--- a/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
+++ b/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
@@ -9,6 +9,7 @@ package io.javalin.testing
 import io.javalin.http.ContentType
 import io.javalin.http.HttpCode
 import kong.unirest.HttpMethod
+import kong.unirest.HttpResponse
 import kong.unirest.Unirest
 
 class HttpUtil(port: Int) {
@@ -33,3 +34,6 @@ class HttpUtil(port: Int) {
     fun sse(path: String) = Unirest.get(origin + path).header("Accept", "text/event-stream").header("Connection", "keep-alive").header("Cache-Control", "no-cache").asStringAsync()
 
 }
+
+fun HttpResponse<*>.status(): HttpCode? =
+    HttpCode.forStatus(this.status)


### PR DESCRIPTION
* #1603

TL;DR we were letting user to set multiple futures and we didn't really care which one ended up in a `Result` - all we cared about was to properly handle state we found by atomic get & update of user's result. This PR will extend protection of user's logic by exposing a thread-safe possibility to launch async task. With such change, the `ctx.future()` & `ctx.async` should be always prioritized over other methods to spawn and handle async contex due to guarantee of proper execution.