### PR TITLE
[validation] Add queryParamsAsClass method

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -181,6 +181,10 @@ interface Context {
     /** Gets a list of query params for the specified key, or empty list. */
     fun queryParams(key: String): List<String> = queryParamMap()[key] ?: emptyList()
 
+    /** Creates a typed [Validator] for the queryParams() value */
+    fun <T> queryParamsAsClass(key: String, clazz: Class<T>): Validator<List<T>> =
+        Validator.create(clazz, queryParams(key).joinToString("|"), key) as Validator<List<T>>
+
     /** Gets a map with all the query param keys and values. */
     fun queryParamMap(): Map<String, List<String>> = splitKeyValueStringAndGroupByKey(queryString() ?: "", characterEncoding() ?: "UTF-8")
 
@@ -488,6 +492,9 @@ inline fun <reified T : Any> Context.headerAsClass(header: String): Validator<T>
 
 /** Reified version of [Context.queryParamAsClass] (Kotlin only) */
 inline fun <reified T : Any> Context.queryParamAsClass(key: String): Validator<T> = queryParamAsClass(key, T::class.java)
+
+/** Reified version of [Context.queryParamsAsClass] (Kotlin only) */
+inline fun <reified T : Any> Context.queryParamsAsClass(key: String): Validator<List<T>> = queryParamsAsClass(key, T::class.java)
 
 /** Reified version of [Context.formParamAsClass] (Kotlin only) */
 inline fun <reified T : Any> Context.formParamAsClass(key: String): Validator<T> = formParamAsClass(key, T::class.java)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -183,7 +183,7 @@ interface Context {
 
     /** Creates a typed [Validator] for the queryParams() value */
     fun <T> queryParamsAsClass(key: String, clazz: Class<T>): Validator<List<T>> =
-        Validator.create(clazz, queryParams(key).joinToString("|"), key) as Validator<List<T>>
+        Validator.create(clazz, queryParams(key), key) as Validator<List<T>>
 
     /** Gets a map with all the query param keys and values. */
     fun queryParamMap(): Map<String, List<String>> = splitKeyValueStringAndGroupByKey(queryString() ?: "", characterEncoding() ?: "UTF-8")

--- a/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
+++ b/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
@@ -28,7 +28,7 @@ open class BaseValidator<T>(val fieldName: String, protected var typedValue: T?,
         this(fieldName, null, StringSource<T>(stringValue, clazz, jsonMapper))
 
     private val errors by lazy {
-        if (stringSource != null) {
+        if (stringSource != null) { 
             if (this is BodyValidator) {
                 try {
                     typedValue = stringSource.jsonMapper!!.fromJsonString(stringSource.stringValue!!, stringSource.clazz)
@@ -38,7 +38,11 @@ open class BaseValidator<T>(val fieldName: String, protected var typedValue: T?,
                 }
             } else if (this is NullableValidator || this is Validator) {
                 try {
-                    typedValue = JavalinValidation.convertValue(stringSource.clazz, stringSource.stringValue)
+                    typedValue = if (stringSource.stringValue?.contains("|") == true) { // turn type into list
+                        stringSource.stringValue.split("|").map { JavalinValidation.convertValue(stringSource.clazz, it) }.toList() as T
+                    } else {
+                        JavalinValidation.convertValue(stringSource.clazz, stringSource.stringValue)
+                    }
                 } catch (e: Exception) {
                     JavalinLogger.info("Parameter '$fieldName' with value '${stringSource.stringValue}' is not a valid ${stringSource.clazz.simpleName}")
                     return@lazy mapOf(fieldName to listOf(ValidationError("TYPE_CONVERSION_FAILED", value = stringSource.stringValue)))

--- a/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
+++ b/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
@@ -16,8 +16,9 @@ data class ValidationError<T>(val message: String, val args: Map<String, Any?> =
 class ValidationException(val errors: Map<String, List<ValidationError<Any>>>) : RuntimeException()
 
 data class StringSource<T>(
-    val stringValue: String?,
     val clazz: Class<T>,
+    val stringValue: String? = null,
+    val stringListValue: List<String>? = null,
     val jsonMapper: JsonMapper? = null
 )
 
@@ -25,10 +26,10 @@ open class BaseValidator<T>(val fieldName: String, protected var typedValue: T?,
     internal val rules = mutableListOf<Rule<T>>()
 
     constructor(stringValue: String?, clazz: Class<T>, fieldName: String, jsonMapper: JsonMapper? = null) :
-        this(fieldName, null, StringSource<T>(stringValue, clazz, jsonMapper))
+        this(fieldName, null, StringSource<T>(clazz, stringValue, jsonMapper = jsonMapper))
 
     private val errors by lazy {
-        if (stringSource != null) { 
+        if (stringSource != null) {
             if (this is BodyValidator) {
                 try {
                     typedValue = stringSource.jsonMapper!!.fromJsonString(stringSource.stringValue!!, stringSource.clazz)
@@ -38,8 +39,8 @@ open class BaseValidator<T>(val fieldName: String, protected var typedValue: T?,
                 }
             } else if (this is NullableValidator || this is Validator) {
                 try {
-                    typedValue = if (stringSource.stringValue?.contains("|") == true) { // turn type into list
-                        stringSource.stringValue.split("|").map { JavalinValidation.convertValue(stringSource.clazz, it) }.toList() as T
+                    typedValue = if (stringSource.stringListValue?.isNotEmpty() == true) {
+                        stringSource.stringListValue.map { JavalinValidation.convertValue(stringSource.clazz, it) }.toList() as T
                     } else {
                         JavalinValidation.convertValue(stringSource.clazz, stringSource.stringValue)
                     }

--- a/javalin/src/main/java/io/javalin/validation/NullableValidator.kt
+++ b/javalin/src/main/java/io/javalin/validation/NullableValidator.kt
@@ -7,9 +7,6 @@
 package io.javalin.validation
 
 open class NullableValidator<T>(fieldName: String, typedValue: T? = null, stringSource: StringSource<T>? = null) : BaseValidator<T>(fieldName, typedValue, stringSource) {
-    constructor(stringValue: String?, clazz: Class<T>, fieldName: String) :
-        this(fieldName, null, StringSource<T>(stringValue, clazz))
-
     fun check(check: Check<T?>, error: String) = addRule(fieldName, check, error) as NullableValidator<T>
     fun check(check: Check<T?>, error: ValidationError<T>) = addRule(fieldName, check, error) as NullableValidator<T>
 }

--- a/javalin/src/test/java/io/javalin/TestValidation_Java.java
+++ b/javalin/src/test/java/io/javalin/TestValidation_Java.java
@@ -51,6 +51,20 @@ public class TestValidation_Java {
     }
 
     @Test
+    public void queryParams_can_be_used_to_validate_list() {
+        TestUtil.test((app, http) -> {
+            app.get("/", ctx -> {
+                ctx.queryParamsAsClass("param", Integer.class)
+                    .check(it -> it.stream().allMatch(number -> number < 5), "All must be smaller than 5")
+                    .get();
+            });
+            var response = http.get("/?param=1&param=2&param=5");
+            assertThat(response.getStatus()).isEqualTo(400);
+            assertThat(response.getBody()).contains("All must be smaller than 5");
+        });
+    }
+
+    @Test
     public void validator_works_from_java_too() {
         JavalinValidation.register(Instant.class, v -> Instant.ofEpochMilli(Long.parseLong(v)));
         String intString = "123";


### PR DESCRIPTION
This uses a completely unsafe `queryParams(key).joinToString("|")` and `if (stringSource.stringValue?.contains("|") == true)`. This is easy enough to rewrite, it's just a quick way to get a PR up for discussion.

Context: 
```kotlin
/** Creates a typed [Validator] for the queryParams() value */
fun <T> queryParamsAsClass(key: String, clazz: Class<T>): Validator<List<T>> =
    Validator.create(clazz, queryParams(key).joinToString("|"), key) as Validator<List<T>>
```

Usage:
```kotlin
@Test
fun `queryParams can be used to validate list`() = TestUtil.test { app, http ->
    app.get("/") {
        it.queryParamsAsClass<Int>("param")
            .check({ it.all { it < 5 } }, "All must be smaller than 5")
            .get()
    }
    val response = http.get("/?param=1&param=2&param=5")
    assertThat(response.status).isEqualTo(BAD_REQUEST.code)
    assertThat(response.body).isEqualTo("""{"param":[{"message":"All must be smaller than 5","args":{},"value":[1,2,5]}]}""")
}
```