### PR TITLE
[compression] Add `brotli4j` support and make it default in `javalin-bundle`

### DIFF
--- a/javalin-bundle/pom.xml
+++ b/javalin-bundle/pom.xml
@@ -46,8 +46,8 @@
 
         <!-- brotli compression -->
         <dependency>
-            <groupId>com.nixxcode.jvmbrotli</groupId>
-            <artifactId>jvmbrotli</artifactId>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
         </dependency>
 
         <!-- necessary for HTTP/2 and ALPN (application layer protocol negotiation) -->

--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -50,6 +50,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <optional>true</optional>

--- a/javalin/src/main/java/io/javalin/compression/impl/Brotli4jCompressor.kt
+++ b/javalin/src/main/java/io/javalin/compression/impl/Brotli4jCompressor.kt
@@ -1,0 +1,22 @@
+package io.javalin.compression.impl
+
+
+import com.aayushatharva.brotli4j.encoder.BrotliOutputStream
+import com.aayushatharva.brotli4j.encoder.Encoder
+import io.javalin.compression.CompressionType
+import io.javalin.compression.Compressor
+import java.io.OutputStream
+
+/** @param level Compression level. Higher yields better (but slower) compression. Range 0..11, default = 4 */
+class Brotli4jCompressor(val level: Int) : Compressor {
+    init {
+        require(level in 0..11) { "Valid range for parameter level is 0 to 11" }
+    }
+
+    override fun encoding(): String = CompressionType.BR.typeName
+    override fun extension(): String = CompressionType.BR.extension
+    override fun compress(out: OutputStream): OutputStream = LeveledBrotli4jStream(out, level)
+}
+
+class LeveledBrotli4jStream(out: OutputStream, level: Int) :
+    BrotliOutputStream(out, Encoder.Parameters().setQuality(level))

--- a/javalin/src/main/java/io/javalin/jetty/JettyPrecompressingResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyPrecompressingResourceHandler.kt
@@ -1,7 +1,7 @@
 package io.javalin.jetty
 
 import io.javalin.compression.*
-import io.javalin.compression.CompressionStrategy.Companion.brotliPresent
+import io.javalin.compression.CompressionStrategy.Companion.brotliImplAvailable
 import io.javalin.http.Header
 import io.javalin.util.JavalinLogger
 import jakarta.servlet.http.HttpServletRequest
@@ -19,7 +19,7 @@ object JettyPrecompressingResourceHandler {
     private val compressionStrategy : CompressionStrategy
 
     init {
-        compressionStrategy = if (brotliPresent()) {
+        compressionStrategy = if (brotliImplAvailable()) {
             CompressionStrategy(Brotli(11), Gzip(9))
         } else {
             CompressionStrategy(null,Gzip(9))

--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -64,4 +64,5 @@ enum class CoreDependency(
 
     // Compression
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
+    BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.11.0"),
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.15.0</jackson.databind.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>
+        <brotli4j.version>1.11.0</brotli4j.version>
         <logback.version>1.4.7</logback.version>
         <slf4j.version>2.0.7</slf4j.version>
         <gson.version>2.10.1</gson.version>
@@ -200,6 +201,11 @@
                 <groupId>com.nixxcode.jvmbrotli</groupId>
                 <artifactId>jvmbrotli</artifactId>
                 <version>${jvmbrotli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>brotli4j</artifactId>
+                <version>${brotli4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Closes #1890 

Previous discussion: #1891 

### Advantages (brotli4j)

- It uses the latest version of Brotli ([v1.0.9](https://github.com/google/brotli/releases/tag/v1.0.9)) and fixes https://github.com/advisories/GHSA-5v8v-66v8-mwm7
- Adds support for `Aarch64` Linux and Macos and `ARMv7` Linux
- It's tested on JDK 11, JDK 17
- It is actively developed
- Uses JPMS

### Disadvantages

- Another optional dependency