### PR TITLE
Add auto labeling for issues and links to documentation & discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: "⚠️ Bug report"
 about: Use this template to create a bug report
+labels: "BUG"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F6A9 Feature request"
 about: Use this template to suggest/request a feature
+labels: "FEATURE REQUEST"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/3_Question.md
+++ b/.github/ISSUE_TEMPLATE/3_Question.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F4AC Question"
 about: Use this template to ask a question
+labels: "QUESTION"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+- name: Documentation and examples
+  url: https://javalin.io/documentation
+  about: Find complete documentation with example here.
+- name: GitHub Community Support
+  url: https://discord.com/invite/sgak4e5NKv
+  about: Please ask and answer questions here.


### PR DESCRIPTION
Add this when clicking "New issue":

![image](https://user-images.githubusercontent.com/17381066/196030462-87d7b240-86de-48da-83e4-fe85bae6080b.png)

And automatically add label when creating issues