### PR TITLE
Fix `JettyPrecompressingResourceHandler` regression in #904e360 (6x)

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -48,9 +48,9 @@ class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
                     handler.config.headers.forEach { httpResponse.setHeader(it.key, it.value) }
                     if (handler.config.precompress) {
                         return if (resource.isDirectoryWithWelcomeFile(handler, target))  // if it's a directory, we need to serve the welcome file
-                            JettyPrecompressingResourceHandler.handle(target, getWelcomeFile(handler, target), httpRequest, httpResponse)
+                            JettyPrecompressingResourceHandler.handle(target, getWelcomeFile(handler, target), httpRequest, httpResponse, pvt.compressionStrategy)
                         else
-                            JettyPrecompressingResourceHandler.handle(target, resource, httpRequest, httpResponse)
+                            JettyPrecompressingResourceHandler.handle(target, resource, httpRequest, httpResponse, pvt.compressionStrategy)
                     }
                     httpResponse.contentType = null // Jetty will only set the content-type if it's null
                     return runCatching { handler.handle(target, jettyRequest, httpRequest, httpResponse) }.isSuccess

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
@@ -14,16 +14,12 @@ import io.javalin.jetty.JettyPrecompressingResourceHandler
 import io.javalin.testing.HttpUtil
 import io.javalin.testing.TestDependency
 import io.javalin.testing.TestUtil
-import io.javalin.testing.WebDriverUtil
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.assertj.core.api.Assertions.assertThat
-import org.eclipse.jetty.http.MimeTypes
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
-import org.openqa.selenium.By
-import org.openqa.selenium.chrome.ChromeDriver
 import java.util.zip.GZIPInputStream
 
 class TestStaticFilesPrecompressor {
@@ -76,31 +72,6 @@ class TestStaticFilesPrecompressor {
         assertThat(http.getFile("/secret.html?qp=1", "gzip").contentEncoding()).isEqualTo("gzip")
         assertThat(http.getFile("/secret.html?qp=2", "gzip").contentEncoding()).isEqualTo("gzip")
         assertThat(JettyPrecompressingResourceHandler.compressedFiles.size <= oldSize + 1)
-    }
-
-
-    private val gh1958App: Javalin by lazy {
-        Javalin.create { config ->
-            config.staticFiles.add { staticFiles ->
-                staticFiles.hostedPath = "/"
-                staticFiles.directory = "/public"
-                staticFiles.precompress = true
-            }
-        }
-    }
-
-    private lateinit var driver: ChromeDriver
-
-    @Test
-    fun `chrome can handle precompressed files GH-1958`() = TestUtil.test(gh1958App) { _, http ->
-        driver = WebDriverUtil.getDriver()
-        driver.get(http.origin + "/html.html")
-        val html = driver.findElement(By.tagName("html")).getAttribute("innerHTML")
-        assertThat(html).contains("HTML works")
-        assertThat(html).contains("JavaScript works")
-        if (::driver.isInitialized) {
-            driver.quit()
-        }
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
@@ -12,11 +12,14 @@ import io.javalin.jetty.JettyPrecompressingResourceHandler
 import io.javalin.testing.HttpUtil
 import io.javalin.testing.TestDependency
 import io.javalin.testing.TestUtil
+import io.javalin.testing.WebDriverUtil
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.openqa.selenium.By
+import org.openqa.selenium.chrome.ChromeDriver
 
 class TestStaticFilesPrecompressor {
 
@@ -68,6 +71,31 @@ class TestStaticFilesPrecompressor {
         assertThat(http.getFile("/secret.html?qp=1", "gzip").contentEncoding()).isEqualTo("gzip")
         assertThat(http.getFile("/secret.html?qp=2", "gzip").contentEncoding()).isEqualTo("gzip")
         assertThat(JettyPrecompressingResourceHandler.compressedFiles.size <= oldSize + 1)
+    }
+
+
+    private val gh1958App: Javalin by lazy {
+        Javalin.create { config ->
+            config.staticFiles.add { staticFiles ->
+                staticFiles.hostedPath = "/"
+                staticFiles.directory = "/public"
+                staticFiles.precompress = true
+            }
+        }
+    }
+
+    private lateinit var driver: ChromeDriver
+
+    @Test
+    fun `chrome can handle precompressed files GH-1958`() = TestUtil.test(gh1958App) { _, http ->
+        driver = WebDriverUtil.getDriver()
+        driver.get(http.origin + "/html.html")
+        val html = driver.findElement(By.tagName("html")).getAttribute("innerHTML")
+        assertThat(html).contains("HTML works")
+        assertThat(html).contains("JavaScript works")
+        if (::driver.isInitialized) {
+            driver.quit()
+        }
     }
 
     private fun Response.contentLength() = this.headers.get(Header.CONTENT_LENGTH)

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
@@ -98,6 +98,21 @@ class TestStaticFilesPrecompressor {
         }
     }
 
+    @Test
+    fun `first available encoding is used`() = TestUtil.test(Javalin.create { config ->
+        config.staticFiles.add { staticFiles ->
+            staticFiles.hostedPath = "/"
+            staticFiles.directory = "/public"
+            staticFiles.precompress = true
+        }
+    }) { _, http ->
+        assertThat(http.getFile("/html.html", "br").contentEncoding()).isEqualTo("br")
+        assertThat(http.getFile("/html.html", "gzip").contentEncoding()).isEqualTo("gzip")
+        assertThat(http.getFile("/html.html", "gzip, br").contentEncoding()).isEqualTo("gzip")
+        assertThat(http.getFile("/html.html", "br, gzip").contentEncoding()).isEqualTo("br")
+        assertThat(http.getFile("/html.html", "deflate, gzip, br").contentEncoding()).isEqualTo("gzip")
+    }
+
     private fun Response.contentLength() = this.headers.get(Header.CONTENT_LENGTH)
     private fun Response.contentEncoding() = this.headers.get(Header.CONTENT_ENCODING)
 


### PR DESCRIPTION
`acceptEncoding` and `contentEncoding` headers were improperly handled.
Closes #1958