### PR TITLE
Implement JSON streaming in JavalinJackson

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeoutException
 import java.util.function.Supplier
+import java.util.stream.Stream
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
@@ -424,18 +425,19 @@ interface Context {
     fun json(obj: Any): Context = json(obj, obj::class.java)
 
     /**
-     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper]. The registered
-     * [io.javalin.json.JsonMapper] may write the output stream directly, or it may return a value that will
-     * be set as the context result. Also sets content type to application/json.
+     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper] and sets it as the context result.
+     * Also sets content type to application/json.
      */
-    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).apply {
-        if (!jsonMapper().handleOutputStream(outputStream(), obj, type)) {
-            result(jsonMapper().toJsonStream(obj, type))
-        }
-    }
-
+    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).result(jsonMapper().toJsonStream(obj, type))
     /** @see [jsonStream] */
     fun jsonStream(obj: Any): Context = jsonStream(obj, obj::class.java)
+
+    /**
+     * Consumes the specified stream with the configured JsonMapper, which transforms the stream's
+     * content to JSON, writing the results directly to the response's `outputStream` as the stream
+     * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
+     */
+    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeStream(this, stream)
 
     /** Sets context result to specified html string and sets content-type to text/html. */
     fun html(html: String): Context = contentType(ContentType.TEXT_HTML).result(html)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -437,8 +437,8 @@ interface Context {
      * content to JSON, writing the results directly to the response's `outputStream` as the stream
      * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
      */
-    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeStream(
-        this.contentType(ContentType.APPLICATION_JSON).outputStream(), stream
+    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeToOutputStream(
+        stream, this.contentType(ContentType.APPLICATION_JSON).outputStream()
     )
 
     /** Sets context result to specified html string and sets content-type to text/html. */

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -437,7 +437,9 @@ interface Context {
      * content to JSON, writing the results directly to the response's `outputStream` as the stream
      * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
      */
-    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeStream(this, stream)
+    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeStream(
+        this.contentType(ContentType.APPLICATION_JSON).outputStream(), stream
+    )
 
     /** Sets context result to specified html string and sets content-type to text/html. */
     fun html(html: String): Context = contentType(ContentType.TEXT_HTML).result(html)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -424,10 +424,16 @@ interface Context {
     fun json(obj: Any): Context = json(obj, obj::class.java)
 
     /**
-     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper] and sets it as the context result.
-     * Also sets content type to application/json.
+     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper]. The registered
+     * [io.javalin.json.JsonMapper] may write the output stream directly, or it may return a value that will
+     * be set as the context result. Also sets content type to application/json.
      */
-    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).result(jsonMapper().toJsonStream(obj, type))
+    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).apply {
+        if (!jsonMapper().handleOutputStream(outputStream(), obj, type)) {
+            result(jsonMapper().toJsonStream(obj, type))
+        }
+    }
+
     /** @see [jsonStream] */
     fun jsonStream(obj: Any): Context = jsonStream(obj, obj::class.java)
 

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -50,7 +50,7 @@ class JavalinJackson(private var objectMapper: ObjectMapper? = null) : JsonMappe
         }
     }
 
-    override fun writeStream(outputStream: OutputStream, stream: Stream<*>) {
+    override fun writeToOutputStream(stream: Stream<*>, outputStream: OutputStream) {
         mapper.writer().writeValuesAsArray(outputStream).use { sequenceWriter ->
             stream.forEach { sequenceWriter.write(it) }
         }

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -8,8 +8,6 @@ package io.javalin.json
 
 import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.javalin.http.ContentType
-import io.javalin.http.Context
 import io.javalin.http.InternalServerErrorResponse
 import io.javalin.util.CoreDependency
 import io.javalin.util.DependencyUtil
@@ -52,11 +50,8 @@ class JavalinJackson(private var objectMapper: ObjectMapper? = null) : JsonMappe
         }
     }
 
