### PR TITLE
[build] Tell Kotlin compiler to generate default methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,9 @@
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/main/java</sourceDir>
                             </sourceDirs>
+                            <args>
+                                <arg>-Xjvm-default=all</arg>
+                            </args>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
I forgot about it, but by default Kotlin does not generate Java-compatible default methods in interfaces, so we want to force this to keep proper interop & API consistency