### PR TITLE
Override default excludes in maven-surefire-plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,19 @@
                             <version>${junit.version}</version>
                         </dependency>
                     </dependencies>
+                    <configuration>
+                        <!--
+                        default: **/*$*
+                        Source: https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes
+
+                        Not removing this default causes roots tests mixed with nested tests to be not executed by
+                        Maven.
+                        Similar JUnit issue: https://github.com/junit-team/junit5/issues/1377
+                        -->
+                        <excludes>
+                            <exclude/>
+                        </excludes>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
This fixes certain tests not being executed by Maven.

Concrete example: TestFuture.kt
The two root tests are not executed by Maven without this change.
You can check for successful application of this fix by looking at the raw action logs and searching for `TestFuture`
Two tests should be shown as run, something similar to this:
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.032 s - in io.javalin.TestFuture
```


See also this JUnit5 issue: https://github.com/junit-team/junit5/issues/1377