### PR TITLE
Add `jetty-alpn-java-server` to BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
                 <artifactId>jetty-alpn-conscrypt-server</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
 
             <!-- Jetty WebSocket -->
             <dependency>


### PR DESCRIPTION
Enables platforms not supported by conscrypt to implement the default Security Provider present in the JVM. (Such as Apple Silicon)

Currently used by javalin-ssl