-    override fun writeStream(ctx: Context, stream: Stream<*>) {
-        ctx.contentType(ContentType.APPLICATION_JSON)
-        val compressedOutputStream = ctx.outputStream()
-        mapper.writer().writeValues(compressedOutputStream).use { sequenceWriter ->
-            sequenceWriter.init(true) // wrapInArray=true, a Stream<T> of data implies Array in JSON output
+    override fun writeStream(outputStream: OutputStream, stream: Stream<*>) {
+        mapper.writer().writeValuesAsArray(outputStream).use { sequenceWriter ->
             stream.forEach { sequenceWriter.write(it) }
         }
     }

--- a/javalin/src/main/java/io/javalin/json/JsonMapper.kt
+++ b/javalin/src/main/java/io/javalin/json/JsonMapper.kt
@@ -9,6 +9,7 @@ package io.javalin.json
 import io.javalin.Javalin
 import io.javalin.http.Context
 import java.io.InputStream
+import java.io.OutputStream
 import java.lang.reflect.Type
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
@@ -27,6 +28,13 @@ interface JsonMapper {
      * an InputStream from an OutputStream.
      */
     fun toJsonStream(obj: Any, type: Type): InputStream = throw NotImplementedError("JsonMapper#toJsonStream not implemented")
+
+    /**
+     * Javalin will call this method first before calling [toJsonStream]. If this true is
+     * returned, then the responsiblity for writing all output is delegated to this function.
+     * If false is returned, then Javalin will continue with its call to [toJsonStream].
+     */
+    fun handleOutputStream(outputStream: OutputStream, obj: Any, type: Type): Boolean = false
 
     /**
      * If [.fromJsonStream] is not implemented, Javalin will use this method

--- a/javalin/src/main/java/io/javalin/json/JsonMapper.kt
+++ b/javalin/src/main/java/io/javalin/json/JsonMapper.kt
@@ -46,10 +46,10 @@ interface JsonMapper {
      * Once Javalin calls this function, it will not participate any further in the response. It becomes
      * your responsibility to deliver the remainder of the response to the `outputStream`.
      *
-     * When your implementation returns from the `writeStream` function, assume that the underlying resources
-     * for the `stream` will be released.
+     * When your implementation returns from this function, assume that the underlying resources for
+     * the `stream` will be released.
      */
-    fun writeStream(outputStream: OutputStream, stream: Stream<*>): Unit = throw NotImplementedError("JsonMapper#writeStream not implemented")
+    fun writeToOutputStream(stream: Stream<*>, outputStream: OutputStream): Unit = throw NotImplementedError("JsonMapper#writeToOutputStream not implemented")
 
     /**
      * If [.fromJsonStream] is not implemented, Javalin will use this method

--- a/javalin/src/main/java/io/javalin/json/JsonMapper.kt
+++ b/javalin/src/main/java/io/javalin/json/JsonMapper.kt
@@ -39,11 +39,9 @@ interface JsonMapper {
      * It is implied that the `stream` of objects will be transformed to an Array type in JSON. In other words,
      * it is your responsibility to surround the output with `[` and `]`.
      *
-     * Use `ctx.outputStream()` for the compressed output stream. Or use `ctx.res().outputStream` if you need the
-     * raw uncompressed stream.
+     * The `outputStream` will be a compressed output stream.
      *
-     * You are responsible for setting the content type header, which is likely to be "application/json" done
-     * by calling `ctx.contentType(ContentType.APPLICATION_JSON)`.
+     * The content type header will already be set to "application/json".
      *
      * Once Javalin calls this function, it will not participate any further in the response. It becomes
      * your responsibility to deliver the remainder of the response to the `outputStream`.
@@ -51,7 +49,7 @@ interface JsonMapper {
      * When your implementation returns from the `writeStream` function, assume that the underlying resources
      * for the `stream` will be released.
      */
-    fun writeStream(ctx: Context, stream: Stream<*>): Unit = throw NotImplementedError("JsonMapper#writeStream not implemented")
+    fun writeStream(outputStream: OutputStream, stream: Stream<*>): Unit = throw NotImplementedError("JsonMapper#writeStream not implemented")
 
     /**
      * If [.fromJsonStream] is not implemented, Javalin will use this method

--- a/javalin/src/test/java/io/javalin/TestJson.kt
+++ b/javalin/src/test/java/io/javalin/TestJson.kt
@@ -277,4 +277,14 @@ internal class TestJson {
             assertThat(http.jsonGet("/json-stream").body).isEqualTo(expectedResponse)
         }
 
+    @Test
+    fun `can write a JSON stream with async`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            ctx.async {
+                ctx.writeJsonStream(listOf("a", "b", "c").stream())
+            }
+        }
+        assertThat(http.jsonGet("/").body).isEqualTo("""["a","b","c"]""")
+    }
+
 }

--- a/javalin/src/test/java/io/javalin/TestJson.kt
+++ b/javalin/src/test/java/io/javalin/TestJson.kt
@@ -122,7 +122,7 @@ internal class TestJson {
         log = TestUtil.captureStdOut {
             app.get("/write-json-stream") { it.writeJsonStream(listOf<String>().stream()) }.also { http.getBody("/write-json-stream") }
         }
-        assertThat(log).contains("JsonMapper#writeStream not implemented")
+        assertThat(log).contains("JsonMapper#writeToOutputStream not implemented")
     }
 
 
@@ -222,7 +222,7 @@ internal class TestJson {
         data class Foo(val value: Long)
         val source = listOf(Foo(1_000_000), Foo(1_000_001))
         val baos = ByteArrayOutputStream()
-        JavalinJackson().writeStream(baos, source.stream())
+        JavalinJackson().writeToOutputStream(source.stream(), baos)
         assertThat("""[{"value":1000000},{"value":1000001}]""").isEqualTo(baos.toString())
     }
 
@@ -239,7 +239,7 @@ internal class TestJson {
         var value = 1_000_000_000L
         val take = 50_000_000
         val seq = generateSequence { Foo(value++) }
-        JavalinJackson().writeStream(countingOutputStream, seq.take(take).asStream())
+        JavalinJackson().writeToOutputStream(seq.take(take).asStream(), countingOutputStream)
         // expectedCharacterCount is approximately 1GB
         val expectedCharacterCount = 2 + // bookend brackets
             (take - 1) + // commas

--- a/javalin/src/test/java/io/javalin/TestJson.kt
+++ b/javalin/src/test/java/io/javalin/TestJson.kt
@@ -215,10 +215,9 @@ internal class TestJson {
     @Test
     fun `JavalinJackson can convert a small Stream to JSON`() {
         data class Foo(val value: Long)
-        var value = 1_000_000L
-        val seq = generateSequence { if (value < 1_000_002) Foo(value++) else null }
+        val source = listOf(Foo(1_000_000), Foo(1_000_001))
         val baos = ByteArrayOutputStream()
-        JavalinJackson().writeStream(baos, seq.asStream())
+        JavalinJackson().writeStream(baos, source.stream())
         assertThat("""[{"value":1000000},{"value":1000001}]""").isEqualTo(baos.toString())
     }
 


### PR DESCRIPTION
This adds a `writeStream()` function to JsonMapper interface, a `writeJsonStream()` function to `Context`, and implements `writeStream()` in `JavalinJackson`.
