### PR TITLE
[logging] Categorize created but never started message as a startup message

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
@@ -23,9 +23,9 @@ object JettyUtil {
     fun maybeLogIfServerNotStarted(jettyServer: JettyServer) = Thread {
         Thread.sleep(5000)
         if (!jettyServer.started) {
-            JavalinLogger.info("It looks like you created a Javalin instance, but you never started it.")
-            JavalinLogger.info("Try: Javalin app = Javalin.create().start();")
-            JavalinLogger.info("For more help, visit https://javalin.io/documentation#server-setup")
+            JavalinLogger.startup("It looks like you created a Javalin instance, but you never started it.")
+            JavalinLogger.startup("Try: Javalin app = Javalin.create().start();")
+            JavalinLogger.startup("For more help, visit https://javalin.io/documentation#server-setup")
         }
     }.start()
 


### PR DESCRIPTION
This is the simplest possible solution for #1740 - making the warning about not having started Javalin a "startup" message so it can be suppressed with `JavalinLogger.startupInfo = false`. Downside is it still creates a useless thread and you have to give up all the startup messages to suppress it, but this would work for our use case fine.

closes #1740