### PR TITLE
[javalin] Handling path == hostedPath edge-case in JettyResourceHandles - #1944

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -23,7 +23,6 @@ import org.eclipse.jetty.util.resource.EmptyResource
 import org.eclipse.jetty.util.resource.Resource
 import java.io.File
 import java.nio.file.AccessDeniedException
-import kotlin.LazyThreadSafetyMode.NONE
 import io.javalin.http.staticfiles.ResourceHandler as JavalinResourceHandler
 
 class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
@@ -97,6 +96,7 @@ open class ConfigurableHandler(val config: StaticFileConfig, jettyServer: Server
                 if (config.aliasCheck?.check(path, aliasResource) == true) aliasResource else throw AccessDeniedException("Failed alias check")
 
             config.hostedPath == "/" -> super.getResource(path) // same as regular ResourceHandler
+            path == config.hostedPath -> super.getResource("/")
             path.startsWith(config.hostedPath + "/") -> super.getResource(path.removePrefix(config.hostedPath))
             else -> EmptyResource.INSTANCE // files that don't start with hostedPath should not be accessible
         }

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
@@ -175,11 +175,29 @@ class TestStaticFiles {
     }
 
     @Test
-    fun `directory root return welcome file if there is a welcome file`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
+    fun `directory root returns welcome file`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
         assertThat(http.get("/subdir/").httpCode()).isEqualTo(OK)
         assertThat(http.getBody("/subdir/")).isEqualTo("<h1>Welcome file</h1>")
         assertThat(http.get("/subdir").httpCode()).isEqualTo(OK)
         assertThat(http.getBody("/subdir")).isEqualTo("<h1>Welcome file</h1>")
+    }
+
+    @Test
+    fun `directory root returns welcome file, when custom hostedPath matches path`() {
+        val staticWithCustomHostedPath = Javalin.create { config ->
+            config.staticFiles.add {
+                it.directory = "/public/subdir"
+                it.location = Location.CLASSPATH
+                it.hostedPath = "/subdir"
+            }
+        }
+
+        return TestUtil.test(staticWithCustomHostedPath) { _, http ->
+            assertThat(http.get("/subdir/").httpCode()).isEqualTo(OK)
+            assertThat(http.getBody("/subdir/")).isEqualTo("<h1>Welcome file</h1>")
+            assertThat(http.get("/subdir").httpCode()).isEqualTo(OK)
+            assertThat(http.getBody("/subdir")).isEqualTo("<h1>Welcome file</h1>")
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description of changes
- Fixes #1944 - Handling the case when URL path exactly matches the hostedPath of a resource (Reproducible when URL without trailing slash is used to reach a resource with custom hostedPath)
- Added a unit test for this specific case
  - Without the fix, the new test would fail with:
`io.javalin.staticfiles.TestStaticFiles.directory root returns welcome file, when custom hostedPath matches path  Time elapsed: 0.024 s  <<< ERROR!
java.lang.RuntimeException: 
java.lang.Exception: Assertion error: 
expected: 200 OK
 but was: 404 Not Found
	at io.javalin.testing.TestUtil.test(TestUtil.java:38)`