### PR TITLE
Add missing `headerAsClass` to `WsContext`

### DIFF
--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -68,6 +68,8 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
 
     fun header(header: String): String? = upgradeCtx.header(header)
     fun headerMap(): Map<String, String> = upgradeCtx.headerMap()
+    /** Creates a typed [io.javalin.validation.Validator] for the [header] value */
+    fun <T> headerAsClass(header: String, clazz: Class<T>) = upgradeCtx.headerAsClass(header, clazz)
 
     fun cookie(name: String) = upgradeCtx.cookie(name)
     fun cookieMap(): Map<String, String> = upgradeCtx.cookieMap()


### PR DESCRIPTION
Present in docs: 
![image](https://user-images.githubusercontent.com/23284823/236822073-c461a217-756f-4792-9505-f81fc6cfa46d.png)

But not in code:
![image](https://user-images.githubusercontent.com/23284823/236822133-2fd194c2-57bd-48ff-b2f8-bca5ab219380.png)
