### PR TITLE
Fix RouteOverviewTest by actually iterating over all entries

### DIFF
--- a/javalin/src/main/java/io/javalin/routing/PathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/routing/PathMatcher.kt
@@ -27,6 +27,9 @@ class PathMatcher {
     internal fun hasEntries(handlerType: HandlerType, requestUri: String): Boolean =
         handlerEntries[handlerType]!!.any { entry -> match(entry, requestUri) }
 
+    internal fun getAllEntriesOfType(handlerType: HandlerType) =
+        handlerEntries[handlerType]!!
+
     private fun match(entry: HandlerEntry, requestPath: String): Boolean = when (entry.path) {
         "*" -> true
         requestPath -> true

--- a/javalin/src/test/java/io/javalin/routeoverview/TestRouteOverviewPlugin.kt
+++ b/javalin/src/test/java/io/javalin/routeoverview/TestRouteOverviewPlugin.kt
@@ -20,7 +20,7 @@ class TestRouteOverviewPlugin {
         VisualTest.setupJavalinRoutes(app)
 
         val allPaths = HandlerType.values()
-            .flatMap { app.javalinServlet().matcher.findEntries(it, "*").map { entry -> entry.path } }
+            .flatMap { app.javalinServlet().matcher.getAllEntriesOfType(it).map { entry -> entry.path } }
 
         assertThat(allPaths).isNotEmpty
         assertThat(http.getBody("/overview")).contains(allPaths)


### PR DESCRIPTION
The old implementation just searched for stars as `entry.matches("*")` always returns false leading to only two matches out of 32.

