### PR TITLE
Add Javalin#updateConfig to allow config updates after creation

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -50,6 +50,7 @@ public class Javalin implements AutoCloseable {
     /**
      * Do not use this field unless you know what you're doing.
      * Application config should be declared in {@link Javalin#create(Consumer)}
+     * Alternatively use {@link Javalin#updateConfig(Consumer)} to update the config at a later date.
      */
     public JavalinConfig cfg = new JavalinConfig();
 
@@ -261,6 +262,20 @@ public class Javalin implements AutoCloseable {
      */
     public <T> T attribute(String key) {
         return (T) cfg.pvt.appAttributes.get(key);
+    }
+
+    /**
+     * Updates the instance's configuration with new user configuration.
+     * It fulfills a similar role to the existing {@link Javalin#create(Consumer)} call and can be called on an existing
+     * instance.
+     *
+     * @param userConfig new user configuration
+     * @return application instance.
+     * @see Javalin#create(Consumer)
+     */
+    public Javalin updateConfig(Consumer<JavalinConfig> userConfig) {
+        userConfig.accept(cfg);
+        return this;
     }
 
     /**

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
@@ -8,8 +8,8 @@
 package io.javalin.staticfiles
 
 import io.javalin.Javalin
-import io.javalin.http.Header
 import io.javalin.http.ContentType
+import io.javalin.http.Header
 import io.javalin.http.HttpStatus.NOT_FOUND
 import io.javalin.http.HttpStatus.OK
 import io.javalin.http.HttpStatus.UNAUTHORIZED
@@ -296,6 +296,15 @@ class TestStaticFiles {
     fun `logs handlers added on startup`() {
         TestUtil.test(multiLocationStaticResourceApp) { _, _ -> }
         assertThat(multiLocationStaticResourceApp.attribute<String>("testlogs").split("Static file handler added").size - 1).isEqualTo(4)
+    }
+
+    @Test
+    fun `static files can be added after app creation`() = TestUtil.test(
+        Javalin.create().updateConfig { it.staticFiles.add("/public", Location.CLASSPATH) }
+    ) { _, http ->
+        assertThat(http.get("/html.html").httpCode()).isEqualTo(OK)
+        assertThat(http.get("/html.html").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
+        assertThat(http.getBody("/html.html")).contains("HTML works")
     }
 
 }


### PR DESCRIPTION
Inspired by some discussion on the Javalin Discord server: 
This PR add a new method for Javalin instances called `updateConfig` which fulfills a similiar role to the existing `create(Consumer)` function except that the new method is an instacne method and not a static method.

The testcase is inspired by the real world use case to add static files dynamically after creation of the instance.

Do note that I did not fix the issue for adding static files after server start. 
You currently have to do something like this after adding your files if you want to add static files after starting Javalin:

```kotlin
val app = Javalin.create().start()
app.updateConfig {
  it.staticFiles.add("/assets", Location.CLASSPATH)
  it.pvt.resourceHandler?.init(mapOf("server" to javalin.cfg.pvt.server))
}
```