### PR TITLE
Bump jetty version to satisfy owasp CVE-2023-26048, CVE-2023-26049

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <guava.version>31.1-jre</guava.version>
         <jackson.version>2.13.3</jackson.version>
         <jackson.databind.version>2.13.3</jackson.databind.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>
         <logback.version>1.2.11</logback.version>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2023-26048
https://nvd.nist.gov/vuln/detail/CVE-2023-26049
This issue has been patched in versions 9.4.51, 10.0.14, and 11.0.14.