### PR TITLE
Ability to configure multipart upload through settings

### DIFF
--- a/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
@@ -28,16 +28,6 @@ class FileUploadConfig {
     }
 
     /**
-     * This class represents the potential file size descriptors to avoid the use of hard-coded multipliers
-     */
-    enum class SizeUnit(val multiplier: Int){
-        BYTES(1),
-        KB(1024),
-        MB(1024 * 1024),
-        GB(1024 * 1024 * 1024)
-    }
-
-    /**
      * Sets the location of the cache directory used to write file uploads
      *
      * @param path : the path of the cache directory used to write file uploads > maxInMemoryFileSize
@@ -82,4 +72,14 @@ class FileUploadConfig {
     private fun multipartConfigElement(): MultipartConfigElement{
         return MultipartConfigElement(cacheDirectory,maxFileSize,maxTotalRequestSize,maxInMemoryFileSize)
     }
+}
+
+/**
+ * This class represents the potential file size descriptors to avoid the use of hard-coded multipliers
+ */
+enum class SizeUnit(val multiplier: Int){
+    BYTES(1),
+    KB(1024),
+    MB(1024 * 1024),
+    GB(1024 * 1024 * 1024)
 }

--- a/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
@@ -32,7 +32,7 @@ class FileUploadConfig {
     /**
      * This class represents the potential file size descriptors to avoid the use of hard-coded multipliers
      */
-    enum class Units(val multiplier: Int){
+    enum class SizeUnit(val multiplier: Int){
         BYTES(1),
         KB(1024),
         MB(1024 * 1024),
@@ -52,30 +52,30 @@ class FileUploadConfig {
      * Sets the maximum file size for an individual file upload
      *
      * @param size : the maximum size of the file
-     * @param units : the units that this size is measured in
+     * @param sizeUnit : the units that this size is measured in
      */
-    fun maxFileSize(size: Long, units: Units){
-        this.maxFileSize = size * units.multiplier
+    fun maxFileSize(size: Long, sizeUnit: SizeUnit){
+        this.maxFileSize = size * sizeUnit.multiplier
     }
 
     /**
      * Sets the maximum size for a single file before it will be cached to disk rather than read in memory
      *
      * @param size : the maximum size of the file
-     * @param units : the units that this size is measured in
+     * @param sizeUnit : the units that this size is measured in
      */
-    fun maxInMemoryFileSize(size: Int, units: Units){
-        this.maxInMemoryFileSize = size * units.multiplier
+    fun maxInMemoryFileSize(size: Int, sizeUnit: SizeUnit){
+        this.maxInMemoryFileSize = size * sizeUnit.multiplier
     }
 
     /**
      * Sets the maximum size for the entire multipart request
      *
      * @param size : the maximum size of the file
-     * @param units : the units that this size is measured in
+     * @param sizeUnit : the units that this size is measured in
      */
-    fun maxTotalRequestSize(size: Long, units: Units){
-        this.maxTotalRequestSize = size * units.multiplier
+    fun maxTotalRequestSize(size: Long, sizeUnit: SizeUnit){
+        this.maxTotalRequestSize = size * sizeUnit.multiplier
     }
 
     /**

--- a/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
@@ -12,12 +12,10 @@ import jakarta.servlet.MultipartConfigElement
  * @property maxTotalRequestSize : the maximum size allowed (in bytes) for the entire multipart request
  */
 class FileUploadConfig {
-    //@formatter:off
     private var cacheDirectory = System.getProperty("java.io.tmpdir")
     private var maxFileSize: Long = -1
     private var maxInMemoryFileSize: Int = -1
     private var maxTotalRequestSize: Long = -1
-    //@formatter:on
 
     //when the configuration is initialized we override the preupload function in the multipart util to read the
     //configuration from these settings rather than the current hard-coded method

--- a/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/FileUploadConfig.kt
@@ -1,0 +1,87 @@
+package io.javalin.config
+
+import io.javalin.http.util.MultipartUtil
+import jakarta.servlet.MultipartConfigElement
+
+/**
+ * This class contains the configuration for handling multipart file uploads
+ *
+ * @property cacheDirectory : the directory where files which exceed the maximum in memory size should be cached
+ * @property maxFileSize : the maximum size allowed (in bytes) for an individual uploaded file
+ * @property maxInMemoryFileSize : the maximum size allowed (in bytes) before uploads are cached to disk
+ * @property maxTotalRequestSize : the maximum size allowed (in bytes) for the entire multipart request
+ */
+class FileUploadConfig {
+    //@formatter:off
+    private var cacheDirectory = System.getProperty("java.io.tmpdir")
+    private var maxFileSize: Long = -1
+    private var maxInMemoryFileSize: Int = -1
+    private var maxTotalRequestSize: Long = -1
+    //@formatter:on
+
+    //when the configuration is initialized we override the preupload function in the multipart util to read the
+    //configuration from these settings rather than the current hard-coded method
+    init{
+        MultipartUtil.preUploadFunction = { req ->
+            if(req.getAttribute(MultipartUtil.MULTIPART_CONFIG_ATTRIBUTE) == null){
+                req.setAttribute(MultipartUtil.MULTIPART_CONFIG_ATTRIBUTE, multipartConfigElement())
+            }
+        }
+    }
+
+    /**
+     * This class represents the potential file size descriptors to avoid the use of hard-coded multipliers
+     */
+    enum class Units(val multiplier: Int){
+        BYTES(1),
+        KB(1024),
+        MB(1024 * 1024),
+        GB(1024 * 1024 * 1024)
+    }
+
+    /**
+     * Sets the location of the cache directory used to write file uploads
+     *
+     * @param path : the path of the cache directory used to write file uploads > maxInMemoryFileSize
+     */
+    fun cacheDirectory(path: String){
+        this.cacheDirectory = path
+    }
+
+    /**
+     * Sets the maximum file size for an individual file upload
+     *
+     * @param size : the maximum size of the file
+     * @param units : the units that this size is measured in
+     */
+    fun maxFileSize(size: Long, units: Units){
+        this.maxFileSize = size * units.multiplier
+    }
+
+    /**
+     * Sets the maximum size for a single file before it will be cached to disk rather than read in memory
+     *
+     * @param size : the maximum size of the file
+     * @param units : the units that this size is measured in
+     */
+    fun maxInMemoryFileSize(size: Int, units: Units){
+        this.maxInMemoryFileSize = size * units.multiplier
+    }
+
+    /**
+     * Sets the maximum size for the entire multipart request
+     *
+     * @param size : the maximum size of the file
+     * @param units : the units that this size is measured in
+     */
+    fun maxTotalRequestSize(size: Long, units: Units){
+        this.maxTotalRequestSize = size * units.multiplier
+    }
+
+    /**
+     * builds a multipart configuration element from the current file upload settings
+     */
+    private fun multipartConfigElement(): MultipartConfigElement{
+        return MultipartConfigElement(cacheDirectory,maxFileSize,maxTotalRequestSize,maxInMemoryFileSize)
+    }
+}

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -12,7 +12,6 @@ import io.javalin.json.JavalinJackson
 import io.javalin.json.JsonMapper
 import io.javalin.rendering.FILE_RENDERER_KEY
 import io.javalin.rendering.FileRenderer
-import io.javalin.rendering.JavalinRenderer
 import io.javalin.rendering.LegacyFileRenderer
 import io.javalin.security.AccessManager
 import io.javalin.validation.JavalinValidation.addValidationExceptionMapper
@@ -32,6 +31,7 @@ class JavalinConfig {
     @JvmField val spaRoot = SpaRootConfig(pvt)
     @JvmField val compression = CompressionConfig(pvt)
     @JvmField val requestLogger = RequestLoggerConfig(pvt)
+    @JvmField val fileUpload = FileUploadConfig()
     @JvmField val plugins = PluginConfig()
     @JvmField val vue = JavalinVueConfig()
     @JvmField val contextResolver = ContextResolverConfig()

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -31,7 +31,6 @@ class JavalinConfig {
     @JvmField val spaRoot = SpaRootConfig(pvt)
     @JvmField val compression = CompressionConfig(pvt)
     @JvmField val requestLogger = RequestLoggerConfig(pvt)
-    @JvmField val fileUpload = FileUploadConfig()
     @JvmField val plugins = PluginConfig()
     @JvmField val vue = JavalinVueConfig()
     @JvmField val contextResolver = ContextResolverConfig()

--- a/javalin/src/main/java/io/javalin/config/JettyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JettyConfig.kt
@@ -8,6 +8,9 @@ import java.util.function.Consumer
 import java.util.function.Supplier
 
 class JettyConfig(private val pvt: PrivateConfig) {
+    //@formatter:off
+    @JvmField val multipartConfig = MultipartConfig()
+    //@formatter:on
 
     fun server(server: Supplier<Server?>) {
         pvt.server = server.get()

--- a/javalin/src/main/java/io/javalin/config/MultipartConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/MultipartConfig.kt
@@ -11,7 +11,7 @@ import jakarta.servlet.MultipartConfigElement
  * @property maxInMemoryFileSize : the maximum size allowed (in bytes) before uploads are cached to disk
  * @property maxTotalRequestSize : the maximum size allowed (in bytes) for the entire multipart request
  */
-class FileUploadConfig {
+class MultipartConfig {
     private var cacheDirectory = System.getProperty("java.io.tmpdir")
     private var maxFileSize: Long = -1
     private var maxInMemoryFileSize: Int = -1

--- a/javalin/src/main/java/io/javalin/http/util/MultipartUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/MultipartUtil.kt
@@ -13,7 +13,7 @@ import jakarta.servlet.http.Part
 import java.nio.charset.Charset
 
 object MultipartUtil {
-    private const val MULTIPART_CONFIG_ATTRIBUTE = "org.eclipse.jetty.multipartConfig"
+    const val MULTIPART_CONFIG_ATTRIBUTE = "org.eclipse.jetty.multipartConfig"
 
     var preUploadFunction: (HttpServletRequest) -> Unit = { req ->
         val existingConfig = req.getAttribute(MULTIPART_CONFIG_ATTRIBUTE)

--- a/javalin/src/test/java/io/javalin/TestMultipartForms.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipartForms.kt
@@ -277,16 +277,16 @@ class TestMultipartForms {
         //paths exist and are writable on the system the test is being run on.  However, if the other parameters
         //are read successfully
         app.updateConfig {
-            it.fileUpload.maxFileSize(100, SizeUnit.MB)
-            it.fileUpload.maxInMemoryFileSize(10, SizeUnit.MB)
-            it.fileUpload.maxTotalRequestSize(1, SizeUnit.GB)
+            it.jetty.multipartConfig.maxFileSize(100, SizeUnit.MB)
+            it.jetty.multipartConfig.maxInMemoryFileSize(10, SizeUnit.MB)
+            it.jetty.multipartConfig.maxTotalRequestSize(1, SizeUnit.GB)
         }
 
         app.post("/test-multipart-config") { ctx ->
             //get the files - this is solely required to ensure that the preUploadFunction has been called
             ctx.uploadedFiles()
 
-            //now get hold of the multipartconfigelement from the request attributes
+            //now get hold of the MultipartConfigElement from the request attributes
             val config = ctx.attribute<MultipartConfigElement>(MultipartUtil.MULTIPART_CONFIG_ATTRIBUTE)!!
 
             ctx.result("${config.maxFileSize}:${config.fileSizeThreshold}:${config.maxRequestSize}")

--- a/javalin/src/test/java/io/javalin/TestMultipartForms.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipartForms.kt
@@ -6,8 +6,10 @@
 
 package io.javalin
 
+import io.javalin.config.FileUploadConfig
 import io.javalin.http.ContentType
 import io.javalin.http.formParamAsClass
+import io.javalin.http.util.MultipartUtil
 import io.javalin.json.fromJsonString
 import io.javalin.testing.TestUtil
 import io.javalin.testing.UploadInfo
@@ -263,6 +265,41 @@ class TestMultipartForms {
 
         //create the expected response
         val expected = "file1 --> image.png, file_array[] --> sound.mp3:text.txt"
+
+        //and verify it
+        assertThat(response).isEqualTo(expected)
+    }
+
+    @Test
+    fun `changing the multipart config correctly sets it`() = TestUtil.test{ app, http ->
+
+        //note: this test does not check the cache directory is set correctly as there is no way to know which
+        //paths exist and are writable on the system the test is being run on.  However, if the other parameters
+        //are read successfully
+        app.updateConfig {
+            it.fileUpload.maxFileSize(100,FileUploadConfig.Units.MB)
+            it.fileUpload.maxInMemoryFileSize(10,FileUploadConfig.Units.MB)
+            it.fileUpload.maxTotalRequestSize(1, FileUploadConfig.Units.GB)
+        }
+
+        app.post("/test-multipart-config") { ctx ->
+            //get the files - this is solely required to ensure that the preUploadFunction has been called
+            ctx.uploadedFiles()
+
+            //now get hold of the multipartconfigelement from the request attributes
+            val config = ctx.attribute<MultipartConfigElement>(MultipartUtil.MULTIPART_CONFIG_ATTRIBUTE)!!
+
+            ctx.result("${config.maxFileSize}:${config.fileSizeThreshold}:${config.maxRequestSize}")
+        }
+
+        //post the data to the end point
+        val response = http.post("/test-multipart-config")
+            .field("file1", File("src/test/resources/upload-test/image.png"))
+            .asString()
+            .body
+
+        //create the expected response which are the various sizes (in bytes) separated by colons
+        val expected = "${100*1024*1024}:${10*1024*1024}:${1*1024*1024*1024}"
 
         //and verify it
         assertThat(response).isEqualTo(expected)

--- a/javalin/src/test/java/io/javalin/TestMultipartForms.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipartForms.kt
@@ -6,7 +6,7 @@
 
 package io.javalin
 
-import io.javalin.config.FileUploadConfig
+import io.javalin.config.SizeUnit
 import io.javalin.http.ContentType
 import io.javalin.http.formParamAsClass
 import io.javalin.http.util.MultipartUtil
@@ -277,9 +277,9 @@ class TestMultipartForms {
         //paths exist and are writable on the system the test is being run on.  However, if the other parameters
         //are read successfully
         app.updateConfig {
-            it.fileUpload.maxFileSize(100,FileUploadConfig.SizeUnit.MB)
-            it.fileUpload.maxInMemoryFileSize(10,FileUploadConfig.SizeUnit.MB)
-            it.fileUpload.maxTotalRequestSize(1, FileUploadConfig.SizeUnit.GB)
+            it.fileUpload.maxFileSize(100, SizeUnit.MB)
+            it.fileUpload.maxInMemoryFileSize(10, SizeUnit.MB)
+            it.fileUpload.maxTotalRequestSize(1, SizeUnit.GB)
         }
 
         app.post("/test-multipart-config") { ctx ->

--- a/javalin/src/test/java/io/javalin/TestMultipartForms.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipartForms.kt
@@ -277,9 +277,9 @@ class TestMultipartForms {
         //paths exist and are writable on the system the test is being run on.  However, if the other parameters
         //are read successfully
         app.updateConfig {
-            it.fileUpload.maxFileSize(100,FileUploadConfig.Units.MB)
-            it.fileUpload.maxInMemoryFileSize(10,FileUploadConfig.Units.MB)
-            it.fileUpload.maxTotalRequestSize(1, FileUploadConfig.Units.GB)
+            it.fileUpload.maxFileSize(100,FileUploadConfig.SizeUnit.MB)
+            it.fileUpload.maxInMemoryFileSize(10,FileUploadConfig.SizeUnit.MB)
+            it.fileUpload.maxTotalRequestSize(1, FileUploadConfig.SizeUnit.GB)
         }
 
         app.post("/test-multipart-config") { ctx ->


### PR DESCRIPTION
I've done it the way that was discussed on the issue, whereby the user can set each parameter separately rather than via a single function with defaults.  There are a couple of things I'm not convinced about

### Single Function vs Being able to set each parameter
I've done it the way discussed in the issue, where the user can set each attribute separately, but to me this has significant downsides solely to allow people to avoid static multipliers. Specifically, with a single function, we can construct a fully formed multipart config element at that point and set the preUploadFunction.  This means we don't need to instantiate one on every upload but can simply use a cached version.  

By allowing the user to set each parameter independently (particularly since they can then call updateConfig) we don't know when they are finished so at the moment I am constructing this on every upload.  To be fair, so does the current MultipartUtil so it won't make anything slower!

### Java Compatibility
I'm used to working with pure kotlin codebases.  I noticed a lot of @JvmField annotations and so on which I assume are for Java compatibility and have tried to follow existing code as much as possible, but can't be sure this is all working with Java.

### Testing Cache Directory
Not sure how to test the cache directory is being set correctly since I don't want to hard-code a path and the only path which is guaranteed to exist is the Java temp directory - which is already the default!  Also not sure if you wanted a check when creating the javalin config that the relevant directory exists?