### PR TITLE
Update Jetty Dependency to Version 11.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <!-- DEPENDENCIES -->
         <annotations.version>24.0.1</annotations.version>
-        <jetty.version>11.0.15</jetty.version>
+        <jetty.version>11.0.17</jetty.version>
         <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.15.0</jackson.databind.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>


### PR DESCRIPTION
Updated the Jetty dependency to version `11.0.17`.
Fixes #2017.