### PR TITLE
Fix request listeners registered in contextHandlerConfig

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -58,7 +58,7 @@ class JettyServer(val cfg: JavalinConfig) {
         val wsAndHttpHandler = object : ServletContextHandler(nullParent, Util.normalizeContextPath(cfg.routing.contextPath), SESSIONS) {
             override fun doHandle(target: String, jettyRequest: Request, request: HttpServletRequest, response: HttpServletResponse) {
                 request.setAttribute("jetty-target-and-request", Pair(target, jettyRequest)) // used in JettyResourceHandler
-                nextHandle(target, jettyRequest, request, response)
+                super.doHandle(target, jettyRequest, request, response)
             }
         }.apply {
             this.sessionHandler = cfg.pvt.sessionHandler


### PR DESCRIPTION
I recently migrated an application from spark to javalin 5, and we use
the sentry servlet integration to enrich our sentry error reporting, and
noticed it wasn't actually getting called in the javalin app.

The default ContextHandler's `doHandle` method does the necessary
invocations of `ServletRequestListener`s that have been registered, and
I think just calling `super` to get that handling in `wsAndHttpHandler` is
the correct behavior, but maybe there was some reason that it intentionally
did not call `super.doHandle` that I missed.  It appears this will be a
non-issue in Javalin 6 since this handling was refactored in a way that
removed the method override, but I think this is worth fixing in Javalin 5.
