### PR TITLE
Update suggested slf4j-simple version

### DIFF
--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -57,7 +57,7 @@ enum class CoreDependency(
     JACKSON_KTORM("Jackson Ktorm", "org.ktorm.jackson.KtormModule", "org.ktorm", "ktorm-jackson", "3.4.1"),
 
     // Logging
-    SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "1.7.36"),
+    SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "2.0.3"),
 
     // Compression
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),


### PR DESCRIPTION
This is a tiny thing I noticed today: The slf4j-simple version that is currently suggested in the console if no slf4j provider can be found is incompatible with the slf4j-api version in use. I.e. if you add this specific version you'll get another warning that it is too old.

```
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions prior to 1.8.
SLF4J: Ignoring binding found at [jar:file:.../slf4j-simple-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```