### PR TITLE
[core] Replace `PathMatcher#findEntries` full-copy list result with lazy stream

### DIFF
--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -86,6 +86,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
@@ -201,6 +213,44 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>run-benchmarks</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <classpathScope>test</classpathScope>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>org.openjdk.jmh.Main</argument>
+                                <argument>.*</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/javalin/src/main/java/io/javalin/http/HandlerType.kt
+++ b/javalin/src/main/java/io/javalin/http/HandlerType.kt
@@ -6,21 +6,28 @@
 
 package io.javalin.http
 
-enum class HandlerType {
+enum class HandlerType(val isHttpMethod: Boolean = true) {
 
-    GET, POST, PUT, PATCH, DELETE, HEAD, TRACE, CONNECT, OPTIONS, BEFORE, AFTER, INVALID;
-
-    fun isHttpMethod() = when (this) {
-        GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH -> true
-        else -> false
-    }
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    HEAD,
+    TRACE,
+    CONNECT,
+    OPTIONS,
+    BEFORE(isHttpMethod = false),
+    BEFORE_MATCHED(isHttpMethod = false),
+    AFTER_MATCHED(isHttpMethod = false),
+    AFTER(isHttpMethod = false),
+    INVALID(isHttpMethod = false);
 
     companion object {
 
         private val methodMap = values().associateBy { it.toString() }
 
-        fun findByName(name: String): HandlerType =
-            methodMap[name.uppercase()] ?: INVALID
+        fun findByName(name: String): HandlerType = methodMap[name.uppercase()] ?: INVALID
 
     }
 

--- a/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
@@ -10,6 +10,7 @@ import io.javalin.http.servlet.SubmitOrder.FIRST
 import io.javalin.http.servlet.SubmitOrder.LAST
 import io.javalin.http.util.MethodNotAllowedUtil
 import io.javalin.security.accessManagerNotConfiguredException
+import io.javalin.util.Util.firstOrNull
 import jakarta.servlet.http.HttpServletResponseWrapper
 
 object DefaultTasks {

--- a/javalin/src/main/java/io/javalin/http/util/MethodNotAllowedUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/MethodNotAllowedUtil.kt
@@ -14,7 +14,7 @@ import io.javalin.routing.PathMatcher
 object MethodNotAllowedUtil {
 
     fun findAvailableHttpHandlerTypes(matcher: PathMatcher, requestUri: String) =
-        enumValues<HandlerType>().filter { it.isHttpMethod() && matcher.findEntries(it, requestUri).isNotEmpty() }
+        enumValues<HandlerType>().filter { it.isHttpMethod && matcher.findEntries(it, requestUri).findFirst().isPresent }
 
     fun getAvailableHandlerTypes(ctx: Context, availableHandlerTypes: List<HandlerType>): Map<String, String> = mapOf(
         (if (acceptsHtml(ctx)) "Available methods" else "availableMethods") to availableHandlerTypes.joinToString(", ")

--- a/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
@@ -11,6 +11,7 @@ import io.javalin.util.JavalinLogger
 import io.javalin.websocket.WsConfig
 import io.javalin.websocket.WsContext
 import java.util.*
+import java.util.stream.Stream
 
 internal open class DevLoggingPlugin : JavalinPlugin {
 
@@ -39,9 +40,12 @@ internal open class DevLoggingPlugin : JavalinPlugin {
 fun requestDevLogger(matcher: PathMatcher, ctx: Context, time: Float) = try {
     val requestUri = ctx.path()
     with(ctx) {
-        val allMatching = (matcher.findEntries(HandlerType.BEFORE, requestUri) +
-            matcher.findEntries(ctx.method(), requestUri) +
-            matcher.findEntries(HandlerType.AFTER, requestUri))
+        val allMatching = Stream.of(
+                matcher.findEntries(HandlerType.BEFORE, requestUri),
+                matcher.findEntries(ctx.method(), requestUri),
+                matcher.findEntries(HandlerType.AFTER, requestUri)
+            )
+            .flatMap { it }
             .map { it.type.name + "=" + it.path }
         val resHeaders = res().headerNames.asSequence().map { it to res().getHeader(it) }.toMap()
         JavalinLogger.info(

--- a/javalin/src/main/java/io/javalin/plugin/bundled/RedirectToLowercasePathPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/RedirectToLowercasePathPlugin.kt
@@ -13,6 +13,7 @@ import io.javalin.plugin.JavalinPlugin
 import io.javalin.plugin.PluginPriority
 import io.javalin.routing.PathParser
 import io.javalin.routing.PathSegment
+import io.javalin.util.Util.firstOrNull
 import java.util.*
 
 /**
@@ -57,7 +58,7 @@ open class RedirectToLowercasePathPlugin : JavalinPlugin {
             val requestUri = ctx.path().removePrefix(ctx.contextPath())
             val matcher = app.javalinServlet().matcher
 
-            if (matcher.findEntries(ctx.method(), requestUri).firstOrNull() != null) {
+            if (matcher.findEntries(ctx.method(), requestUri).findFirst().isPresent) {
                 return@before // we found a route for this case, no need to redirect
             }
 

--- a/javalin/src/main/java/io/javalin/routing/PathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/routing/PathMatcher.kt
@@ -8,6 +8,7 @@ package io.javalin.routing
 
 import io.javalin.http.HandlerType
 import java.util.*
+import java.util.stream.Stream
 
 class PathMatcher {
 
@@ -15,19 +16,19 @@ class PathMatcher {
         HandlerType.values().associateWithTo(EnumMap(HandlerType::class.java)) { arrayListOf() }
 
     fun add(entry: HandlerEntry) {
-        if (entry.type.isHttpMethod() && handlerEntries[entry.type]!!.find { it.type == entry.type && it.path == entry.path } != null) {
+        if (entry.type.isHttpMethod && handlerEntries[entry.type]!!.find { it.type == entry.type && it.path == entry.path } != null) {
             throw IllegalArgumentException("Handler with type='${entry.type}' and path='${entry.path}' already exists.")
         }
         handlerEntries[entry.type]!!.add(entry)
     }
 
-    fun findEntries(handlerType: HandlerType, requestUri: String) =
-        handlerEntries[handlerType]!!.filter { he -> match(he, requestUri) }
+    fun findEntries(handlerType: HandlerType, requestUri: String): Stream<HandlerEntry> =
+        handlerEntries[handlerType]!!.stream().filter { he -> match(he, requestUri) }
 
     internal fun hasEntries(handlerType: HandlerType, requestUri: String): Boolean =
         handlerEntries[handlerType]!!.any { entry -> match(entry, requestUri) }
 
-    internal fun getAllEntriesOfType(handlerType: HandlerType) =
+    internal fun getAllEntriesOfType(handlerType: HandlerType): List<HandlerEntry> =
         handlerEntries[handlerType]!!
 
     private fun match(entry: HandlerEntry, requestPath: String): Boolean = when (entry.path) {

--- a/javalin/src/main/java/io/javalin/util/Util.kt
+++ b/javalin/src/main/java/io/javalin/util/Util.kt
@@ -14,6 +14,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.*
+import java.util.stream.Stream
 import java.util.zip.Adler32
 import java.util.zip.CheckedInputStream
 
@@ -109,6 +110,14 @@ object Util {
             superclass = superclass.superclass
         }
         return null
+    }
+
+    fun <T : Any> Stream<T>.firstOrNull(): T? = findFirst().orElse(null)
+
+    inline fun <T : Any> Stream<T>.firstOrNull(body: (T) -> Unit): T? {
+        val value = firstOrNull()
+        if (value != null) body(value)
+        return value
     }
 
 }

--- a/javalin/src/test/java/io/javalin/performance/PathMatcherBenchmark.java
+++ b/javalin/src/test/java/io/javalin/performance/PathMatcherBenchmark.java
@@ -1,0 +1,102 @@
+package io.javalin.performance;
+
+import io.javalin.config.RoutingConfig;
+import static io.javalin.http.HandlerType.GET;
+
+import io.javalin.http.HandlerType;
+import io.javalin.routing.HandlerEntry;
+import io.javalin.routing.PathMatcher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
+@SuppressWarnings({ "OptionalGetWithoutIsPresent" })
+public class PathMatcherBenchmark {
+
+    public static void main(String[] args) throws Exception {
+        var opt = new OptionsBuilder()
+            .include(PathMatcherBenchmark.class.getName())
+            .build();
+        new Runner(opt).run();
+    }
+
+    private OldPathMatcher oldPathMatcher;
+    private PathMatcher pathMatcher;
+
+    @Setup
+    public void setup() {
+        this.oldPathMatcher = new OldPathMatcher();
+        this.pathMatcher = new PathMatcher();
+        var routingConfig = new RoutingConfig();
+        for (int i = 0; i < 50; i++) {
+            this.pathMatcher.add(new HandlerEntry(GET, "/hello" + i, routingConfig, Collections.emptySet(), (ctx) -> {}));
+            this.oldPathMatcher.add(new HandlerEntry(GET, "/hello" + i, routingConfig, Collections.emptySet(), (ctx) -> {}));
+        }
+    }
+
+    @Benchmark
+    public void matchFirstStream(Blackhole blackhole) {
+        blackhole.consume(pathMatcher.findEntries(GET, "/hello0").findFirst().get());
+    }
+
+    @Benchmark
+    public void matchLastStream(Blackhole blackhole) {
+        blackhole.consume(pathMatcher.findEntries(GET, "/hello49").findFirst().get());
+    }
+
+    @Benchmark
+    public void matchFirstList(Blackhole blackhole) {
+        blackhole.consume(oldPathMatcher.findEntries(GET, "/hello0").iterator().next());
+    }
+
+    @Benchmark
+    public void matchLastList(Blackhole blackhole) {
+        blackhole.consume(oldPathMatcher.findEntries(GET, "/hello49").iterator().next());
+    }
+
+}
+
+final class OldPathMatcher {
+    @SuppressWarnings("Convert2Diamond")
+    private final EnumMap<HandlerType, ArrayList<HandlerEntry>> handlerEntries = new EnumMap<HandlerType, ArrayList<HandlerEntry>>(
+        Arrays.stream(HandlerType.values()).collect(Collectors.toMap((handler) -> handler, (handler) -> new ArrayList<>()))
+    );
+
+    public void add(HandlerEntry entry) {
+        handlerEntries.get(entry.getType()).add(entry);
+    }
+
+    public List<HandlerEntry> findEntries(HandlerType handlerType, String requestUri) {
+        var results = new ArrayList<HandlerEntry>();
+        handlerEntries.get(handlerType).forEach(entry -> {
+            if (match(entry, requestUri)) {
+                results.add(entry);
+            }
+        });
+        return results;
+    }
+
+    private boolean match(HandlerEntry entry, String requestPath) {
+        if (entry.getPath().equals("*")) return true;
+        if (entry.getPath().equals(requestPath)) return true;
+        return entry.matches(requestPath);
+    }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <moshi.version>1.13.0</moshi.version>
         <java.websocket.version>1.5.2</java.websocket.version>
         <junit.version>5.9.3</junit.version>
+        <jmh.version>1.37</jmh.version>
         <mockito.version>5.4.0</mockito.version>
         <mockk.version>1.13.5</mockk.version>
         <unirest.version>3.13.10</unirest.version>


### PR DESCRIPTION
A continuation of micro optimizations (#1942). 
This time, I've changed the way how `PathMatcher` returns matched entries - we're using this method 3 times in our request lifecycle:

* https://github.com/javalin/javalin/blob/48cd9eb25ac19c2838b487c59573e5cbd107f621/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt#L18
* https://github.com/javalin/javalin/blob/48cd9eb25ac19c2838b487c59573e5cbd107f621/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt#L24
* https://github.com/javalin/javalin/blob/48cd9eb25ac19c2838b487c59573e5cbd107f621/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt#L68

The 3 full-copy lists are replaced with 3 streams, as long as it doesn't matter that much for `BEFORE/AFTER` (because we're iterating through the whole result anyway), it'll be definitely an upgrade for http scope that requests only the first element (`firstOrNull `) and ignores the rest of elements. `Stream` is used over `Sequence`, because `Sequence` cannot be used by Java users.

The results for a single `pathMatcher.findEntries().first()` call:

```
Benchmark                               Mode  Cnt         Score   Error  Units
// old:
PathMatcherBenchmark.matchFirstList    thrpt    2    398864,329          ops/s
PathMatcherBenchmark.matchLastList     thrpt    2    384358,609          ops/s
// new:
PathMatcherBenchmark.matchFirstStream  thrpt    2  30094664,631          ops/s
PathMatcherBenchmark.matchLastStream   thrpt    2    414129,483          ops/s
```