### PR TITLE
[servlet] Replace invalid `isReady` call with `isInitialized()` (Fix #1752)

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -104,7 +104,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
         } catch (throwable: Throwable) {
             exceptionMapper.handleUnexpectedThrowable(res(), throwable) // handle any unexpected error, e.g. write failure
         } finally {
-            if (outputStreamWrapper.isReady) outputStream().close() // close initialized output wrappers
+            if (outputStreamWrapper.isInitialized()) outputStream().close() // close initialized output wrappers
             if (isAsync()) req().asyncContext.complete() // guarantee completion of async context to eliminate the possibility of hanging connections
         }
     }

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -108,8 +108,8 @@ class JavalinServletContext(
     private val queryParams by lazy { super.queryParamMap() }
     override fun queryParamMap(): Map<String, List<String>> = queryParams
 
-    internal val outputStreamWrapper by lazy { CompressedOutputStream(compressionStrategy, this) }
-    override fun outputStream(): ServletOutputStream = outputStreamWrapper
+    internal val outputStreamWrapper = lazy { CompressedOutputStream(compressionStrategy, this) }
+    override fun outputStream(): ServletOutputStream = outputStreamWrapper.value
 
     override fun redirect(location: String, status: HttpStatus) {
         header(Header.LOCATION, location).status(status).result("Redirected")


### PR DESCRIPTION
Fixes #1752 

In most cases this bug only spams in console as it's trying to create new compressed stream when the stream is already closed. If it'll happen in async ctx, then we're not properly closing async ctx, because it won't be executed:

```
            if (isAsync()) req().asyncContext.complete() // guarantee completion of async context to eliminate the possibility of hanging connections
```

Because it happens in `finally` closure & we don't do anything after that, I'm kinda unable to write unit test without modifying this code. Our execution flow is valid, it was pretty much just a typo