### PR TITLE
Ability to set Jetty HttpConfiguration easily

### DIFF
--- a/javalin/src/main/java/io/javalin/config/JettyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JettyConfig.kt
@@ -11,7 +11,6 @@ import java.util.function.Supplier
 class JettyConfig(private val pvt: PrivateConfig) {
     //@formatter:off
     @JvmField val multipartConfig = MultipartConfig()
-    @JvmField val customizers = mutableListOf<HttpConfiguration.Customizer>()
     //@formatter:on
 
     fun server(server: Supplier<Server?>) {
@@ -30,4 +29,7 @@ class JettyConfig(private val pvt: PrivateConfig) {
         pvt.wsFactoryConfig = wsFactoryConfig
     }
 
+    fun httpConfigurationConfig(httpConfigurationConfig:  Consumer<HttpConfiguration>) {
+        pvt.httpConfigurationConfig = httpConfigurationConfig
+    }
 }

--- a/javalin/src/main/java/io/javalin/config/JettyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JettyConfig.kt
@@ -1,5 +1,6 @@
 package io.javalin.config
 
+import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -10,6 +11,7 @@ import java.util.function.Supplier
 class JettyConfig(private val pvt: PrivateConfig) {
     //@formatter:off
     @JvmField val multipartConfig = MultipartConfig()
+    @JvmField val customizers = mutableListOf<HttpConfiguration.Customizer>()
     //@formatter:on
 
     fun server(server: Supplier<Server?>) {

--- a/javalin/src/main/java/io/javalin/config/PrivateConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/PrivateConfig.kt
@@ -11,6 +11,7 @@ import io.javalin.security.AccessManager
 import io.javalin.util.JavalinLogger
 import io.javalin.websocket.WsConfig
 import jakarta.servlet.http.HttpServletResponse
+import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -32,6 +33,8 @@ class PrivateConfig {
     @JvmField var servletContextHandlerConsumer: Consumer<ServletContextHandler>? = null
     @JvmField var compressionStrategy = CompressionStrategy.GZIP
     @JvmField var servletRequestLifecycle = listOf(DefaultTasks.BEFORE, DefaultTasks.HTTP, DefaultTasks.ERROR, DefaultTasks.AFTER)
+    @JvmField var httpConfigurationConfig: Consumer<HttpConfiguration>? = null
+
     fun javaLangErrorHandler(handler: JavaLangErrorHandler) = apply { this.javaLangErrorHandler = handler }
     internal var javaLangErrorHandler: JavaLangErrorHandler = JavaLangErrorHandler { res, error ->
         res.status = INTERNAL_SERVER_ERROR.code

--- a/javalin/src/main/java/io/javalin/config/PrivateConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/PrivateConfig.kt
@@ -10,13 +10,11 @@ import io.javalin.http.staticfiles.ResourceHandler
 import io.javalin.security.AccessManager
 import io.javalin.util.JavalinLogger
 import io.javalin.websocket.WsConfig
-import jakarta.servlet.http.HttpServletResponse
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory
-import java.lang.Error
 import java.util.function.Consumer
 
 // @formatter:off

--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -75,8 +75,8 @@ class JettyServer(val cfg: JavalinConfig) {
             if (connectors.isEmpty()) { // user has not added their own connectors, we add a single HTTP connector
                 connectors = arrayOf(defaultConnector(this))
             } else {
-                if(cfg.jetty.customizers.isNotEmpty()){
-                    JavalinLogger.startup("Customizers added to the JettyConfig have not been applied as a custom Jetty server was provided")
+                if(cfg.pvt.httpConfigurationConfig != null){
+                    JavalinLogger.startup("Http Configuration added to the JettyConfig has not been applied as a custom Jetty server was provided")
                 }
             }
         }.start()
@@ -103,9 +103,8 @@ class JettyServer(val cfg: JavalinConfig) {
         val httpConfiguration = HttpConfiguration()
         httpConfiguration.uriCompliance = UriCompliance.RFC3986 // accept ambiguous values in path and let Javalin handle them
 
-        cfg.jetty.customizers.forEach {
-            httpConfiguration.addCustomizer(it)
-        }
+        //now apply the custom http configuration if we have one
+        cfg.pvt.httpConfigurationConfig?.accept(httpConfiguration)
 
         return ServerConnector(server, HttpConnectionFactory(httpConfiguration)).apply {
             this.port = serverPort

--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -50,7 +50,7 @@ class JettyServer(val cfg: JavalinConfig) {
         }
 
         val encodingMap = MimeTypes.getInferredEncodings()
-        encodingMap.put("text/plain","utf-8");
+        encodingMap.put("text/plain","utf-8")
 
         cfg.pvt.sessionHandler = cfg.pvt.sessionHandler ?: defaultSessionHandler()
         val nullParent = null // javalin handlers are orphans
@@ -74,6 +74,10 @@ class JettyServer(val cfg: JavalinConfig) {
             handler = if (handler == null) wsAndHttpHandler else handler.attachHandler(wsAndHttpHandler)
             if (connectors.isEmpty()) { // user has not added their own connectors, we add a single HTTP connector
                 connectors = arrayOf(defaultConnector(this))
+            } else {
+                if(cfg.jetty.customizers.isNotEmpty()){
+                    JavalinLogger.startup("Customizers added to the JettyConfig have not been applied as a custom Jetty server was provided")
+                }
             }
         }.start()
 
@@ -98,6 +102,10 @@ class JettyServer(val cfg: JavalinConfig) {
         // TODO: Required to support ignoreTrailingSlashes, because Jetty 11 will refuse requests with doubled slashes
         val httpConfiguration = HttpConfiguration()
         httpConfiguration.uriCompliance = UriCompliance.RFC3986 // accept ambiguous values in path and let Javalin handle them
+
+        cfg.jetty.customizers.forEach {
+            httpConfiguration.addCustomizer(it)
+        }
 
         return ServerConnector(server, HttpConnectionFactory(httpConfiguration)).apply {
             this.port = serverPort

--- a/javalin/src/test/java/io/javalin/TestCustomJettyHttpConfiguration.kt
+++ b/javalin/src/test/java/io/javalin/TestCustomJettyHttpConfiguration.kt
@@ -12,11 +12,13 @@ import org.eclipse.jetty.server.ForwardedRequestCustomizer
 import org.eclipse.jetty.server.HttpConnectionFactory
 import org.junit.jupiter.api.Test
 
-class TestJettyCustomizers {
+class TestCustomJettyHttpConfiguration {
     private val customizer = ForwardedRequestCustomizer()
     @Test
     fun `customizers get added`() = TestUtil.test(Javalin.create { cfg ->
-        cfg.jetty.customizers.add(customizer)
+        cfg.jetty.httpConfigurationConfig{
+            it.customizers.add(customizer)
+        }
     }) { javalin, http ->
         javalin.jettyServer.server().connectors.forEach {
             val cf = it.getConnectionFactory(HttpConnectionFactory::class.java)

--- a/javalin/src/test/java/io/javalin/TestCustomJettyHttpConfiguration.kt
+++ b/javalin/src/test/java/io/javalin/TestCustomJettyHttpConfiguration.kt
@@ -25,4 +25,30 @@ class TestCustomJettyHttpConfiguration {
             assertThat(cf.httpConfiguration.customizers).contains(customizer)
         }
     }
+
+    @Test
+    fun `X-Fowarded-Proto Works With Customizer`() = TestUtil.test(Javalin.create { cfg ->
+        cfg.jetty.httpConfigurationConfig{
+            it.customizers.add(customizer)
+        }
+    }) { javalin, http ->
+        javalin.get("/"){
+            it.result(it.scheme())
+        }
+
+        val response = http.get("/", mapOf("X-Forwarded-Proto" to "https")).body
+
+        assertThat(response).isEqualTo("https")
+    }
+
+    @Test
+    fun `X-Fowarded-Proto Does Not Work Without Customizer`() = TestUtil.test(Javalin.create()) { javalin, http ->
+        javalin.get("/"){
+            it.result(it.scheme())
+        }
+
+        val response = http.get("/", mapOf("X-Forwarded-Proto" to "https")).body
+
+        assertThat(response).isNotEqualTo("https")
+    }
 }

--- a/javalin/src/test/java/io/javalin/TestJettyCustomizers.kt
+++ b/javalin/src/test/java/io/javalin/TestJettyCustomizers.kt
@@ -1,0 +1,26 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.jetty.server.ForwardedRequestCustomizer
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.junit.jupiter.api.Test
+
+class TestJettyCustomizers {
+    private val customizer = ForwardedRequestCustomizer()
+    @Test
+    fun `customizers get added`() = TestUtil.test(Javalin.create { cfg ->
+        cfg.jetty.customizers.add(customizer)
+    }) { javalin, http ->
+        javalin.jettyServer.server().connectors.forEach {
+            val cf = it.getConnectionFactory(HttpConnectionFactory::class.java)
+            assertThat(cf.httpConfiguration.customizers).contains(customizer)
+        }
+    }
+}


### PR DESCRIPTION
closes javalin/javalin#1909

@tipsy 
as requested I've refactored this to use a Consumer<HttpConfiguration>.  I've then changed the warning message in the JettyServer to reflect this and changed the test to make sure it still works