### PR TITLE
[sse] Prefix each line with `data: `

### DIFF
--- a/javalin/src/main/java/io/javalin/http/sse/Emitter.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/Emitter.kt
@@ -18,9 +18,11 @@ class Emitter(private var response: HttpServletResponse) {
                 write("id: $id$NEW_LINE")
             }
             write("event: $event$NEW_LINE")
-            write("data: ")
-            data.copyTo(response.outputStream)
-            write(NEW_LINE)
+
+            data.buffered().reader().useLines {
+                it.forEach { line -> write("data: $line$NEW_LINE") }
+            }
+
             write(NEW_LINE)
             response.flushBuffer()
         } catch (ignored: IOException) {

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -118,6 +118,13 @@ class TestSse {
     }
 
     @Test
+    fun `sending multi line data works`() = TestUtil.test { app, http ->
+        app.sse("/sse") { it.doAndClose { it.sendEvent("a\nb") } }
+        val body = http.sse("/sse").get().body
+        assertThat(body).isEqualTo("event: message\ndata: a\ndata: b\n\n")
+    }
+
+    @Test
     fun `sending async data is properly processed`() = TestUtil.test { app, http ->
         app.sse("/sse") {
             it.sendEvent("Sync event")


### PR DESCRIPTION
Each line of data in an SSE message must be prefixed with `data: `, according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format) and the [spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage).
Clients are responsible for joining adjacent `data: ` lines using a newline character.

Fixes #1774.