### PR TITLE
[async] Disable default timeout system for all async requests

### DIFF
--- a/javalin/src/main/java/io/javalin/http/util/AsyncUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/AsyncUtil.kt
@@ -1,5 +1,6 @@
 package io.javalin.http.util
 
+import io.javalin.config.HttpConfig
 import io.javalin.http.Context
 import io.javalin.util.ConcurrencyUtil
 import io.javalin.util.function.ThrowingRunnable
@@ -16,9 +17,14 @@ internal object AsyncUtil {
 
     val defaultExecutor = ConcurrencyUtil.executorService("JavalinDefaultAsyncThreadPool")
 
+    /**
+     * Utility method that executes [task] asynchronously using [executor] ([defaultExecutor] by default).
+     * It also provides custom timeout handling via [onTimeout] callback registered directly on underlying [CompletableFuture],
+     * so global [HttpConfig.asyncTimeout] does not affect this particular task.
+     */
     fun submitAsyncTask(context: Context, executor: ExecutorService?, timeout: Long, onTimeout: Runnable?, task: ThrowingRunnable<Exception>): Unit =
         context.future {
-            context.req().asyncContext.timeout = 0 // override default timeout system
+            context.req().asyncContext.timeout = 0 // we're using cf timeouts below, so we need to disable default jetty timeout listener
 
             CompletableFuture.runAsync({ task.run() }, executor ?: defaultExecutor)
                 .let { if (timeout > 0) it.orTimeout(timeout, MILLISECONDS) else it }

--- a/javalin/src/main/java/io/javalin/http/util/AsyncUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/AsyncUtil.kt
@@ -18,6 +18,8 @@ internal object AsyncUtil {
 
     fun submitAsyncTask(context: Context, executor: ExecutorService?, timeout: Long, onTimeout: Runnable?, task: ThrowingRunnable<Exception>): Unit =
         context.future {
+            context.req().asyncContext.timeout = 0 // override default timeout system
+
             CompletableFuture.runAsync({ task.run() }, executor ?: defaultExecutor)
                 .let { if (timeout > 0) it.orTimeout(timeout, MILLISECONDS) else it }
                 .let { if (onTimeout == null) it else it.exceptionally { exception ->

--- a/javalin/src/test/java/io/javalin/TestFuture.kt
+++ b/javalin/src/test/java/io/javalin/TestFuture.kt
@@ -51,7 +51,7 @@ internal class TestFuture {
         }
 
         @Test
-        fun `async context can be used already in future body`() = TestUtil.test { app, http ->
+        fun `async context can be used in future supplier`() = TestUtil.test { app, http ->
             app.get("/") { ctx ->
                 ctx.future {
                     completedFuture(ctx.req().asyncContext.timeout).thenApply { ctx.result(it.toString()) }

--- a/javalin/src/test/java/io/javalin/TestFuture.kt
+++ b/javalin/src/test/java/io/javalin/TestFuture.kt
@@ -50,6 +50,16 @@ internal class TestFuture {
             assertThat(http.getBody("/")).isEqualTo("Success")
         }
 
+        @Test
+        fun `async context can be used already in future body`() = TestUtil.test { app, http ->
+            app.get("/") { ctx ->
+                ctx.future {
+                    completedFuture(ctx.req().asyncContext.timeout).thenApply { ctx.result(it.toString()) }
+                }
+            }
+            assertThat(http.getBody("/")).isEqualTo(app.cfg.http.asyncTimeout.toString())
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
Resolves #1822 

This PR:
1. Makes it possible to use `asyncCtx` in `future` supplier
2. Disables global timeout for `async` requests (because they're using other timeout system)