### PR TITLE
Make Jetbrains annotations an optional dependency

### DIFF
--- a/javalin/module-info.java
+++ b/javalin/module-info.java
@@ -23,7 +23,6 @@ module io.javalin {
     exports io.javalin.vue;
     exports io.javalin.websocket;
 
-    requires transitive org.jetbrains.annotations;
     requires transitive kotlin.stdlib;
     requires transitive org.slf4j;
     requires transitive org.eclipse.jetty.server;
@@ -34,6 +33,7 @@ module io.javalin {
     requires transitive org.eclipse.jetty.websocket.jetty.server;
 
     //optional dependencies
+    requires static org.jetbrains.annotations;
     requires static com.aayushatharva.brotli4j;
     requires static com.aayushatharva.brotli4j.service;
     requires static com.fasterxml.jackson.databind;

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>${annotations.version}</version>
+                <scope>provided</scope>
             </dependency>
             <!-- Logging -->
             <dependency>


### PR DESCRIPTION
1. org.jetbrains.annotations is now a static (optional) dependency in **module-info.java**.
2. org.jetbrains.annotations is now marked as `<scope>provided</scope>` in **pom.xml**.

I'm not 100% sure about point 2, since I'm not a Maven user.

I searched for "maven compile time only dependency" and according to this old Stackoverflow answer [Is there a Maven "compiler-only" scope for dependency artifacts](https://stackoverflow.com/questions/12824112/is-there-a-maven-compiler-only-scope-for-dependency-artifacts) and [Maven Dependency Scopes](https://www.baeldung.com/maven-dependency-scopes) this is the way to exclude the jar from being a runtime dependency.

Fixes #1947