### PR TITLE
[meta] Fix wrong package name in `module-info.java`

### DIFF
--- a/javalin/module-info.java
+++ b/javalin/module-info.java
@@ -15,7 +15,7 @@ module io.javalin {
     exports io.javalin.plugin;
     exports io.javalin.plugin.bundled;
     exports io.javalin.rendering;
-    exports io.javalin.routing;
+    exports io.javalin.router;
     exports io.javalin.security;
     exports io.javalin.util;
     exports io.javalin.util.function;


### PR DESCRIPTION
We're not getting IDE warnings because of the move from #1923.