### PR TITLE
Expose HttpStatus.forStatus to Java

### DIFF
--- a/javalin/src/main/java/io/javalin/http/HttpStatus.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpStatus.kt
@@ -75,6 +75,7 @@ enum class HttpStatus(val code: Int, val message: String) {
     companion object {
         private val cachedValues: Array<HttpStatus> = HttpStatus.values()
 
+        @JvmStatic
         fun forStatus(status: Int) = cachedValues.find { it.code == status } ?: UNKNOWN
     }
 


### PR DESCRIPTION
Hello,
I'm working on a Java project and noticed the `HttpStatus.forStatus` method is missing. I added the `@JvmStatic` so the method is available in Java.