### PR TITLE
update testtools to use localhost to skip resolution

### DIFF
--- a/javalin-testtools/src/main/java/io/javalin/testtools/HttpClient.kt
+++ b/javalin-testtools/src/main/java/io/javalin/testtools/HttpClient.kt
@@ -14,7 +14,7 @@ import java.util.function.Consumer
 
 class HttpClient(val app: Javalin, val okHttp: OkHttpClient) {
 
-    var origin: String = "http://localhost:${app.port()}"
+    var origin: String = "http://127.0.0.1:${app.port()}"
 
     fun request(request: Request) = okHttp.newCall(request).execute()
     fun request(path: String, builder: Request.Builder) = request(builder.url(origin + path).build())


### PR DESCRIPTION
I Noticed a strange behavior when running tests in CI, where the test is much slower because its resolving each request to localhost. While this might be an issue thats only on my setup, we will always be using 127.0.0.1 anyway, so this shouldn't break anything