### PR TITLE
Fix snapshot release workflow

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -6,7 +6,11 @@ on:
 
 jobs:
   publish:
-    if: github.repository == 'javalin/javalin'
+    if: |
+      github.repository == 'javalin/javalin' &&
+      !contains(github.event.head_commit.message, '[maven-release-plugin] prepare release')
+      
+
     name: Publish snapshot
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #1871

Since the only state where the version is not a snapshot happens when using the `mvn release:prepare` goal, we can just skip snapshots for this specific commit.