### PR TITLE
Move test dependencies from parent to submodule

### DIFF
--- a/javalin-micrometer/pom.xml
+++ b/javalin-micrometer/pom.xml
@@ -36,11 +36,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/javalin-testtools/pom.xml
+++ b/javalin-testtools/pom.xml
@@ -38,11 +38,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -70,26 +70,31 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
+            <version>${unirest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
+            <version>${java.websocket.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -100,11 +105,13 @@
         <dependency>
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi</artifactId>
+            <version>${moshi.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi-kotlin</artifactId>
+            <version>${moshi.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -115,11 +122,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
+            <version>${selenium.chrome.driver.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
+            <version>${webdrivermanager.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -125,7 +125,14 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>swagger-ui</artifactId>
+            <version>${swagger.ui.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:tipsy/javalin.git</connection>
-        <developerConnection>scm:git:git@github.com:tipsy/javalin.git</developerConnection>
-        <url>https://github.com/tipsy/javalin.git</url>
+        <connection>scm:git:git@github.com:javalin/javalin.git</connection>
+        <developerConnection>scm:git:git@github.com:javalin/javalin.git</developerConnection>
+        <url>https://github.com/javalin/javalin.git</url>
         <tag>HEAD</tag>
     </scm>
     <developers>
@@ -36,7 +36,7 @@
     </developers>
     <issueManagement>
         <system>GitHub Issue Tracker</system>
-        <url>https://github.com/tipsy/javalin/issues</url>
+        <url>https://github.com/javalin/javalin/issues</url>
     </issueManagement>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -232,62 +232,6 @@
                 <version>${okhttp.version}</version>
             </dependency>
             <!-- END Optional dependencies -->
-
-            <!-- BEGIN Test dependencies -->
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.konghq</groupId>
-                <artifactId>unirest-java</artifactId>
-                <version>${unirest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.java-websocket</groupId>
-                <artifactId>Java-WebSocket</artifactId>
-                <version>${java.websocket.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.moshi</groupId>
-                <artifactId>moshi</artifactId>
-                <version>${moshi.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.moshi</groupId>
-                <artifactId>moshi-kotlin</artifactId>
-                <version>${moshi.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-chrome-driver</artifactId>
-                <version>${selenium.chrome.driver.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.github.bonigarcia</groupId>
-                <artifactId>webdrivermanager</artifactId>
-                <version>${webdrivermanager.version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -288,18 +288,6 @@
                 <version>${webdrivermanager.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>swagger-ui</artifactId>
-                <version>${swagger.ui.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Fixes javalin/javalin-openapi#160 and javalin/javalin-ssl#74.

The problem
-
I'm using javalin-parent as a BOM for my plugin, resolving jetty dependencies with it. 
Currently, the BOM (basically the `<dependencyManagment>` block of the POM) includes several test dependencies used by subprojects. These dependencies are exported to any projects making use of it, and their versions supersede those of the project when they're higher, for example:

- `javalin-swagger-plugin` depends on `org.webjars:swagger-ui:3.52.5`
- `javalin-parent`  depends on `org.webjars:swagger-ui:4.10.3`
- `javalin-ssl` depends on `javalin-parent`

When a gradle projects depends on both `javalin-swagger-plugin` and `javalin-ssl`, the resolved version of `org.webjars:swagger-ui` is `4.10.3`, **breaking the swagger plugin**.  Even when the `org.webjars:swagger-ui` artifact is not used by any of the modules of `javalin-parent` other than for testing. 
There are some other artifacts that cause no problems but might still override versions if using the bom.

The solution
-
Since these artifacts are only used in testing, moving its declaration to the submodules is enough to provide a working BOM in `javalin-parent` with no test dependencies. Versions are still set through the properties in the parent pom, and inherited by the children modules.

Also
-
I fixed some links pointing to tipsy/javalin