### PR TITLE
[context] Restore `ctx.resultStream()`

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -309,11 +309,11 @@ interface Context {
      */
     fun result(resultStream: InputStream): Context
 
-    /** Gets the current [io.javalin.http.servlet.JavalinServletContext.resultStream] as a [String] (if set), and reset the underlying stream */
-    fun result(): String? = readAndResetStreamIfPossible(resultStream(), responseCharset())
+    /** Gets the current [io.javalin.http.servlet.JavalinServletContext.resultAsInputStream] as a [String] (if set), and reset the underlying stream */
+    fun resultAsString(): String? = readAndResetStreamIfPossible(resultAsInputStream(), responseCharset())
 
-    /** Gets the current [io.javalin.http.servlet.JavalinServletContext.resultStream] */
-    fun resultStream(): InputStream?
+    /** Gets the current [io.javalin.http.servlet.JavalinServletContext.resultAsInputStream] */
+    fun resultAsInputStream(): InputStream?
 
     /**
      * Utility function that allows to run async task on top of the [Context.future] method.

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -310,7 +310,10 @@ interface Context {
     fun result(resultStream: InputStream): Context
 
     /** Gets the current [io.javalin.http.servlet.JavalinServletContext.resultStream] as a [String] (if set), and reset the underlying stream */
-    fun result(): String?
+    fun result(): String? = readAndResetStreamIfPossible(resultStream(), responseCharset())
+
+    /** Gets the current [io.javalin.http.servlet.JavalinServletContext.resultStream] */
+    fun resultStream(): InputStream?
 
     /**
      * Utility function that allows to run async task on top of the [Context.future] method.

--- a/javalin/src/main/java/io/javalin/http/Handler.java
+++ b/javalin/src/main/java/io/javalin/http/Handler.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Main interface for endpoint actions. A handler has a void return type,
- * so you have to use {@link Context#result} to return data to the client.
+ * so you have to use {@link Context#resultAsString} to return data to the client.
  *
  * @see Context
  * @see <a href="https://javalin.io/documentation#handlers">Handler in documentation</a>

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -69,7 +69,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
         it.addListener(onTimeout = { // a timeout avoids the pipeline - we need to handle it manually + it's not thread-safe
             status(INTERNAL_SERVER_ERROR) // default error handling
             errorMapper.handle(statusCode(), this) // user defined error handling
-            if (resultStream == null) result(REQUEST_TIMEOUT.message) // write default response only if handler didn't do anything
+            if (resultStream() == null) result(REQUEST_TIMEOUT.message) // write default response only if handler didn't do anything
             writeResponseAndLog()
         })
     }
@@ -88,7 +88,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
         try {
             if (responseWritten.getAndSet(true)) return // prevent writing more than once, it's required because timeout listener can terminate the flow at any time
             outputStream().use { outputStream ->
-                resultStream?.use { resultStream ->
+                resultStream()?.use { resultStream ->
                     val etagWritten = ETagGenerator.tryWriteEtagAndClose(cfg.http.generateEtags, this, resultStream)
                     if (!etagWritten) resultStream.copyTo(outputStream, 4096)
                 }

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -69,7 +69,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
         it.addListener(onTimeout = { // a timeout avoids the pipeline - we need to handle it manually + it's not thread-safe
             status(INTERNAL_SERVER_ERROR) // default error handling
             errorMapper.handle(statusCode(), this) // user defined error handling
-            if (resultStream() == null) result(REQUEST_TIMEOUT.message) // write default response only if handler didn't do anything
+            if (resultAsInputStream() == null) result(REQUEST_TIMEOUT.message) // write default response only if handler didn't do anything
             writeResponseAndLog()
         })
     }
@@ -88,7 +88,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
         try {
             if (responseWritten.getAndSet(true)) return // prevent writing more than once, it's required because timeout listener can terminate the flow at any time
             outputStream().use { outputStream ->
-                resultStream()?.use { resultStream ->
+                resultAsInputStream()?.use { resultStream ->
                     val etagWritten = ETagGenerator.tryWriteEtagAndClose(cfg.http.generateEtags, this, resultStream)
                     if (!etagWritten) resultStream.copyTo(outputStream, 4096)
                 }

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -121,7 +121,7 @@ class JavalinServletContext(
         this.resultStream = resultStream
     }
 
-    override fun resultStream(): InputStream? = resultStream
+    override fun resultAsInputStream(): InputStream? = resultStream
 
     override fun future(future: Supplier<out CompletableFuture<*>>) {
         if (userFutureSupplier != null) throw IllegalStateException("Cannot override future from the same handler")

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -46,7 +46,7 @@ class JavalinServletContext(
     private var pathParamMap: Map<String, String> = mapOf(),
     internal var endpointHandlerPath: String = "",
     internal var userFutureSupplier: Lazy<CompletableFuture<*>>? = null,
-    internal var resultStream: InputStream? = null,
+    private var resultStream: InputStream? = null,
 ) : Context {
 
     init {
@@ -116,12 +116,12 @@ class JavalinServletContext(
         }
     }
 
-    override fun result(inputStream: InputStream): Context = apply {
-        runCatching { resultStream?.close() } // avoid memory leaks for multiple result() calls
-        resultStream = inputStream
+    override fun result(resultStream: InputStream): Context = apply {
+        runCatching { this.resultStream?.close() } // avoid memory leaks for multiple result() calls
+        this.resultStream = resultStream
     }
 
-    override fun result(): String? = readAndResetStreamIfPossible(resultStream, responseCharset())
+    override fun resultStream(): InputStream? = resultStream
 
     override fun future(future: Supplier<out CompletableFuture<*>>) {
         if (userFutureSupplier != null) throw IllegalStateException("Cannot override future from the same handler")

--- a/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
@@ -4,7 +4,6 @@ import io.javalin.Javalin
 import io.javalin.http.Context
 import io.javalin.http.HandlerType
 import io.javalin.http.Header
-import io.javalin.http.servlet.JavalinServletContext
 import io.javalin.plugin.Plugin
 import io.javalin.plugin.PluginLifecycleInit
 import io.javalin.routing.PathMatcher
@@ -63,14 +62,14 @@ fun requestDevLogger(matcher: PathMatcher, ctx: Context, time: Float) = try {
 private fun String.probablyFormData() = this.trim().firstOrNull()?.isLetter() == true && this.split("=").size >= 2
 
 private fun resBody(ctx: Context): String {
-    val stream = ctx.resultStream() ?: return "No body was set"
+    val stream = ctx.resultAsInputStream() ?: return "No body was set"
     if (!stream.markSupported()) {
         return "Body is binary (not logged)"
     }
 
     val gzipped = ctx.res().getHeader(Header.CONTENT_ENCODING) == "gzip"
     val brotlied = ctx.res().getHeader(Header.CONTENT_ENCODING) == "br"
-    val resBody = ctx.result()!!
+    val resBody = ctx.resultAsString()!!
     return when {
         gzipped -> "Body is gzipped (${resBody.length} bytes, not logged)"
         brotlied -> "Body is brotlied (${resBody.length} bytes, not logged)"

--- a/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
@@ -63,8 +63,7 @@ fun requestDevLogger(matcher: PathMatcher, ctx: Context, time: Float) = try {
 private fun String.probablyFormData() = this.trim().firstOrNull()?.isLetter() == true && this.split("=").size >= 2
 
 private fun resBody(ctx: Context): String {
-    val internalContext = ctx as JavalinServletContext
-    val stream = internalContext.resultStream ?: return "No body was set"
+    val stream = ctx.resultStream() ?: return "No body was set"
     if (!stream.markSupported()) {
         return "Body is binary (not logged)"
     }

--- a/javalin/src/test/java/io/javalin/TestAccessManager.kt
+++ b/javalin/src/test/java/io/javalin/TestAccessManager.kt
@@ -75,7 +75,7 @@ class TestAccessManager {
             handler.handle(ctx)
         }
     }) { app, http ->
-        app.get("/secured", { it.result(it.result() ?: "") }, ROLE_ONE)
+        app.get("/secured", { it.result(it.resultAsString() ?: "") }, ROLE_ONE)
         assertThat(callWithRole(http.origin, "/secured", "ROLE_ONE")).isEqualTo("Test")
     }
 

--- a/javalin/src/test/java/io/javalin/TestApiBuilder.kt
+++ b/javalin/src/test/java/io/javalin/TestApiBuilder.kt
@@ -146,7 +146,7 @@ class TestApiBuilder {
         app.routes {
             path("api") {
                 before("/*") { it.result("before") }
-                get { it.result((it.result() ?: "") + "get") }
+                get { it.result((it.resultAsString() ?: "") + "get") }
                 after("/*", updateAnswer("after"))
             }
         }
@@ -155,7 +155,7 @@ class TestApiBuilder {
     }
 
     private fun simpleAnswer(body: String) = Handler { it.result(body) }
-    private fun updateAnswer(body: String) = Handler { it.result(it.result()!! + body) }
+    private fun updateAnswer(body: String) = Handler { it.result(it.resultAsString()!! + body) }
 
     @Test
     fun `ApiBuilder throws if used outside of routes{} call`() = TestUtil.test { _, _ ->

--- a/javalin/src/test/java/io/javalin/TestFuture.kt
+++ b/javalin/src/test/java/io/javalin/TestFuture.kt
@@ -73,14 +73,14 @@ internal class TestFuture {
         fun `calling future in (before - get - after) handlers works`() = TestUtil.test { app, http ->
             app.before("/future") { ctx -> ctx.future { getFuture("before").thenApply { ctx.result(it) } } }
             app.get("/future") { ctx -> ctx.future { getFuture("nothing") } }
-            app.after("/future") { ctx -> ctx.future { getFuture("${ctx.result()}, after").thenApply { ctx.result(it) } } }
+            app.after("/future") { ctx -> ctx.future { getFuture("${ctx.resultAsString()}, after").thenApply { ctx.result(it) } } }
             assertThat(http.get("/future").body).isEqualTo("before, after")
         }
 
         @Test
         fun `calling future in (before - before) handlers works`() = TestUtil.test { app, http ->
             app.before { it.future { getFuture("before 1").thenAccept { v -> it.result(v) } } }
-            app.before { it.future { getFuture("${it.result()}, before 2").thenAccept { v -> it.result(v) } } }
+            app.before { it.future { getFuture("${it.resultAsString()}, before 2").thenAccept { v -> it.result(v) } } }
             app.get("/future") {}
             assertThat(http.get("/future").body).isEqualTo("before 1, before 2")
         }
@@ -315,4 +315,4 @@ internal class TestFuture {
 
 }
 
-private fun Context.accumulatingResult(s: String) = this.result((result() ?: "") + s)
+private fun Context.accumulatingResult(s: String) = this.result((resultAsString() ?: "") + s)

--- a/javalin/src/test/java/io/javalin/TestLogging.kt
+++ b/javalin/src/test/java/io/javalin/TestLogging.kt
@@ -72,8 +72,8 @@ class TestLogging {
         val loggerLog = mutableListOf<String?>()
         val bodyLoggingJavalin = Javalin.create {
             it.requestLogger.http { ctx, _ ->
-                loggerLog.add(ctx.result())
-                loggerLog.add(ctx.result())
+                loggerLog.add(ctx.resultAsString())
+                loggerLog.add(ctx.resultAsString())
             }
         }
         TestUtil.test(bodyLoggingJavalin) { app, http ->

--- a/javalin/src/test/java/io/javalin/TestResponse.kt
+++ b/javalin/src/test/java/io/javalin/TestResponse.kt
@@ -158,7 +158,7 @@ class TestResponse {
 
         app.get("/test") { context ->
             context.result(result)
-            context.result()
+            context.resultAsString()
         }
 
         assertThat(http.getBody("/test")).isEqualTo(result)

--- a/javalin/src/test/java/io/javalin/TestRouting.kt
+++ b/javalin/src/test/java/io/javalin/TestRouting.kt
@@ -79,9 +79,9 @@ class TestRouting {
     @Test
     fun `filers are executed in order`() = TestUtil.test { app, http ->
         app.before { it.result("1") }
-        app.before { it.result(it.result() + "2") }
-        app.get("/hello") { it.result(it.result() + "Hello") }
-        app.after { it.result(it.result() + "3") }
+        app.before { it.result(it.resultAsString() + "2") }
+        app.get("/hello") { it.result(it.resultAsString() + "Hello") }
+        app.after { it.result(it.resultAsString() + "3") }
         assertThat(http.getBody("/hello")).isEqualTo("12Hello3")
     }
 
@@ -233,7 +233,7 @@ class TestRouting {
     fun `non sub-path star wildcard works for plain paths`() = TestUtil.test { app, http ->
         app.get("/p") { it.result("1") }.also { assertThat(http.getBody("/p")).isEqualTo("1") }
         app.get("/p-test") { it.result("2") }.also { assertThat(http.getBody("/p-test")).isEqualTo("2") }
-        app.after("/p*") { it.result("${it.result()}AFTER") }.also {
+        app.after("/p*") { it.result("${it.resultAsString()}AFTER") }.also {
             assertThat(http.getBody("/p")).isEqualTo("1AFTER")
             assertThat(http.getBody("/p-test")).isEqualTo("2AFTER")
         }
@@ -243,7 +243,7 @@ class TestRouting {
     fun `non sub-path wildcard works for path-params`() = TestUtil.test { app, http ->
         app.get("/{pp}-test") { it.result("2") }.also { assertThat(http.getBody("/p-test")).isEqualTo("2") }
         app.get("/{pp}") { it.result("1") }.also { assertThat(http.getBody("/p")).isEqualTo("1") }
-        app.after("/{pp}*") { it.result("${it.result()}AFTER") }.also {
+        app.after("/{pp}*") { it.result("${it.resultAsString()}AFTER") }.also {
             assertThat(http.getBody("/p")).isEqualTo("1AFTER")
             assertThat(http.getBody("/p-test")).isEqualTo("2AFTER")
         }
@@ -252,7 +252,7 @@ class TestRouting {
     @Test
     fun `sub-path wildcard works for path-params`() = TestUtil.test { app, http ->
         app.routes {
-            after("/partners/{pp}*") { it.result("${it.result()} - after") }
+            after("/partners/{pp}*") { it.result("${it.resultAsString()} - after") }
             path("/partners/{pp}") {
                 get { it.result("root") }
                 get("/api") { it.result("api") }


### PR DESCRIPTION
* #1659

Why I don't think it is a good idea to remove `resultStream()`:
- It's the root value that determines if context contains response or not -> So we can e.g. determine if response has been written by simply checking if `ctx.resultStream() == null`
- It's faster than `ctx.result()` because `ctx.result()` will try to read and convert whole stream to string - it's good to mention that not all responses are human readable context, so this method is pretty useless for any kind of media type
- It's inconsistent, why do we offer `ctx.result()` if we're not offering `ctx.resultStream()`, I'd rather expose `resultStream` than `result` as it just provides more possibilities to do sth with result in general
- Exposing `resultStream` only as a field has also some disadvantages:
  - Internal visibility makes it impossible to access for Kotlin users even after casting servlet to `JavalinServletContext`
  - It'll encourage to use field rather than methods, so someone could do sth like `ctx.resultStream = newStream` and create memory leak by not closing the previous stream

That's why this PR restores `ctx.resultStream()` method and makes its field `private` in ctx impl