### PR TITLE
[util] Update `missingDependencyMessage` message

### DIFF
--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -47,8 +47,8 @@ object DependencyUtil {
         |    <version>${dependency.version}</version>
         |</dependency>
         |
-        |build.gradle:
-        |implementation group: '${dependency.groupId}', name: '${dependency.artifactId}', version: '${dependency.version}'
+        |build.gradle or build.gradle.kts:
+        |implementation("${dependency.groupId}:${dependency.artifactId}:${dependency.version}")
         |
         |Find the latest version here:
         |https://search.maven.org/search?q=${URLEncoder.encode("g:" + dependency.groupId + " AND a:" + dependency.artifactId, "UTF-8")}


### PR DESCRIPTION
Use more popular Gradle format for defining dependency and support Kotlin DSL as well using kts compatible syntax