### PR TITLE
[config] Remove `Javalin.updateConfig`

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -42,7 +42,6 @@ public class Javalin implements AutoCloseable {
     /**
      * Do not use this field unless you know what you're doing.
      * Application config should be declared in {@link Javalin#create(Consumer)}.
-     * Alternatively use {@link Javalin#updateConfig(Consumer)} to update the config at a later date.
      */
     public JavalinConfig cfg = new JavalinConfig();
     protected JavalinServlet javalinServlet = new JavalinServlet(cfg);
@@ -200,28 +199,6 @@ public class Javalin implements AutoCloseable {
      */
     public <T> T attribute(String key) {
         return (T) cfg.pvt.appAttributes.get(key);
-    }
-
-    /**
-     * Updates the instance's configuration with new user configuration.
-     * It fulfills a similar role to the existing {@link Javalin#create(Consumer)} call and can be called on an existing
-     * instance.
-     * <p>
-     * Do note that this method is not a replacement to {@link Javalin#create(Consumer)},
-     * this method may or may not take effect on some parts of your application.
-     * You have to be conscious how your application works and if it can be reconfigured after startup.
-     * </p>
-     * The recommended way is to always use {@link Javalin#create(Consumer)} for configuring Javalin and only using
-     * this method if there is no other way.
-     *
-     * @param userConfig new user configuration
-     * @return application instance.
-     * @see Javalin#create(Consumer)
-     */
-    public Javalin updateConfig(Consumer<JavalinConfig> userConfig) {
-        userConfig.accept(cfg);
-        cfg.pvt.pluginManager.initializePlugins(this);
-        return this;
     }
 
     /**

--- a/javalin/src/test/java/io/javalin/TestAccessManager.kt
+++ b/javalin/src/test/java/io/javalin/TestAccessManager.kt
@@ -44,7 +44,7 @@ class TestAccessManager {
     @Test
     fun `AccessManager does not run if roles are not present`() = TestUtil.test { app, http ->
         app.get("/unsecured") { it.result("Hello") }
-        app.updateConfig { it.accessManager { _, _, _ -> throw RuntimeException() } }
+        app.cfg.accessManager { _, _, _ -> throw RuntimeException() }
         assertThat(http.getBody("/unsecured")).isEqualTo("Hello")
     }
 

--- a/javalin/src/test/java/io/javalin/TestMultipartForms.kt
+++ b/javalin/src/test/java/io/javalin/TestMultipartForms.kt
@@ -272,11 +272,10 @@ class TestMultipartForms {
 
     @Test
     fun `changing the multipart config correctly sets it`() = TestUtil.test { app, http ->
-
         //note: this test does not check the cache directory is set correctly as there is no way to know which
         //paths exist and are writable on the system the test is being run on.  However, if the other parameters
         //are read successfully
-        app.updateConfig {
+        app.cfg.also {
             it.jetty.multipartConfig.maxFileSize(100, SizeUnit.MB)
             it.jetty.multipartConfig.maxInMemoryFileSize(10, SizeUnit.MB)
             it.jetty.multipartConfig.maxTotalRequestSize(1, SizeUnit.GB)

--- a/javalin/src/test/java/io/javalin/TestPlugins.kt
+++ b/javalin/src/test/java/io/javalin/TestPlugins.kt
@@ -96,23 +96,6 @@ class TestPlugins {
     }
 
     @Test
-    fun `uninitialized plugins should be picked up in update config`() {
-        var pluginAInitCount = 0
-        var pluginBInitCount = 0
-
-        TestUtil.test(Javalin.create { config ->
-            config.registerPlugin { pluginAInitCount++ }
-        }) { app, _ ->
-            app.updateConfig { config ->
-                config.registerPlugin { pluginBInitCount++ }
-            }
-        }
-
-        assertThat(pluginAInitCount).isEqualTo(1) // make sure that plugin A was not initialized 2 times
-        assertThat(pluginBInitCount).isEqualTo(1) // make sure that plugin B has been initialized
-    }
-
-    @Test
     fun `plugins are initialized in the proper order`() {
         val calls = mutableListOf<String>()
 

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
@@ -308,7 +308,7 @@ class TestStaticFiles {
 
     @Test
     fun `static files can be added after app creation`() = TestUtil.test(
-        Javalin.create().updateConfig { it.staticFiles.add("/public", Location.CLASSPATH) }
+        Javalin.create().also { it.cfg.staticFiles.add("/public", Location.CLASSPATH) }
     ) { _, http ->
         assertThat(http.get("/html.html").httpCode()).isEqualTo(OK)
         assertThat(http.get("/html.html").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
@@ -317,15 +317,14 @@ class TestStaticFiles {
 
     @Test
     fun `static files can be added after app start with previous static files`() = TestUtil.test(
-        Javalin.create().updateConfig { it.staticFiles.add("/public", Location.CLASSPATH) }
+        Javalin.create().also { it.cfg.staticFiles.add("/public", Location.CLASSPATH) }
     ) { app, http ->
-        app.updateConfig {
-            it.staticFiles.add { staticFiles ->
-                staticFiles.hostedPath = "/url-prefix"
-                staticFiles.directory = "/public"
-                staticFiles.location = Location.CLASSPATH
-            }
+        app.cfg.staticFiles.add { staticFiles ->
+            staticFiles.hostedPath = "/url-prefix"
+            staticFiles.directory = "/public"
+            staticFiles.location = Location.CLASSPATH
         }
+
         assertThat(http.get("/html.html").httpCode()).isEqualTo(OK)
         assertThat(http.get("/html.html").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
         assertThat(http.getBody("/html.html")).contains("HTML works")
@@ -339,10 +338,7 @@ class TestStaticFiles {
     fun `static files can be added after app start without previous static files`() = TestUtil.test(
         Javalin.create()
     ) { app, http ->
-        app.updateConfig {
-            it.staticFiles.add("/public", Location.CLASSPATH)
-        }
-
+        app.cfg.staticFiles.add("/public", Location.CLASSPATH)
         assertThat(http.get("/html.html").httpCode()).isEqualTo(OK)
         assertThat(http.get("/html.html").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
         assertThat(http.getBody("/html.html")).contains("HTML works")


### PR DESCRIPTION
This is a part of #1894. We should remove this method, not only because it's against our further goals, but what's more important, because it's an entry point in the official API for users to access properties that results in undefined behaviors. 