### PR TITLE
Add mimeTypes option to staticFiles and switch to text/javascript

### DIFF
--- a/javalin/src/main/java/io/javalin/http/ContentType.kt
+++ b/javalin/src/main/java/io/javalin/http/ContentType.kt
@@ -25,6 +25,7 @@ enum class ContentType(
     TEXT_CSS("text/css", true, "css"),
     TEXT_CSV("text/csv", false, "csv"),
     TEXT_HTML("text/html", true, "html", "htm"),
+    TEXT_JS("text/javascript", true, "js", "mjs"),
     TEXT_MARKDOWN("text/markdown", true, "md"),
     TEXT_PROPERTIES("text/x-java-properties", true, "properties"),
     TEXT_XML("text/xml", true, "xml"),
@@ -73,7 +74,12 @@ enum class ContentType(
     APPLICATION_DOCX("application/vnd.openxmlformats-officedocument.wordprocessingml.document", false, "docx"),
     APPLICATION_EPUB("application/epub+zip", false, "epub"),
     APPLICATION_GZ("application/gzip", false, "gz"),
-    APPLICATION_JS("application/javascript", true, "js", "mjs"),
+    @Deprecated(
+        message = "use TEXT_JS instead.",
+        replaceWith = ReplaceWith("io.javalin.http.ContentType.TEXT_JS"),
+        level = DeprecationLevel.ERROR
+    )
+    APPLICATION_JS("application/javascript", true, "application/javascript"),
     APPLICATION_JSON("application/json", true, "json"),
     APPLICATION_MPKG("application/vnd.apple.installer+xml", false, "mpkg"),
     APPLICATION_JAR("application/java-archive", false, "jar"),
@@ -104,7 +110,14 @@ enum class ContentType(
         const val HTML = "text/html"
         const val XML = "text/xml"
         const val OCTET_STREAM = "application/octet-stream"
+        @Deprecated(
+            message = "represents the older application/javascript mimetype. This will change to represent text/javascript instead. Please use either JAVASCRIPT_LEGACY or JAVASCRIPT_MODERN instead to be explicit",
+            replaceWith = ReplaceWith("io.javalin.http.ContentType.JAVASCRIPT_MODERN"),
+            level = DeprecationLevel.WARNING
+        )
         const val JAVASCRIPT = "application/javascript"
+        const val JAVASCRIPT_LEGACY = "application/javascript"
+        const val JAVASCRIPT_MODERN = "text/javascript"
         const val JSON = "application/json"
         const val FORM_DATA = "multipart/form-data"
 

--- a/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
@@ -1,5 +1,6 @@
 package io.javalin.http.staticfiles
 
+import io.javalin.http.ContentType
 import io.javalin.http.Header
 import jakarta.servlet.http.HttpServletRequest
 import org.eclipse.jetty.server.handler.ContextHandler.AliasCheck
@@ -14,8 +15,29 @@ data class StaticFileConfig(
     @JvmField var aliasCheck: AliasCheck? = null,
     @JvmField var headers: Map<String, String> = mutableMapOf(Header.CACHE_CONTROL to "max-age=0"),
     @JvmField var skipFileFunction: (HttpServletRequest) -> Boolean = { false },
+    @JvmField val mimeTypes: MimeTypesConfig = MimeTypesConfig()
 ) {
     internal fun refinedToString(): String {
         return this.toString().replace(", skipFileFunction=(jakarta.servlet.http.HttpServletRequest) -> kotlin.Boolean", "")
+    }
+}
+
+class MimeTypesConfig {
+    private val extensionToMimeType: MutableMap<String, String> = mutableMapOf()
+
+    fun getMapping(): Map<String, String> = extensionToMimeType.toMap()
+
+    fun add(contentType: ContentType) {
+        add(contentType.mimeType, *contentType.extensions)
+    }
+
+    fun add(contentType: ContentType, vararg extensions: String) {
+        add(contentType.mimeType, *extensions)
+    }
+
+    fun add(mimeType: String, vararg extensions: String) {
+        extensions.forEach { ext ->
+            extensionToMimeType[ext] = mimeType
+        }
     }
 }

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -7,12 +7,14 @@
 package io.javalin.jetty
 
 import io.javalin.config.PrivateConfig
+import io.javalin.http.ContentType
 import io.javalin.http.staticfiles.Location
 import io.javalin.http.staticfiles.StaticFileConfig
 import io.javalin.util.JavalinException
 import io.javalin.util.JavalinLogger
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.eclipse.jetty.http.MimeTypes
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ResourceHandler
@@ -76,6 +78,15 @@ open class ConfigurableHandler(val config: StaticFileConfig, jettyServer: Server
         isDirAllowed = false
         isEtags = true
         server = jettyServer
+        mimeTypes = MimeTypes()
+        // TODO: the next two lines can be removed once Jetty releases a version with their new mimetype mappings.
+        //   Ref: https://github.com/eclipse/jetty.project/issues/9342
+        //   Ref: https://github.com/eclipse/jetty.project/pull/9347
+        mimeTypes.addMimeMapping("js", ContentType.JAVASCRIPT_MODERN)
+        mimeTypes.addMimeMapping("mjs", ContentType.JAVASCRIPT_MODERN)
+        config.mimeTypes.getMapping().forEach { (ext, mimeType) ->
+            mimeTypes.addMimeMapping(ext, mimeType)
+        }
         start()
     }
 

--- a/javalin/src/test/java/io/javalin/staticfiles/TestSinglePageMode.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestSinglePageMode.kt
@@ -81,7 +81,7 @@ class TestSinglePageMode {
 
     @Test
     fun `SinglePageHandler doesn't affect static files - classpath`() = TestUtil.test(rootSinglePageApp_classPath) { _, http ->
-        assertThat(http.htmlGet("/script.js").headers.getFirst(Header.CONTENT_TYPE)).contains("application/javascript")
+        assertThat(http.htmlGet("/script.js").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.JAVASCRIPT_MODERN)
         assertThat(http.htmlGet("/webjars/swagger-ui/${TestDependency.swaggerVersion}/swagger-ui.css").headers.getFirst(
             Header.CONTENT_TYPE)).contains(ContentType.CSS)
         assertThat(http.htmlGet("/webjars/swagger-ui/${TestDependency.swaggerVersion}/swagger-ui.css").httpCode()).isEqualTo(OK)

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
@@ -143,8 +143,15 @@ class TestStaticFiles {
     @Test
     fun `serving JS from classpath works`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
         assertThat(http.get("/script.js").httpCode()).isEqualTo(OK)
-        assertThat(http.get("/script.js").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.JAVASCRIPT)
+        assertThat(http.get("/script.js").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.JAVASCRIPT_MODERN)
         assertThat(http.getBody("/script.js")).contains("JavaScript works")
+    }
+
+    @Test
+    fun `serving mjs from classpath works`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
+        assertThat(http.get("/module.mjs").httpCode()).isEqualTo(OK)
+        assertThat(http.get("/module.mjs").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.JAVASCRIPT_MODERN)
+        assertThat(http.getBody("/module.mjs")).contains("export function test()").contains("mjs works")
     }
 
     @Test
@@ -207,7 +214,7 @@ class TestStaticFiles {
         assertThat(http.get("/html.html").status).isEqualTo(200)
         assertThat(http.get("/html.html").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
         assertThat(http.getBody("/html.html")).contains("HTML works")
-        assertThat(http.get("/script.js").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.JAVASCRIPT)
+        assertThat(http.get("/script.js").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.JAVASCRIPT_MODERN)
         assertThat(http.get("/styles.css").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.CSS)
     }
 
@@ -340,4 +347,16 @@ class TestStaticFiles {
         assertThat(http.getBody("/html.html")).contains("HTML works")
     }
 
+    @Test
+    fun `can add custom mimetype mappings`() = TestUtil.test(Javalin.create { config ->
+        config.staticFiles.add {
+            it.directory = "/public"
+            it.location = Location.CLASSPATH
+            it.mimeTypes.add("application/x-javalin", "javalin")
+        }
+    }) { _, http ->
+        assertThat(http.get("/file.javalin").httpCode()).isEqualTo(OK)
+        assertThat(http.get("/file.javalin").headers.getFirst(Header.CONTENT_TYPE)).contains("application/x-javalin")
+        assertThat(http.getBody("/file.javalin")).contains("TESTFILE.javalin")
+    }
 }

--- a/javalin/src/test/resources/public/file.javalin
+++ b/javalin/src/test/resources/public/file.javalin
@@ -1,0 +1,1 @@
+TESTFILE.javalin

--- a/javalin/src/test/resources/public/module.mjs
+++ b/javalin/src/test/resources/public/module.mjs
@@ -1,0 +1,3 @@
+export function test() {
+    return 'mjs works'
+}


### PR DESCRIPTION
Had to change the extension value of `ContentType.APPLICATION_JS`, as we currently require unique extensions for each content type.
This does not affect using the content type in `Context.contentType()`

Similarly I switched everything over to `text/javascript` as a mimetype, so we stay in sync with Jetty.

Ref: javalin/javalin#1820