### PR TITLE
[servlet] Replace `Lazy<CompletableFuture>` with `Supplier<CompletableFuture>`

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -53,7 +53,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
 
     private fun JavalinServletContext.handleUserFuture() {
         val userFutureSupplier = userFutureSupplier!!.also { userFutureSupplier = null } // nullcheck in handleSync
-        val userFuture = handleTask { userFutureSupplier.value } ?: return handleSync() // get future from supplier or handle error
+        val userFuture = handleTask { userFutureSupplier.get() } ?: return handleSync() // get future from supplier or handle error
         if (!isAsync()) startAsyncAndAddDefaultTimeoutListeners()
         req().asyncContext.addListener(onTimeout = { userFuture.cancel(true) })
         userFuture

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -45,7 +45,7 @@ class JavalinServletContext(
     private var matchedPath: String = "",
     private var pathParamMap: Map<String, String> = mapOf(),
     internal var endpointHandlerPath: String = "",
-    internal var userFutureSupplier: Lazy<CompletableFuture<*>>? = null,
+    internal var userFutureSupplier: Supplier<out CompletableFuture<*>>? = null,
     internal var resultStream: InputStream? = null,
 ) : Context {
 
@@ -125,7 +125,7 @@ class JavalinServletContext(
 
     override fun future(future: Supplier<out CompletableFuture<*>>) {
         if (userFutureSupplier != null) throw IllegalStateException("Cannot override future from the same handler")
-        userFutureSupplier = lazy { future.get() }
+        userFutureSupplier = future
     }
 
 }


### PR DESCRIPTION
We don't need to use Lazy anymore due to some cleanups in servlet handling we've made during the latest servlet rewrite