### PR TITLE
[cleanup] Use cached `Enum.entries` from Kotlin 1.9 instead of `Enum.values()`

### DIFF
--- a/javalin/src/main/java/io/javalin/event/EventManager.kt
+++ b/javalin/src/main/java/io/javalin/event/EventManager.kt
@@ -15,7 +15,7 @@ import java.util.function.Consumer
 
 class EventManager {
 
-    val lifecycleHandlers = JavalinLifecycleEvent.values().associateWith { HashSet<LifecycleEventListener>() }
+    val lifecycleHandlers = JavalinLifecycleEvent.entries.associateWith { HashSet<LifecycleEventListener>() }
     var handlerAddedHandlers = mutableSetOf<Consumer<HandlerMetaInfo>>()
     val wsHandlerAddedHandlers = mutableSetOf<Consumer<WsHandlerMetaInfo>>()
 

--- a/javalin/src/main/java/io/javalin/http/HttpStatus.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpStatus.kt
@@ -86,10 +86,11 @@ enum class HttpStatus(val code: Int, val message: String) {
         "$code $message"
 
     companion object {
-        private val cachedValues: Array<HttpStatus> = HttpStatus.values()
 
         @JvmStatic
-        fun forStatus(status: Int) = cachedValues.find { it.code == status } ?: UNKNOWN
+        fun forStatus(status: Int): HttpStatus =
+            HttpStatus.entries.find { it.code == status } ?: UNKNOWN
+
     }
 
 }

--- a/javalin/src/main/java/io/javalin/router/matcher/PathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/router/matcher/PathMatcher.kt
@@ -14,7 +14,7 @@ import java.util.stream.Stream
 class PathMatcher {
 
     private val handlerEntries: Map<HandlerType, MutableList<HttpHandlerEntry>> =
-        HandlerType.values().associateWithTo(EnumMap(HandlerType::class.java)) { arrayListOf() }
+        HandlerType.entries.associateWithTo(EnumMap(HandlerType::class.java)) { arrayListOf() }
 
     fun add(entry: HttpHandlerEntry) {
         if (entry.type.isHttpMethod && handlerEntries[entry.type]!!.find { it.type == entry.type && it.path == entry.path } != null) {

--- a/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
@@ -28,10 +28,9 @@ data class WsHandlerEntry(
  */
 class WsPathMatcher {
 
-    private val wsHandlerEntries = WsHandlerType.values()
-        .associateTo(EnumMap<WsHandlerType, MutableList<WsHandlerEntry>>(WsHandlerType::class.java)) {
-            it to mutableListOf()
-        }
+    private val wsHandlerEntries = WsHandlerType
+        .entries
+        .associateWithTo(EnumMap<WsHandlerType, MutableList<WsHandlerEntry>>(WsHandlerType::class.java)) { mutableListOf() }
 
     fun add(entry: WsHandlerEntry) {
         if (wsHandlerEntries[entry.type]!!.find { it.type == entry.type && it.path == entry.path } != null) {

--- a/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
+++ b/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
@@ -11,14 +11,14 @@ class ContentTypeTest {
 
     @Test
     fun `fetching content type by mime type should get the right type`() {
-        ContentType.values().forEach {
+        ContentType.entries.forEach {
             assertThat(ContentType.getContentType(it.mimeType)).isEqualTo(it)
         }
     }
 
     @Test
     fun `fetching content type by its extension should get the right type`() {
-        ContentType.values().forEach { type ->
+        ContentType.entries.forEach { type ->
             type.extensions.forEach { extension ->
                 assertThat(ContentType.getContentTypeByExtension(extension)).isEqualTo(type)
                 assertThat(ContentType.getMimeTypeByExtension(extension)).isEqualTo(type.mimeType)

--- a/javalin/src/test/java/io/javalin/http/HttpResponseExceptionTest.kt
+++ b/javalin/src/test/java/io/javalin/http/HttpResponseExceptionTest.kt
@@ -8,7 +8,7 @@ class HttpResponseExceptionTest {
 
     @Test
     fun `all HttpStatus values should be covered by an Exception class`() {
-        for (httpStatus in HttpStatus.values()) {
+        for (httpStatus in HttpStatus.entries) {
             if (httpStatus == HttpStatus.UNKNOWN) {
                 continue
             }

--- a/javalin/src/test/java/io/javalin/http/HttpStatusCodeTest.kt
+++ b/javalin/src/test/java/io/javalin/http/HttpStatusCodeTest.kt
@@ -7,7 +7,7 @@ class HttpStatusCodeTest {
 
     @Test
     fun `fetching http codes by code should get the right code`() {
-        HttpStatus.values().forEach {
+        HttpStatus.entries.forEach {
             assertThat(HttpStatus.forStatus(it.code)).isEqualTo(it)
         }
     }
@@ -20,7 +20,7 @@ class HttpStatusCodeTest {
 
     @Test
     fun `http code provides formatted implementation of toString() method`() {
-        HttpStatus.values().forEach {
+        HttpStatus.entries.forEach {
             assertThat("${it.code} ${it.message}").isEqualTo(it.toString())
         }
     }

--- a/javalin/src/test/java/io/javalin/performance/PathMatcherBenchmark.java
+++ b/javalin/src/test/java/io/javalin/performance/PathMatcherBenchmark.java
@@ -77,7 +77,7 @@ public class PathMatcherBenchmark {
 final class OldPathMatcher {
     @SuppressWarnings("Convert2Diamond")
     private final EnumMap<HandlerType, ArrayList<HttpHandlerEntry>> handlerEntries = new EnumMap<HandlerType, ArrayList<HttpHandlerEntry>>(
-        Arrays.stream(HandlerType.values()).collect(Collectors.toMap((handler) -> handler, (handler) -> new ArrayList<>()))
+        HandlerType.getEntries().stream().collect(Collectors.toMap((handler) -> handler, (handler) -> new ArrayList<>()))
     );
 
     public void add(HttpHandlerEntry entry) {


### PR DESCRIPTION
https://kotlinlang.org/docs/whatsnew19.html#stable-replacement-of-the-enum-class-values-function