### PR TITLE
[context] Remove dependency on `JavalinConfig` & reduce Context size by 8 bytes

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -25,12 +25,14 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
     val exceptionMapper = ExceptionMapper(cfg)
     val errorMapper = ErrorMapper()
 
-    private val servletContextConfig = JavalinServletContextConfig(
-        appAttributes = cfg.pvt.appAttributes,
-        compressionStrategy = cfg.pvt.compressionStrategy,
-        requestLoggerEnabled = cfg.pvt.requestLogger != null,
-        defaultContentType = cfg.http.defaultContentType
-    )
+    private val servletContextConfig by lazy {
+        JavalinServletContextConfig(
+            appAttributes = cfg.pvt.appAttributes,
+            compressionStrategy = cfg.pvt.compressionStrategy,
+            requestLoggerEnabled = cfg.pvt.requestLogger != null,
+            defaultContentType = cfg.http.defaultContentType
+        )
+    }
 
     override fun service(request: HttpServletRequest, response: HttpServletResponse) {
         try {

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -25,9 +25,20 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
     val exceptionMapper = ExceptionMapper(cfg)
     val errorMapper = ErrorMapper()
 
+    private val servletContextConfig = JavalinServletContextConfig(
+        appAttributes = cfg.pvt.appAttributes,
+        compressionStrategy = cfg.pvt.compressionStrategy,
+        requestLoggerEnabled = cfg.pvt.requestLogger != null,
+        defaultContentType = cfg.http.defaultContentType
+    )
+
     override fun service(request: HttpServletRequest, response: HttpServletResponse) {
         try {
-            val ctx = JavalinServletContext(req = request, res = response, cfg = cfg)
+            val ctx = JavalinServletContext(
+                cfg = servletContextConfig,
+                req = request,
+                res = response
+            )
 
             val submitTask: (SubmitOrder, Task) -> Unit = { order, task ->
                 when (order) {

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -8,7 +8,6 @@ package io.javalin.http.servlet
 
 import io.javalin.compression.CompressedOutputStream
 import io.javalin.compression.CompressionStrategy
-import io.javalin.config.JavalinConfig
 import io.javalin.http.ContentType
 import io.javalin.http.Context
 import io.javalin.http.HandlerType
@@ -48,7 +47,7 @@ class JavalinServletContext(
     private val startTimeNanos: Long? = if (cfg.requestLoggerEnabled) System.nanoTime() else null,
     private var handlerType: HandlerType = HandlerType.BEFORE,
     private var matchedPath: String = "",
-    private var pathParamMap: Map<String, String> = mapOf(),
+    private var pathParamMap: Map<String, String> = emptyMap(),
     internal var endpointHandlerPath: String = "",
     internal var userFutureSupplier: Supplier<out CompletableFuture<*>>? = null,
     private var resultStream: InputStream? = null,

--- a/javalin/src/main/java/io/javalin/jetty/JavalinJettyServlet.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JavalinJettyServlet.kt
@@ -39,12 +39,14 @@ class JavalinJettyServlet(val cfg: JavalinConfig, private val httpServlet: Javal
     val wsExceptionMapper = WsExceptionMapper()
     val wsPathMatcher = WsPathMatcher()
 
-    private val servletContextConfig = JavalinServletContextConfig(
-        appAttributes = cfg.pvt.appAttributes,
-        compressionStrategy = cfg.pvt.compressionStrategy,
-        requestLoggerEnabled = cfg.pvt.requestLogger != null,
-        defaultContentType = cfg.http.defaultContentType,
-    )
+    private val servletContextConfig by lazy {
+        JavalinServletContextConfig(
+            appAttributes = cfg.pvt.appAttributes,
+            compressionStrategy = cfg.pvt.compressionStrategy,
+            requestLoggerEnabled = cfg.pvt.requestLogger != null,
+            defaultContentType = cfg.http.defaultContentType,
+        )
+    }
 
     fun addHandler(handlerType: WsHandlerType, path: String, ws: Consumer<WsConfig>, roles: Set<RouteRole>) {
         wsPathMatcher.add(WsEntry(handlerType, path, cfg.routing, WsConfig().apply { ws.accept(this) }, roles))


### PR DESCRIPTION
This PR:
* Replaces global `JavalinConfig` with dedicated `JavalinServletContextConfig`
* Replaces 2 references to objects with 1 reference to constant cfg instance
* Creates a space for further properties pulled out from global cfg