### PR TITLE
Change when a compression stream is created

### DIFF
--- a/javalin/src/main/java/io/javalin/compression/CompressionStrategy.kt
+++ b/javalin/src/main/java/io/javalin/compression/CompressionStrategy.kt
@@ -55,7 +55,7 @@ class CompressionStrategy(brotli: Brotli? = null, gzip: Gzip? = null) {
     }
 
     /** 1500 is the size of a packet, compressing responses smaller than this serves no purpose */
-    var minSizeForCompression = 1500
+    var defaultMinSizeForCompression = 1500
 
     /** Those mime types will be processed using NONE compression strategy */
     var excludedMimeTypesFromCompression = listOf(

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -443,6 +443,8 @@ interface Context {
      * Consumes the specified stream with the configured JsonMapper, which transforms the stream's
      * content to JSON, writing the results directly to the response's `outputStream` as the stream
      * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
+     * The response will always be compressed regardless of size, given that compression is enabled in
+     * the Javalin configuration.
      */
     fun writeJsonStream(stream: Stream<*>)
 

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -6,6 +6,7 @@
 
 package io.javalin.http
 
+import io.javalin.compression.CompressedOutputStream.Companion.ALWAYS_COMPRESS
 import io.javalin.config.contextResolver
 import io.javalin.http.servlet.attributeOrCompute
 import io.javalin.http.servlet.cacheAndSetSessionAttribute
@@ -435,9 +436,10 @@ interface Context {
      * content to JSON, writing the results directly to the response's `outputStream` as the stream
      * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
      */
-    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeToOutputStream(
-        stream, this.contentType(ContentType.APPLICATION_JSON).outputStream()
-    )
+    fun writeJsonStream(stream: Stream<*>) {
+        attribute(ALWAYS_COMPRESS, true)
+        jsonMapper().writeToOutputStream(stream, this.contentType(ContentType.APPLICATION_JSON).outputStream())
+    }
 
     /** Sets context result to specified html string and sets content-type to text/html. */
     fun html(html: String): Context = contentType(ContentType.TEXT_HTML).result(html)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -6,7 +6,6 @@
 
 package io.javalin.http
 
-import io.javalin.compression.CompressedOutputStream.Companion.ALWAYS_COMPRESS
 import io.javalin.config.contextResolver
 import io.javalin.http.servlet.attributeOrCompute
 import io.javalin.http.servlet.cacheAndSetSessionAttribute
@@ -294,12 +293,21 @@ interface Context {
     fun responseCharset(): Charset = runCatching { Charset.forName(res().characterEncoding) }.getOrElse { Charset.defaultCharset() }
 
     /**
-     * Gets output-stream you can write to.
-     * This stream by default uses compression specified in Javalin configuration,
-     * if you're looking for raw, uncompressed servlet's output-stream, use `ctx.res().outputStream`.
+     * Gets the output stream you can write to.
+     * This stream by default uses compression specified in the Javalin configuration.
+     * If you're looking for the servlet's raw, uncompressed output stream, use `ctx.res().outputStream`.
      * @see [HttpServletResponse.getOutputStream]
      */
     fun outputStream(): ServletOutputStream
+
+    /**
+     * The output stream returned by outputStream() will use compression (as specified in Javalin configuration), but
+     * compression will happen only if the first write to the output stream is larger than `minSizeForCompression`.
+     * Setting this value to zero will cause compression to always be used. This value must be assigned before calling
+     * outputStream() for the first time. The default value is set to the value of
+     * [io.javalin.config.CompressionStrategy.defaultMinSizeForCompression].
+     */
+    var minSizeForCompression: Int
 
     /**
      * Writes the specified inputStream as a seekable stream.
@@ -436,10 +444,7 @@ interface Context {
      * content to JSON, writing the results directly to the response's `outputStream` as the stream
      * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
      */
-    fun writeJsonStream(stream: Stream<*>) {
-        attribute(ALWAYS_COMPRESS, true)
-        jsonMapper().writeToOutputStream(stream, this.contentType(ContentType.APPLICATION_JSON).outputStream())
-    }
+    fun writeJsonStream(stream: Stream<*>)
 
     /** Sets context result to specified html string and sets content-type to text/html. */
     fun html(html: String): Context = contentType(ContentType.TEXT_HTML).result(html)

--- a/javalin/src/test/java/io/javalin/TestCompression.kt
+++ b/javalin/src/test/java/io/javalin/TestCompression.kt
@@ -20,7 +20,6 @@ import kong.unirest.Unirest
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIf


### PR DESCRIPTION
A request scope attribute `ALWAYS_COMPRESS` will signal that a compression stream should always be created, if allowed. This attribute is now used for the `writeJsonStream()` call, where the total bytes to write cannot be known in advance.

The evaluation of creating a compressed stream or not was reworked to only evaluate only once.

closes #1950