### PR TITLE
[content-type] Support FONT_WOFF & FONT_WOFF2

### DIFF
--- a/javalin/src/main/java/io/javalin/http/ContentType.kt
+++ b/javalin/src/main/java/io/javalin/http/ContentType.kt
@@ -64,6 +64,8 @@ enum class ContentType(
 
     FONT_OTF("font/otf", false, "otf"),
     FONT_TTF("font/ttf", false, "ttf"),
+    FONT_WOFF("font/woff", false, "woff"),
+    FONT_WOFF2("font/woff2", false, "woff2"),
 
     /* Application */
 


### PR DESCRIPTION
This PR adds WOFF/WOFF2 mentioned by [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)

Resolves #1934 