### PR TITLE
[utils] Expose `minThreads` & `maxThreads` in `ConcurrencyUtil#jettyThreadPool` method

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
@@ -17,7 +17,7 @@ object JettyUtil {
         setAttribute("is-default-server", true)
     }
 
-    private fun defaultThreadPool() = ConcurrencyUtil.jettyThreadPool("JettyServerThreadPool")
+    private fun defaultThreadPool() = ConcurrencyUtil.jettyThreadPool("JettyServerThreadPool", 8, 250)
 
     @JvmStatic
     fun maybeLogIfServerNotStarted(jettyServer: JettyServer) = Thread {

--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -26,9 +26,9 @@ object ConcurrencyUtil {
     fun newSingleThreadScheduledExecutor(name: String): ScheduledExecutorService =
         Executors.newSingleThreadScheduledExecutor(NamedThreadFactory(name))
 
-    fun jettyThreadPool(name: String): ThreadPool = when (useLoom && loomAvailable) {
+    fun jettyThreadPool(name: String, minThreads: Int, maxThreads: Int): ThreadPool = when (useLoom && loomAvailable) {
         true -> LoomThreadPool(name)
-        false -> QueuedThreadPool(250, 8, 60_000).apply { this.name = name }
+        false -> QueuedThreadPool(maxThreads, minThreads, 60_000).apply { this.name = name }
     }
 }
 


### PR DESCRIPTION
I'd like to use `ConcurrencyUtil.jettyThreadPool` to setup custom thread-pool with loom support, but currently thread-pool limits are hard-coded.