### PR TITLE
Reorganize JavalinJackson, JavalinGson, and JsonMapper test classes

### DIFF
--- a/javalin/src/test/java/io/javalin/TestJavalinGson.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinGson.kt
@@ -1,0 +1,24 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.json.JavalinGson
+import org.junit.jupiter.api.Test
+
+internal class TestJavalinGson {
+
+    @Test
+    fun `JavalinGson can convert a small Stream to JSON`() {
+        TestJsonMapper.convertSmallStreamToJson(JavalinGson())
+    }
+
+    @Test
+    fun `JavalinGson can convert a large Stream to JSON`() {
+        TestJsonMapper.convertLargeStreamToJson(JavalinGson())
+    }
+
+}

--- a/javalin/src/test/java/io/javalin/TestJavalinGson.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinGson.kt
@@ -6,7 +6,12 @@
 
 package io.javalin
 
+import com.google.gson.Gson
+import io.javalin.http.bodyAsClass
 import io.javalin.json.JavalinGson
+import io.javalin.testing.SerializableObject
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 
 internal class TestJavalinGson {
@@ -19,6 +24,23 @@ internal class TestJavalinGson {
     @Test
     fun `JavalinGson can convert a large Stream to JSON`() {
         TestJsonMapper.convertLargeStreamToJson(JavalinGson())
+    }
+
+    @Test
+    fun `user can serialize objects using gson mapper`() = TestUtil.test(Javalin.create {
+        it.jsonMapper(JavalinGson())
+    }) { app, http ->
+        app.get("/") { it.json(SerializableObject()) }
+        Assertions.assertThat(http.getBody("/")).isEqualTo(Gson().toJson(SerializableObject()))
+    }
+
+    @Test
+    fun `user can deserialize objects using gson mapper`() = TestUtil.test(Javalin.create {
+        it.jsonMapper(JavalinGson())
+    }) { app, http ->
+        app.post("/") { it.result(it.bodyAsClass<SerializableObject>().value1) }
+        Assertions.assertThat(http.post("/").body(Gson().toJson(SerializableObject())).asString().body)
+            .isEqualTo(SerializableObject().value1)
     }
 
 }

--- a/javalin/src/test/java/io/javalin/TestJavalinJackson.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinJackson.kt
@@ -1,0 +1,24 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.json.JavalinJackson
+import org.junit.jupiter.api.Test
+
+internal class TestJavalinJackson {
+
+    @Test
+    fun `JavalinJackson can convert a small Stream to JSON`() {
+        TestJsonMapper.convertSmallStreamToJson(JavalinJackson())
+    }
+
+    @Test
+    fun `JavalinJackson can convert a large Stream to JSON`() {
+        TestJsonMapper.convertLargeStreamToJson(JavalinJackson())
+    }
+
+}

--- a/javalin/src/test/java/io/javalin/TestJavalinJackson.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinJackson.kt
@@ -6,8 +6,14 @@
 
 package io.javalin
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.javalin.json.JavalinJackson
+import io.javalin.json.fromJsonString
+import io.javalin.json.toJsonString
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import kotlin.streams.asStream
 
 internal class TestJavalinJackson {
 
@@ -20,5 +26,46 @@ internal class TestJavalinJackson {
     fun `JavalinJackson can convert a large Stream to JSON`() {
         TestJsonMapper.convertLargeStreamToJson(JavalinJackson())
     }
+
+
+    data class SerializableDataClass(val value1: String = "Default1", val value2: String)
+
+    @Test
+    fun `can use JavalinJackson with a custom object-mapper on a kotlin data class`() {
+        val mapped = JavalinJackson().toJsonString(SerializableDataClass("First value", "Second value"))
+        val mappedBack = JavalinJackson().fromJsonString<SerializableDataClass>(mapped)
+        Assertions.assertThat("First value").isEqualTo(mappedBack.value1)
+        Assertions.assertThat("Second value").isEqualTo(mappedBack.value2)
+    }
+
+    @Test
+    fun `default JavalinJackson includes nulls`() = TestUtil.test { app, http ->
+        data class TestClass(val one: String? = null, val two: String? = null)
+        app.get("/") { it.json(TestClass()) }
+        Assertions.assertThat(http.getBody("/")).isEqualTo("""{"one":null,"two":null}""")
+    }
+
+    @Test
+    fun `can update ObjectMapper of JavalinJackson`() = TestUtil.test(Javalin.create {
+        it.jsonMapper(JavalinJackson().updateMapper { mapper ->
+            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        })
+    }) { app, http ->
+        data class TestClass(val one: String? = null, val two: String? = null)
+        app.get("/") { it.json(TestClass()) }
+        Assertions.assertThat(http.getBody("/")).isEqualTo("{}")
+    }
+
+    @Test
+    fun `can write a JSON stream with JavalinJackson`() =
+        TestUtil.test(Javalin.create { it.jsonMapper(JavalinJackson()) }) { app, http ->
+            data class Hello(val greet: String, val value: Long)
+            var value = 0L
+            val take = 100
+            val seq = generateSequence { Hello("hi", value++) }
+            app.get("/json-stream") { it.writeJsonStream(seq.take(take).asStream()) }
+            val expectedResponse = List(take) { """{"greet":"hi","value":${it}}""" }.joinToString(",", "[", "]")
+            Assertions.assertThat(http.jsonGet("/json-stream").body).isEqualTo(expectedResponse)
+        }
 
 }

--- a/javalin/src/test/java/io/javalin/TestJson.kt
+++ b/javalin/src/test/java/io/javalin/TestJson.kt
@@ -217,54 +217,6 @@ internal class TestJson {
         assertThat("Second value").isEqualTo(mappedBack.value2)
     }
 
-    fun convertSmallStreamToJson(jsonMapper: JsonMapper) {
-        data class Foo(val value: Long)
-        val source = listOf(Foo(1_000_000), Foo(1_000_001))
-        val baos = ByteArrayOutputStream()
-        jsonMapper.writeToOutputStream(source.stream(), baos)
-        assertThat("""[{"value":1000000},{"value":1000001}]""").isEqualTo(baos.toString())
-    }
-
-    @Test
-    fun `JavalinJackson can convert a small Stream to JSON`() {
-        convertSmallStreamToJson(JavalinJackson())
-    }
-
-    @Test
-    fun `JavalinGson can convert a small Stream to JSON`() {
-        convertSmallStreamToJson(JavalinGson())
-    }
-
-    fun convertLargeStreamToJson(jsonMapper: JsonMapper) {
-        data class Foo(val value: Long)
-
-        val countingOutputStream = object : OutputStream() {
-            var count: Long = 0
-            override fun write(b: Int) {
-                count++
-            }
-        }
-        var value = 1_000_000_000L
-        val take = 50_000_000
-        val seq = generateSequence { Foo(value++) }
-        JavalinJackson().writeToOutputStream(seq.take(take).asStream(), countingOutputStream)
-        // expectedCharacterCount is approximately 1GB
-        val expectedCharacterCount = 2 + // bookend brackets
-            (take - 1) + // commas
-            20 * take // objects {"value":1000000000}
-        assertThat(expectedCharacterCount).isEqualTo(countingOutputStream.count)
-    }
-
-    @Test
-    fun `JavalinJackson can convert a large Stream to JSON`() {
-        convertLargeStreamToJson(JavalinJackson())
-    }
-
-    @Test
-    fun `JavalinGson can convert a large Stream to JSON`() {
-        convertLargeStreamToJson(JavalinGson())
-    }
-
     @Test
     fun `default JavalinJackson includes nulls`() = TestUtil.test { app, http ->
         data class TestClass(val one: String? = null, val two: String? = null)

--- a/javalin/src/test/java/io/javalin/TestJsonMapper.kt
+++ b/javalin/src/test/java/io/javalin/TestJsonMapper.kt
@@ -1,0 +1,50 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.json.JsonMapper
+import org.assertj.core.api.Assertions.assertThat
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import kotlin.streams.asStream
+
+class TestJsonMapper {
+
+    companion object {
+
+        fun convertSmallStreamToJson(jsonMapper: JsonMapper) {
+            data class Foo(val value: Long)
+
+            val source = listOf(Foo(1_000_000), Foo(1_000_001))
+            val baos = ByteArrayOutputStream()
+            jsonMapper.writeToOutputStream(source.stream(), baos)
+            assertThat("""[{"value":1000000},{"value":1000001}]""").isEqualTo(baos.toString())
+        }
+
+        fun convertLargeStreamToJson(jsonMapper: JsonMapper) {
+            data class Foo(val value: Long)
+
+            val countingOutputStream = object : OutputStream() {
+                var count: Long = 0
+                override fun write(b: Int) {
+                    count++
+                }
+            }
+            var value = 1_000_000_000L
+            val take = 50_000_000
+            val seq = generateSequence { Foo(value++) }
+            jsonMapper.writeToOutputStream(seq.take(take).asStream(), countingOutputStream)
+            // expectedCharacterCount is approximately 1GB
+            val expectedCharacterCount = 2 + // bookend brackets
+                (take - 1) + // commas
+                20 * take // objects {"value":1000000000}
+            assertThat(expectedCharacterCount).isEqualTo(countingOutputStream.count)
+        }
+
+    }
+
+}


### PR DESCRIPTION
Move some functions out of `TestJson` and into respective test classes for `JavalinJackson`, `JavalinGson`, and `JsonMapper`.

Fix copy/paste/typo bug in `convertLargeStreamToJson` to use the `jsonMapper` arg rather than a hardwired `JavalinJackson` mapper.