### PR TITLE
GH-1712 Static files handler 404s Welcome Files with `precompress` enabled

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -43,9 +43,9 @@ class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
                 if (resource.isFile() || resource.isDirectoryWithWelcomeFile(handler, target)) {
                     handler.config.headers.forEach { httpResponse.setHeader(it.key, it.value) }
                     if (handler.config.precompress) {
-                        return if (resource.isDirectoryWithWelcomeFile(handler, target)) { // if it's a directory, we need to serve the welcome file
+                        return if (resource.isDirectoryWithWelcomeFile(handler, target))  // if it's a directory, we need to serve the welcome file
                             JettyPrecompressingResourceHandler.handle(target, getWelcomeFile(handler, target), httpRequest, httpResponse)
-                        } else
+                        else
                             JettyPrecompressingResourceHandler.handle(target, resource, httpRequest, httpResponse)
                     }
                     httpResponse.contentType = null // Jetty will only set the content-type if it's null

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticDirectorySlash.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticDirectorySlash.kt
@@ -19,6 +19,15 @@ class TestStaticDirectorySlash {
 
     private val normalJavalin: Javalin by lazy { Javalin.create { it.staticFiles.add("public", Location.CLASSPATH) } }
 
+    private val precompressingJavalin: Javalin by lazy {
+        Javalin.create {
+            it.staticFiles.add{
+                it.directory = "public"
+                it.location = Location.CLASSPATH
+                it.precompress = true
+            }
+        }
+    }
     @Test
     fun `normal javalin ignores static directory slashes`() = TestUtil.test(normalJavalin) { _, http ->
         assertThat(http.getBody("/subpage")).isEqualTo("TEST") // ok, is directory
@@ -26,7 +35,20 @@ class TestStaticDirectorySlash {
     }
 
     @Test
+    fun `precompressing javalin ignores static directory slashes`() = TestUtil.test(precompressingJavalin) { _, http ->
+        assertThat(http.getBody("/subpage")).isEqualTo("TEST") // ok, is directory
+        assertThat(http.getBody("/subpage/")).isEqualTo("TEST") // ok, is directory
+    }
+
+
+    @Test
     fun `normal Javalin serves files but serves directory if it is a directory`() = TestUtil.test(normalJavalin) { _, http ->
+        assertThat(http.getBody("/file")).isEqualTo("TESTFILE") // ok, is file = no slash
+        assertThat(http.getBody("/file/")).isEqualTo(NOT_FOUND.message) // nope, has slash must be directory
+    }
+
+    @Test
+    fun `precompressing Javalin serves files but serves directory if it is a directory`() = TestUtil.test(precompressingJavalin) { _, http ->
         assertThat(http.getBody("/file")).isEqualTo("TESTFILE") // ok, is file = no slash
         assertThat(http.getBody("/file/")).isEqualTo(NOT_FOUND.message) // nope, has slash must be directory
     }


### PR DESCRIPTION
Fixes #1712

When setting `staticFiles.precompress = true;` javalin fails to serve the index.html file in directory requests.