### PR TITLE
[context] Fix typo in documentation

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -61,7 +61,7 @@ interface Context {
     /** Gets the handler type of the current handler */
     fun handlerType(): HandlerType
 
-    /** * Gets the path that was used to match request (also includes before/after paths) */
+    /** Gets the path that was used to match request (also includes before/after paths) */
     fun matchedPath(): String
 
     /** Gets the endpoint path that was used to match request (null in before, available in endpoint/after) */


### PR DESCRIPTION
Extra asterisk is converted into a bullet point.