### PR TITLE
Rename bodyInputStream() method to bodyAsInputStream

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -138,7 +138,7 @@ interface Context {
     fun <T> bodyStreamAsClass(type: Type): T = jsonMapper().fromJsonStream(req().inputStream, type)
 
     /** Gets the underlying [InputStream] for the request body */
-    fun bodyInputStream(): InputStream = req().inputStream
+    fun bodyAsInputStream(): InputStream = req().inputStream
 
     /** Creates a typed [BodyValidator] for the body() value */
     fun <T> bodyValidator(clazz: Class<T>) = BodyValidator(body(), clazz, this.jsonMapper())


### PR DESCRIPTION
As per the [documentaton](https://javalin.io/documentation#context) context.bodyAsInputStream() method return request body as input stream. But actually it is declared as 'bodyInputStream()'. 'bodyAsInputStream()' seems more meaningful.

**Documentation reference**
https://javalin.io/documentation#context