### PR TITLE
[loom] Avoid synchronized lazy values in blocking context and replace required sync lazy inits with ReentrantLock when Loom is enabled

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/ErrorMapper.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/ErrorMapper.kt
@@ -20,8 +20,7 @@ class ErrorMapper {
         errorHandlers.add(MapperEntry(statusCode, contentType, handler))
 
     fun handle(statusCode: Int, ctx: Context) = errorHandlers.filter { it.statusCode == statusCode }.forEach {
-        val contentTypeMatches by lazy { ctx.header(Header.ACCEPT)?.contains(it.contentType, ignoreCase = true) == true }
-        if (it.contentType == "*" || contentTypeMatches) {
+        if (it.contentType == "*" || ctx.header(Header.ACCEPT)?.contains(it.contentType, ignoreCase = true) == true) {
             it.handler.handle(ctx)
         }
     }

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -19,6 +19,8 @@ import io.javalin.http.HttpStatus
 import io.javalin.routing.HandlerEntry
 import io.javalin.security.BasicAuthCredentials
 import io.javalin.util.JavalinLogger
+import io.javalin.util.SynchronizedLazyFactory
+import io.javalin.util.SynchronizedLazyFactory.synchronizedLazy
 import jakarta.servlet.ServletOutputStream
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -30,6 +32,8 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Supplier
+import kotlin.LazyThreadSafetyMode.NONE
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 class JavalinServletContext(
     cfg: JavalinConfig,
@@ -46,7 +50,7 @@ class JavalinServletContext(
     private var pathParamMap: Map<String, String> = mapOf(),
     internal var endpointHandlerPath: String = "",
     internal var userFutureSupplier: Supplier<out CompletableFuture<*>>? = null,
-    private var resultStream: InputStream? = null,
+    private var resultStream: InputStream? = null
 ) : Context {
 
     init {
@@ -81,34 +85,34 @@ class JavalinServletContext(
         else -> throw IllegalStateException("Cannot access the endpoint handler path in a 'BEFORE' handler")
     }
 
-    private val characterEncoding by lazy { super.characterEncoding() ?: "UTF-8" }
+    private val characterEncoding by lazy(NONE) { super.characterEncoding() ?: "UTF-8" }
     override fun characterEncoding(): String = characterEncoding
 
-    private val cookieStore by lazy { super.cookieStore() }
+    private val cookieStore by lazy(PUBLICATION) { super.cookieStore() }
     override fun cookieStore() = cookieStore
 
-    private val method by lazy { super.method() }
+    private val method by lazy(NONE) { super.method() }
     override fun method(): HandlerType = method
 
     override fun handlerType(): HandlerType = handlerType
     override fun matchedPath(): String = matchedPath
 
     /** has to be cached, because we can read input stream only once */
-    private val body by lazy { super.bodyAsBytes() }
+    private val body by synchronizedLazy { super.bodyAsBytes() }
     override fun bodyAsBytes(): ByteArray = body
 
     /** using an additional map lazily so no new objects are created whenever ctx.formParam*() is called */
-    private val formParams by lazy { super.formParamMap() }
+    private val formParams by lazy(NONE) { super.formParamMap() }
     override fun formParamMap(): Map<String, List<String>> = formParams
 
     override fun pathParamMap(): Map<String, String> = Collections.unmodifiableMap(pathParamMap)
     override fun pathParam(key: String): String = pathParamOrThrow(pathParamMap, key, matchedPath)
 
     /** using an additional map lazily so no new objects are created whenever ctx.formParam*() is called */
-    private val queryParams by lazy { super.queryParamMap() }
+    private val queryParams by lazy(NONE) { super.queryParamMap() }
     override fun queryParamMap(): Map<String, List<String>> = queryParams
 
-    internal val outputStreamWrapper = lazy { CompressedOutputStream(compressionStrategy, this) }
+    internal val outputStreamWrapper = synchronizedLazy { CompressedOutputStream(compressionStrategy, this) }
     override fun outputStream(): ServletOutputStream = outputStreamWrapper.value
 
     override fun redirect(location: String, status: HttpStatus) {

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -11,6 +11,7 @@ import io.javalin.http.staticfiles.Location
 import io.javalin.http.staticfiles.StaticFileConfig
 import io.javalin.util.JavalinException
 import io.javalin.util.JavalinLogger
+import io.javalin.util.javalinLazy
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.eclipse.jetty.http.MimeTypes
@@ -87,7 +88,7 @@ open class ConfigurableHandler(val config: StaticFileConfig, jettyServer: Server
     }
 
     override fun getResource(path: String): Resource {
-        val aliasResource by lazy(NONE) { baseResource!!.addPath(URIUtil.canonicalPath(path)) }
+        val aliasResource by javalinLazy { baseResource!!.addPath(URIUtil.canonicalPath(path)) }
         return when {
             config.directory == "META-INF/resources/webjars" ->
                 Resource.newClassPathResource("META-INF/resources$path") ?: EmptyResource.INSTANCE

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -22,6 +22,7 @@ import org.eclipse.jetty.util.resource.EmptyResource
 import org.eclipse.jetty.util.resource.Resource
 import java.io.File
 import java.nio.file.AccessDeniedException
+import kotlin.LazyThreadSafetyMode.NONE
 import io.javalin.http.staticfiles.ResourceHandler as JavalinResourceHandler
 
 class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
@@ -86,7 +87,7 @@ open class ConfigurableHandler(val config: StaticFileConfig, jettyServer: Server
     }
 
     override fun getResource(path: String): Resource {
-        val aliasResource by lazy { baseResource!!.addPath(URIUtil.canonicalPath(path)) }
+        val aliasResource by lazy(NONE) { baseResource!!.addPath(URIUtil.canonicalPath(path)) }
         return when {
             config.directory == "META-INF/resources/webjars" ->
                 Resource.newClassPathResource("META-INF/resources$path") ?: EmptyResource.INSTANCE

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -21,7 +21,7 @@ import java.util.stream.Stream
 
 class JavalinJackson(private var objectMapper: ObjectMapper? = null) : JsonMapper {
 
-    val mapper by lazy {
+    val mapper by javalinLazy {
         if (!Util.classExists(CoreDependency.JACKSON.testClass)) {
             val message =
                 """|It looks like you don't have an object mapper configured.

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -13,6 +13,7 @@ import io.javalin.util.CoreDependency
 import io.javalin.util.DependencyUtil
 import io.javalin.util.JavalinLogger
 import io.javalin.util.Util
+import io.javalin.util.javalinLazy
 import java.io.InputStream
 import java.io.OutputStream
 import java.lang.reflect.Type

--- a/javalin/src/main/java/io/javalin/json/PipedStreamUtil.kt
+++ b/javalin/src/main/java/io/javalin/json/PipedStreamUtil.kt
@@ -1,13 +1,14 @@
 package io.javalin.json
 
 import io.javalin.util.ConcurrencyUtil
+import io.javalin.util.javalinLazy
 import java.io.InputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
 object PipedStreamUtil {
 
-    private val executorService by lazy { ConcurrencyUtil.executorService("JavalinPipedStreamingThreadPool") }
+    private val executorService by javalinLazy { ConcurrencyUtil.executorService("JavalinPipedStreamingThreadPool") }
 
     fun getInputStream(userCallback: (PipedOutputStream) -> Unit): InputStream {
         val pipedOutputStream = PipedOutputStream()

--- a/javalin/src/main/java/io/javalin/routing/ParserState.kt
+++ b/javalin/src/main/java/io/javalin/routing/ParserState.kt
@@ -1,5 +1,7 @@
 package io.javalin.routing
 
+import kotlin.LazyThreadSafetyMode.NONE
+
 private enum class ParserState {
     NORMAL,
     INSIDE_SLASH_IGNORING_BRACKETS,
@@ -10,8 +12,8 @@ private val allDelimiters = setOf('{', '}', '<', '>')
 private val adjacentViolations = listOf("*{", "*<", "}*", ">*")
 
 internal fun convertSegment(segment: String, rawPath: String): PathSegment {
-    val bracketsCount by lazy { segment.count { it in allDelimiters } }
-    val wildcardCount by lazy { segment.count { it == '*' } }
+    val bracketsCount by lazy(NONE) { segment.count { it in allDelimiters } }
+    val wildcardCount by lazy(NONE) { segment.count { it == '*' } }
     return when {
         bracketsCount % 2 != 0 -> throw MissingBracketsException(segment, rawPath)
         adjacentViolations.any { it in segment } -> throw WildcardBracketAdjacentException(segment, rawPath)

--- a/javalin/src/main/java/io/javalin/routing/ParserState.kt
+++ b/javalin/src/main/java/io/javalin/routing/ParserState.kt
@@ -1,5 +1,6 @@
 package io.javalin.routing
 
+import io.javalin.util.javalinLazy
 import kotlin.LazyThreadSafetyMode.NONE
 
 private enum class ParserState {
@@ -12,8 +13,8 @@ private val allDelimiters = setOf('{', '}', '<', '>')
 private val adjacentViolations = listOf("*{", "*<", "}*", ">*")
 
 internal fun convertSegment(segment: String, rawPath: String): PathSegment {
-    val bracketsCount by lazy(NONE) { segment.count { it in allDelimiters } }
-    val wildcardCount by lazy(NONE) { segment.count { it == '*' } }
+    val bracketsCount by javalinLazy { segment.count { it in allDelimiters } }
+    val wildcardCount by javalinLazy { segment.count { it == '*' } }
     return when {
         bracketsCount % 2 != 0 -> throw MissingBracketsException(segment, rawPath)
         adjacentViolations.any { it in segment } -> throw WildcardBracketAdjacentException(segment, rawPath)

--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -80,6 +80,9 @@ internal object LoomUtil {
 
 }
 
+/**
+ * Loom-friendly [kotlin.Lazy] implementation
+ */
 internal class ReentrantLazy<T : Any>(initializer: () -> T) : Lazy<T> {
     private companion object {
         private object UNINITIALIZED_VALUE

--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -11,6 +11,9 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.LazyThreadSafetyMode.SYNCHRONIZED
+import kotlin.concurrent.withLock
 
 object ConcurrencyUtil {
 
@@ -75,6 +78,39 @@ internal object LoomUtil {
         JavalinLogger.startup("Your JDK supports Loom. Javalin will prefer Virtual Threads by default. Disable with `ConcurrencyUtil.useLoom = false`.")
     }
 
+}
+
+internal class ReentrantLazy<T : Any>(initializer: () -> T) : Lazy<T> {
+    private companion object {
+        private object UNINITIALIZED_VALUE
+    }
+
+    private var initializer: (() -> T)? = initializer
+    @Volatile private var lock: ReentrantLock? = ReentrantLock()
+    @Volatile private var _value: Any? = UNINITIALIZED_VALUE
+
+    override val value: T
+        get() {
+            lock?.withLock {
+                if (_value !== UNINITIALIZED_VALUE) {
+                    this._value = initializer!!.invoke()
+                    this.lock = null
+                    this.initializer = null
+                }
+            }
+            @Suppress("UNCHECKED_CAST")
+            return _value as T
+        }
+
+    override fun isInitialized(): Boolean = _value !== UNINITIALIZED_VALUE
+}
+
+/* Use ReentrantLock instead of synchronized block when Loom is enabled */
+object SynchronizedLazyFactory {
+    fun <T : Any> synchronizedLazy(initializer: () -> T): Lazy<T> = when (ConcurrencyUtil.useLoom && ConcurrencyUtil.isLoomAvailable()) {
+        true -> ReentrantLazy(initializer)
+        false -> lazy(SYNCHRONIZED, initializer)
+    }
 }
 
 open class NamedThreadFactory(protected val prefix: String) : ThreadFactory {

--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -92,7 +92,7 @@ internal class ReentrantLazy<T : Any>(initializer: () -> T) : Lazy<T> {
     override val value: T
         get() {
             lock?.withLock {
-                if (_value !== UNINITIALIZED_VALUE) {
+                if (_value === UNINITIALIZED_VALUE) {
                     this._value = initializer!!.invoke()
                     this.lock = null
                     this.initializer = null

--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -84,7 +84,7 @@ internal object LoomUtil {
 /**
  * Loom-friendly [kotlin.Lazy] implementation
  */
-internal class ReentrantLazy<T : Any>(initializer: () -> T) : Lazy<T> {
+internal class ReentrantLazy<T : Any?>(initializer: () -> T) : Lazy<T> {
     private companion object {
         private object UNINITIALIZED_VALUE
     }
@@ -121,7 +121,7 @@ internal class ReentrantLazy<T : Any>(initializer: () -> T) : Lazy<T> {
  * We instead use LazyThreadSafetyMode = NONE by default, and use [ReentrantLazy] when
  * [LazyThreadSafetyMode.SYNCHRONIZED] is requested.
  */
-fun <T : Any> javalinLazy(
+fun <T : Any?> javalinLazy(
     threadSafetyMode: LazyThreadSafetyMode = NONE,
     initializer: () -> T
 ): Lazy<T> = when (threadSafetyMode) {

--- a/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
+++ b/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
@@ -8,6 +8,7 @@ package io.javalin.validation
 
 import io.javalin.json.JsonMapper
 import io.javalin.util.JavalinLogger
+import kotlin.LazyThreadSafetyMode.NONE
 
 typealias Check<T> = (T) -> Boolean
 
@@ -27,7 +28,7 @@ open class BaseValidator<T>(val fieldName: String, protected var typedValue: T?,
     constructor(stringValue: String?, clazz: Class<T>, fieldName: String, jsonMapper: JsonMapper? = null) :
         this(fieldName, null, StringSource<T>(stringValue, clazz, jsonMapper))
 
-    private val errors by lazy {
+    private val errors by lazy(NONE) {
         if (stringSource != null) {
             if (this is BodyValidator) {
                 try {

--- a/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
+++ b/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
@@ -8,6 +8,7 @@ package io.javalin.validation
 
 import io.javalin.json.JsonMapper
 import io.javalin.util.JavalinLogger
+import io.javalin.util.javalinLazy
 import kotlin.LazyThreadSafetyMode.NONE
 
 typealias Check<T> = (T) -> Boolean
@@ -28,24 +29,24 @@ open class BaseValidator<T>(val fieldName: String, protected var typedValue: T?,
     constructor(stringValue: String?, clazz: Class<T>, fieldName: String, jsonMapper: JsonMapper? = null) :
         this(fieldName, null, StringSource<T>(stringValue, clazz, jsonMapper))
 
-    private val errors by lazy(NONE) {
+    private val errors by javalinLazy {
         if (stringSource != null) {
             if (this is BodyValidator) {
                 try {
                     typedValue = stringSource.jsonMapper!!.fromJsonString(stringSource.stringValue!!, stringSource.clazz)
                 } catch (e: Exception) {
                     JavalinLogger.info("Couldn't deserialize body to ${stringSource.clazz.simpleName}", e)
-                    return@lazy mapOf(REQUEST_BODY to listOf(ValidationError("DESERIALIZATION_FAILED", value = stringSource.stringValue)))
+                    return@javalinLazy mapOf(REQUEST_BODY to listOf(ValidationError("DESERIALIZATION_FAILED", value = stringSource.stringValue)))
                 }
             } else if (this is NullableValidator || this is Validator) {
                 try {
                     typedValue = JavalinValidation.convertValue(stringSource.clazz, stringSource.stringValue)
                 } catch (e: Exception) {
                     JavalinLogger.info("Parameter '$fieldName' with value '${stringSource.stringValue}' is not a valid ${stringSource.clazz.simpleName}")
-                    return@lazy mapOf(fieldName to listOf(ValidationError("TYPE_CONVERSION_FAILED", value = stringSource.stringValue)))
+                    return@javalinLazy mapOf(fieldName to listOf(ValidationError("TYPE_CONVERSION_FAILED", value = stringSource.stringValue)))
                 }
                 if (this !is NullableValidator && typedValue == null) { // only check typedValue - null might map to 0, which could be valid?
-                    return@lazy mapOf(fieldName to listOf(ValidationError("NULLCHECK_FAILED", value = stringSource.stringValue)))
+                    return@javalinLazy mapOf(fieldName to listOf(ValidationError("NULLCHECK_FAILED", value = stringSource.stringValue)))
                 }
             }
         }

--- a/javalin/src/main/java/io/javalin/vue/VueFileInliner.kt
+++ b/javalin/src/main/java/io/javalin/vue/VueFileInliner.kt
@@ -2,6 +2,7 @@ package io.javalin.vue
 
 import java.nio.file.Path
 import java.util.regex.Matcher
+import kotlin.LazyThreadSafetyMode.NONE
 
 internal object VueFileInliner {
     private val newlineRegex = Regex("\\r?\\n")
@@ -14,7 +15,7 @@ internal object VueFileInliner {
         return this.split(newlineRegex).joinToString("\n") { line ->
             if (!line.contains("@inlineFile")) return@joinToString line // nothing to inline
             val matchingKey = pathMap.keys.find { line.contains(it) } ?: throw IllegalStateException("Invalid path found: $line")
-            val matchingFileContent by lazy { Matcher.quoteReplacement(pathMap[matchingKey]!!.readText()) }
+            val matchingFileContent by lazy(NONE) { Matcher.quoteReplacement(pathMap[matchingKey]!!.readText()) }
             when {
                 devRegex.containsMatchIn(line) -> if (isDev) line.replace(devRegex, matchingFileContent) else ""
                 notDevRegex.containsMatchIn(line) -> if (!isDev) line.replace(notDevRegex, matchingFileContent) else ""

--- a/javalin/src/main/java/io/javalin/vue/VueFileInliner.kt
+++ b/javalin/src/main/java/io/javalin/vue/VueFileInliner.kt
@@ -1,5 +1,6 @@
 package io.javalin.vue
 
+import io.javalin.util.javalinLazy
 import java.nio.file.Path
 import java.util.regex.Matcher
 import kotlin.LazyThreadSafetyMode.NONE
@@ -15,7 +16,7 @@ internal object VueFileInliner {
         return this.split(newlineRegex).joinToString("\n") { line ->
             if (!line.contains("@inlineFile")) return@joinToString line // nothing to inline
             val matchingKey = pathMap.keys.find { line.contains(it) } ?: throw IllegalStateException("Invalid path found: $line")
-            val matchingFileContent by lazy(NONE) { Matcher.quoteReplacement(pathMap[matchingKey]!!.readText()) }
+            val matchingFileContent by javalinLazy { Matcher.quoteReplacement(pathMap[matchingKey]!!.readText()) }
             when {
                 devRegex.containsMatchIn(line) -> if (isDev) line.replace(devRegex, matchingFileContent) else ""
                 notDevRegex.containsMatchIn(line) -> if (!isDev) line.replace(notDevRegex, matchingFileContent) else ""

--- a/javalin/src/main/java/io/javalin/vue/VueHandler.kt
+++ b/javalin/src/main/java/io/javalin/vue/VueHandler.kt
@@ -4,6 +4,7 @@ import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.http.Header
 import io.javalin.http.InternalServerErrorResponse
+import io.javalin.util.javalinLazy
 import io.javalin.vue.VueFileInliner.inlineFiles
 import java.nio.file.Files
 import java.nio.file.Path
@@ -21,7 +22,7 @@ abstract class VueHandler(private val componentId: String) : Handler {
         c.rootDirectory = c.rootDirectory ?: c.pathMaster.defaultLocation(c.isDev!!)
         val routeComponent = if (componentId.startsWith("<")) componentId else "<$componentId></$componentId>"
         val allFiles = if (c.isDev == true) c.pathMaster.walkPaths() else c.pathMaster.cachedPaths
-        val resolver by lazy { if (c.isDev == true) VueDependencyResolver(allFiles, c.vueAppName) else c.pathMaster.cachedDependencyResolver }
+        val resolver by javalinLazy { if (c.isDev == true) VueDependencyResolver(allFiles, c.vueAppName) else c.pathMaster.cachedDependencyResolver }
         val componentId = routeComponent.removePrefix("<").takeWhile { it !in setOf('>', ' ') }
         val dependencies = if (c.optimizeDependencies) resolver.resolve(componentId) else allFiles.joinVueFiles()
         if (componentId !in dependencies) throw InternalServerErrorResponse("Route component not found: $routeComponent")

--- a/javalin/src/main/java/io/javalin/vue/VuePathMaster.kt
+++ b/javalin/src/main/java/io/javalin/vue/VuePathMaster.kt
@@ -6,6 +6,7 @@
 
 package io.javalin.vue
 
+import io.javalin.util.javalinLazy
 import java.nio.file.FileSystem
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.FileSystems
@@ -16,8 +17,8 @@ import java.util.stream.Collectors
 
 internal class VuePathMaster(val cfg: JavalinVueConfig) {
 
-    internal val cachedPaths by lazy { walkPaths() }
-    internal val cachedDependencyResolver by lazy { VueDependencyResolver(cachedPaths, cfg.vueAppName) }
+    internal val cachedPaths by javalinLazy { walkPaths() }
+    internal val cachedDependencyResolver by javalinLazy { VueDependencyResolver(cachedPaths, cfg.vueAppName) }
 
     fun walkPaths(): Set<Path> = Files.walk(cfg.rootDirectory, 20).use { it.collect(Collectors.toSet()) }
 

--- a/javalin/src/main/java/io/javalin/websocket/WsAutomaticPing.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsAutomaticPing.kt
@@ -1,14 +1,15 @@
 package io.javalin.websocket
 
 import io.javalin.util.ConcurrencyUtil
+import io.javalin.util.javalinLazy
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-val executor: ScheduledExecutorService by lazy { ConcurrencyUtil.newSingleThreadScheduledExecutor("JavalinWebSocketPingThread") }
-val pingFutures: ConcurrentHashMap<WsContext, ScheduledFuture<*>?> by lazy { ConcurrentHashMap() }
+val executor: ScheduledExecutorService by javalinLazy { ConcurrencyUtil.newSingleThreadScheduledExecutor("JavalinWebSocketPingThread") }
+val pingFutures: ConcurrentHashMap<WsContext, ScheduledFuture<*>?> by javalinLazy { ConcurrentHashMap() }
 
 fun enableAutomaticPings(ctx: WsContext, interval: Long, unit: TimeUnit, applicationData: ByteBuffer?) {
     synchronized(ctx) {

--- a/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
@@ -86,8 +86,8 @@ class WsConnection(val matcher: WsPathMatcher, val exceptionMapper: WsExceptionM
 
 }
 
-private fun Session.uriNoContextPath(): String =
-    this.upgradeRequest.requestURI.path.removePrefix(jettyUpgradeRequest().httpServletRequest.contextPath)
+internal val Session.jettyUpgradeRequest: JettyServerUpgradeRequest
+    get() = this.upgradeRequest as JettyServerUpgradeRequest
 
-internal fun Session.jettyUpgradeRequest(): JettyServerUpgradeRequest =
-    this.upgradeRequest as JettyServerUpgradeRequest
+private fun Session.uriNoContextPath(): String =
+    this.upgradeRequest.requestURI.path.removePrefix(jettyUpgradeRequest.httpServletRequest.contextPath)

--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -16,6 +16,7 @@ import org.eclipse.jetty.websocket.api.Session
 import java.lang.reflect.Type
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
+import kotlin.LazyThreadSafetyMode.NONE
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
@@ -26,11 +27,9 @@ import kotlin.reflect.typeOf
  */
 abstract class WsContext(val sessionId: String, @JvmField val session: Session) {
 
-    internal val upgradeReq by lazy { session.jettyUpgradeRequest() }
-    internal val upgradeCtx by lazy { upgradeReq.httpServletRequest.getAttribute(upgradeContextKey) as Context }
-
+    internal val upgradeCtx by lazy(NONE) { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeContextKey) as Context }
     @Suppress("UNCHECKED_CAST")
-    internal val sessionAttributes by lazy { upgradeReq.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as Map<String, Any>? }
+    private val sessionAttributes by lazy(NONE) { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as Map<String, Any>? }
 
     /** Returns the path that was used to match this request */
     fun matchedPath() = upgradeCtx.matchedPath()
@@ -100,7 +99,7 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
     inline fun <reified T : Any> pathParamAsClass(key: String) = pathParamAsClass(key, T::class.java)
 
     /** Returns the host as a [String] */
-    fun host(): String = upgradeReq.host // why can't we get this from upgradeCtx?
+    fun host(): String = session.jettyUpgradeRequest.host // why can't we get this from upgradeCtx?
 
     /** Gets a request header by name, or null. */
     fun header(header: String): String? = upgradeCtx.header(header)

--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -31,7 +31,7 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
     internal val upgradeCtx by javalinLazy { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeContextKey) as Context }
 
     @Suppress("UNCHECKED_CAST")
-    private val sessionAttributes by javalinLazy { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as? Map<String, Any> ?: emptyMap() }
+    private val sessionAttributes by javalinLazy { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as? Map<String, Any> }
 
     /** Returns the path that was used to match this request */
     fun matchedPath() = upgradeCtx.matchedPath()

--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -10,6 +10,7 @@ import io.javalin.http.Context
 import io.javalin.jetty.upgradeContextKey
 import io.javalin.jetty.upgradeSessionAttrsKey
 import io.javalin.json.jsonMapper
+import io.javalin.util.javalinLazy
 import org.eclipse.jetty.websocket.api.CloseStatus
 import org.eclipse.jetty.websocket.api.RemoteEndpoint
 import org.eclipse.jetty.websocket.api.Session
@@ -27,9 +28,10 @@ import kotlin.reflect.typeOf
  */
 abstract class WsContext(val sessionId: String, @JvmField val session: Session) {
 
-    internal val upgradeCtx by lazy(NONE) { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeContextKey) as Context }
+    internal val upgradeCtx by javalinLazy { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeContextKey) as Context }
+
     @Suppress("UNCHECKED_CAST")
-    private val sessionAttributes by lazy(NONE) { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as Map<String, Any>? }
+    private val sessionAttributes by javalinLazy { session.jettyUpgradeRequest.httpServletRequest.getAttribute(upgradeSessionAttrsKey) as? Map<String, Any> ?: emptyMap() }
 
     /** Returns the path that was used to match this request */
     fun matchedPath() = upgradeCtx.matchedPath()

--- a/javalin/src/test/java/io/javalin/TestConcurrencyUtil.kt
+++ b/javalin/src/test/java/io/javalin/TestConcurrencyUtil.kt
@@ -1,0 +1,45 @@
+package io.javalin
+
+import io.javalin.util.ReentrantLazy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class TestConcurrencyUtil {
+
+    @Test
+    fun `reentrant lazy should work like synchronized lazy`() {
+        val threads = Runtime.getRuntime().availableProcessors() * 2
+        val await = CountDownLatch(threads)
+        val counter = AtomicInteger(0)
+
+        val lazy = ReentrantLazy {
+            Thread.sleep(1000)
+            counter.incrementAndGet()
+        }
+
+        val fixedExecutor = Executors.newFixedThreadPool(threads)
+
+        for (thread in 0..threads) {
+            fixedExecutor.execute {
+                lazy.value
+                await.countDown()
+            }
+        }
+
+        await.await()
+        assertThat(lazy.isInitialized())
+        assertThat(lazy.value).isEqualTo(1)
+        assertThat(counter.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `reentrant lazy should work like other kotlin lazy`() {
+        val lazy: Lazy<Int> = ReentrantLazy { 1 }
+        val lazyBy by lazy
+        assertThat(lazyBy).isEqualTo(1)
+    }
+
+}


### PR DESCRIPTION
It'll most likely resolve #1966