### PR TITLE
[testtools] Move `TestConfig` defaults to standalone configurable global wrapper

### DIFF
--- a/javalin-testtools/src/main/java/io/javalin/testtools/TestTool.kt
+++ b/javalin-testtools/src/main/java/io/javalin/testtools/TestTool.kt
@@ -8,9 +8,9 @@ import java.io.PrintStream
 import java.util.*
 
 object DefaultTestConfig {
-    var clearCookies: Boolean = true
-    var captureLogs: Boolean = true
-    var okHttpClient: OkHttpClient = OkHttpClient()
+    @JvmStatic var clearCookies: Boolean = true
+    @JvmStatic var captureLogs: Boolean = true
+    @JvmStatic var okHttpClient: OkHttpClient = OkHttpClient()
 }
 
 data class TestConfig @JvmOverloads constructor(

--- a/javalin-testtools/src/main/java/io/javalin/testtools/TestTool.kt
+++ b/javalin-testtools/src/main/java/io/javalin/testtools/TestTool.kt
@@ -7,10 +7,16 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.*
 
+object DefaultTestConfig {
+    var clearCookies: Boolean = true
+    var captureLogs: Boolean = true
+    var okHttpClient: OkHttpClient = OkHttpClient()
+}
+
 data class TestConfig @JvmOverloads constructor(
-    val clearCookies: Boolean = true,
-    val captureLogs: Boolean = true,
-    val okHttpClient: OkHttpClient = OkHttpClient()
+    val clearCookies: Boolean = DefaultTestConfig.clearCookies,
+    val captureLogs: Boolean = DefaultTestConfig.captureLogs,
+    val okHttpClient: OkHttpClient = DefaultTestConfig.okHttpClient
 )
 
 class TestTool(private val testConfig: TestConfig = TestConfig()) {


### PR DESCRIPTION
It's kinda annoying to repeat `TestConfig` setup through several tests, so I think it might be a good idea to move those values to global wrapper.