### PR TITLE
Add missing javadoc 

### DIFF
--- a/javalin/src/main/java/io/javalin/config/BundledPluginsConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/BundledPluginsConfig.kt
@@ -13,25 +13,74 @@ import io.javalin.plugin.bundled.SslRedirectPlugin
 import io.javalin.security.RouteRole
 import java.util.function.Consumer
 
+/**
+ * Configuration to enable bundled plugins or add custom ones.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.bundledPlugins]
+ */
 class BundledPluginsConfig(private val cfg: JavalinConfig) {
 
+    /**
+     * Enables the RouteOverview plugin.
+     * @param path the path from which the route overview should be visible
+     * @param roles the roles restricting who can access the route overview
+     * @see [RouteOverviewPlugin]
+     */
     fun enableRouteOverview(path: String, vararg roles: RouteRole = emptyArray()) =
         cfg.registerPlugin(RouteOverviewPlugin {
             it.path = path
             it.roles = roles
         })
 
+    /**
+     * Enables the Basic Authentication plugin.
+     * @param username the authorized username
+     * @param password the authorized password
+     * @see [BasicAuthPlugin]
+     */
     fun enableBasicAuth(username: String, password: String) =
         cfg.registerPlugin(BasicAuthPlugin {
             it.username = username
             it.password = password
         })
 
+    /**
+     * Enables the Global Headers plugin.
+     *
+     * @param globalHeaderConfig the global headers plugin configuration
+     * @see [GlobalHeadersPlugin]
+     */
     fun enableGlobalHeaders(globalHeadersConfig: Consumer<GlobalHeadersConfig>) = cfg.registerPlugin(GlobalHeadersPlugin(globalHeadersConfig))
+
+    /**
+     * Enables the Cors Plugin.
+     *
+     * @param userConfig the CORS plugin configuration
+     * @see [GlobalHeadersPlugin]
+     */
     fun enableCors(userConfig: Consumer<CorsPluginConfig>) = cfg.registerPlugin(CorsPlugin(userConfig))
+
+    /**
+     * Enables the HttpAllowedMethodsPlugin, automatically handling the Options request on configured routes.
+     */
     fun enableHttpAllowedMethodsOnRoutes() = cfg.registerPlugin(HttpAllowedMethodsPlugin())
+
+    /**
+     * Enables the development debugging logger plugin.
+     */
     fun enableDevLogging() = cfg.registerPlugin(DevLoggingPlugin())
+
+    /**
+     * Enables the RedirectToLowercasePath plugin.
+     */
     fun enableRedirectToLowercasePaths() = cfg.registerPlugin(RedirectToLowercasePathPlugin())
+
+    /**
+     * Enables the SSL Redirects plugin, which redirect any http request to https.
+     *
+     * Note it must be the first plugin enabled to properly handle all requests.
+     */
     fun enableSslRedirects() = cfg.registerPlugin(SslRedirectPlugin())
 
 }

--- a/javalin/src/main/java/io/javalin/config/BundledPluginsConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/BundledPluginsConfig.kt
@@ -16,7 +16,6 @@ import java.util.function.Consumer
 /**
  * Configuration to enable bundled plugins or add custom ones.
  *
- * @param cfg the parent Javalin Configuration
  * @see [JavalinConfig.bundledPlugins]
  */
 class BundledPluginsConfig(private val cfg: JavalinConfig) {
@@ -35,8 +34,6 @@ class BundledPluginsConfig(private val cfg: JavalinConfig) {
 
     /**
      * Enables the Basic Authentication plugin.
-     * @param username the authorized username
-     * @param password the authorized password
      * @see [BasicAuthPlugin]
      */
     fun enableBasicAuth(username: String, password: String) =
@@ -47,40 +44,22 @@ class BundledPluginsConfig(private val cfg: JavalinConfig) {
 
     /**
      * Enables the Global Headers plugin.
-     *
-     * @param globalHeaderConfig the global headers plugin configuration
      * @see [GlobalHeadersPlugin]
      */
     fun enableGlobalHeaders(globalHeadersConfig: Consumer<GlobalHeadersConfig>) = cfg.registerPlugin(GlobalHeadersPlugin(globalHeadersConfig))
 
     /**
      * Enables the Cors Plugin.
-     *
-     * @param userConfig the CORS plugin configuration
      * @see [GlobalHeadersPlugin]
      */
     fun enableCors(userConfig: Consumer<CorsPluginConfig>) = cfg.registerPlugin(CorsPlugin(userConfig))
-
-    /**
-     * Enables the HttpAllowedMethodsPlugin, automatically handling the Options request on configured routes.
-     */
+    /** Enables the HttpAllowedMethodsPlugin, automatically handling the Options request on configured routes. */
     fun enableHttpAllowedMethodsOnRoutes() = cfg.registerPlugin(HttpAllowedMethodsPlugin())
-
-    /**
-     * Enables the development debugging logger plugin.
-     */
+    /**  Enables the development debugging logger plugin. */
     fun enableDevLogging() = cfg.registerPlugin(DevLoggingPlugin())
-
-    /**
-     * Enables the RedirectToLowercasePath plugin.
-     */
+    /** Enables the RedirectToLowercasePath plugin. */
     fun enableRedirectToLowercasePaths() = cfg.registerPlugin(RedirectToLowercasePathPlugin())
-
-    /**
-     * Enables the SSL Redirects plugin, which redirect any http request to https.
-     *
-     * Note it must be the first plugin enabled to properly handle all requests.
-     */
+    /** Enables the SSL Redirects plugin, which redirect any http request to https. Note it must be the first plugin enabled to properly handle all requests.*/
     fun enableSslRedirects() = cfg.registerPlugin(SslRedirectPlugin())
 
 }

--- a/javalin/src/main/java/io/javalin/config/ContextResolverConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/ContextResolverConfig.kt
@@ -7,12 +7,22 @@ const val CONTEXT_RESOLVER_KEY = "javalin-context-resolver"
 
 fun Context.contextResolver() = this.appAttribute<ContextResolverConfig>(CONTEXT_RESOLVER_KEY)
 
+/**
+ * Configure the implementation for Context functions.
+ *
+ * @see [JavalinConfig.contextResolver]
+ */
 class ContextResolverConfig {
     // @formatter:off
+    /** The IP address resolver (default: reads the `remoteAddr` part of the request) */
     @JvmField var ip: (Context) -> String = { it.req().remoteAddr }
+    /** The host resolver (default: reads the `Host` header). */
     @JvmField var host: (Context) -> String? = { it.header(Header.HOST) }
+    /** The scheme resolver (default: reads the `scheme` part of the request). */
     @JvmField var scheme: (Context) -> String = { it.req().scheme }
+    /** The URL resolver (default: reads the `requestUrl` part of the request). */
     @JvmField var url: (Context) -> String = { it.req().requestURL.toString() }
+    /** The full URL resolver (default: reads the url with its query string). */
     @JvmField var fullUrl: (Context) -> String = { it.url() + if (it.queryString() != null) "?" + it.queryString() else "" }
     // @formatter:on
 }

--- a/javalin/src/main/java/io/javalin/config/EventConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/EventConfig.kt
@@ -17,7 +17,6 @@ import io.javalin.event.JavalinLifecycleEvent.SERVER_STOPPING
 import io.javalin.event.JavalinLifecycleEvent.SERVER_STOP_FAILED
 import io.javalin.event.WsHandlerMetaInfo
 import io.javalin.http.Handler
-import io.javalin.websocket.WsCloseHandler
 import java.util.function.Consumer
 
 /**
@@ -28,51 +27,25 @@ import java.util.function.Consumer
  */
 class EventConfig(private val cfg: JavalinConfig) {
 
-    /**
-     * Adds a callback to react on the Server Starting event.
-     * @param lifecycleEventListener the callback
-     */
+    /** Adds a callback to react on the Server Starting event. */
     fun serverStarting(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STARTING, lifecycleEventListener)
-    /**
-     * Adds a callback to react on the Server Started event.
-     * @param lifecycleEventListener the callback
-     */
+    /** Adds a callback to react on the Server Started event. */
     fun serverStarted(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STARTED, lifecycleEventListener)
-    /**
-     * Adds a callback to react on the Server Start Failed event.
-     * @param lifecycleEventListener the callback
-     */
+    /** Adds a callback to react on the Server Start Failed event. */
     fun serverStartFailed(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_START_FAILED, lifecycleEventListener)
-    /**
-     * Adds a callback to react on the Server Stop Failed event.
-     * @param lifecycleEventListener the callback
-     */
+    /** Adds a callback to react on the Server Stop Failed event. */
     fun serverStopFailed(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STOP_FAILED, lifecycleEventListener)
-    /**
-     * Adds a callback to react on the Server Stopping event.
-     * @param lifecycleEventListener the callback
-     */
+    /** Adds a callback to react on the Server Stopping event. */
     fun serverStopping(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STOPPING, lifecycleEventListener)
-    /**
-     * Adds a callback to react on the Server Stopped event.
-     * @param lifecycleEventListener the callback
-     */
+    /** Adds a callback to react on the Server Stopped event. */
     fun serverStopped(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STOPPED, lifecycleEventListener)
 
-    /**
-     * Adds a callback to react when a [Handler] is added.
-     *
-     * @param callback the callback
-     */
+    /** Adds a callback to react when a [Handler] is added. */
     fun handlerAdded(callback: Consumer<HandlerMetaInfo>) {
         eventManager.handlerAddedHandlers.add(callback);
     }
 
-    /**
-     * Adds a callback to react when a websocket Handler is added.
-     *
-     * @param callback the callback
-     */
+    /** Adds a callback to react when a websocket Handler is added. */
     fun wsHandlerAdded(callback: Consumer<WsHandlerMetaInfo>) {
         eventManager.wsHandlerAddedHandlers.add(callback);
     }

--- a/javalin/src/main/java/io/javalin/config/EventConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/EventConfig.kt
@@ -16,21 +16,63 @@ import io.javalin.event.JavalinLifecycleEvent.SERVER_STOPPED
 import io.javalin.event.JavalinLifecycleEvent.SERVER_STOPPING
 import io.javalin.event.JavalinLifecycleEvent.SERVER_STOP_FAILED
 import io.javalin.event.WsHandlerMetaInfo
+import io.javalin.http.Handler
+import io.javalin.websocket.WsCloseHandler
 import java.util.function.Consumer
 
+/**
+ * Configures the events' listener.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.events]
+ */
 class EventConfig(private val cfg: JavalinConfig) {
 
+    /**
+     * Adds a callback to react on the Server Starting event.
+     * @param lifecycleEventListener the callback
+     */
     fun serverStarting(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STARTING, lifecycleEventListener)
+    /**
+     * Adds a callback to react on the Server Started event.
+     * @param lifecycleEventListener the callback
+     */
     fun serverStarted(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STARTED, lifecycleEventListener)
+    /**
+     * Adds a callback to react on the Server Start Failed event.
+     * @param lifecycleEventListener the callback
+     */
     fun serverStartFailed(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_START_FAILED, lifecycleEventListener)
+    /**
+     * Adds a callback to react on the Server Stop Failed event.
+     * @param lifecycleEventListener the callback
+     */
     fun serverStopFailed(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STOP_FAILED, lifecycleEventListener)
+    /**
+     * Adds a callback to react on the Server Stopping event.
+     * @param lifecycleEventListener the callback
+     */
     fun serverStopping(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STOPPING, lifecycleEventListener)
+    /**
+     * Adds a callback to react on the Server Stopped event.
+     * @param lifecycleEventListener the callback
+     */
     fun serverStopped(lifecycleEventListener: LifecycleEventListener) = eventManager.addLifecycleEvent(SERVER_STOPPED, lifecycleEventListener)
 
+    /**
+     * Adds a callback to react when a [Handler] is added.
+     *
+     * @param callback the callback
+     */
     fun handlerAdded(callback: Consumer<HandlerMetaInfo>) {
         eventManager.handlerAddedHandlers.add(callback);
     }
 
+    /**
+     * Adds a callback to react when a websocket Handler is added.
+     *
+     * @param callback the callback
+     */
     fun wsHandlerAdded(callback: Consumer<WsHandlerMetaInfo>) {
         eventManager.wsHandlerAddedHandlers.add(callback);
     }

--- a/javalin/src/main/java/io/javalin/config/HttpConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/HttpConfig.kt
@@ -20,46 +20,30 @@ class HttpConfig(private val cfg: JavalinConfig) {
     @JvmField var asyncTimeout = 0L
     //@formatter:on
 
-    /**
-     * Sets a custom CompressionStrategy.
-     * @param compressionStrategy the strategy to use
-     */
+    /** Sets a custom CompressionStrategy. */
     fun customCompression(compressionStrategy: CompressionStrategy) {
         cfg.pvt.compressionStrategy = compressionStrategy
     }
 
-    /**
-     * Sets a CompressionStrategy using both gzip and brotli.
-     * @param gzipLevel the gzip compression level
-     * @param brotliLevel the brotli compression level
-     */
+    /** Sets a CompressionStrategy using both gzip (default level: 6) and brotli (default level: 4).*/
     @JvmOverloads
     fun brotliAndGzipCompression(gzipLevel: Int = 6, brotliLevel: Int = 4) {
         cfg.pvt.compressionStrategy = CompressionStrategy(Brotli(brotliLevel), Gzip(gzipLevel))
     }
 
-    /**
-     * Sets a CompressionStrategy using gzip
-     * @param level the gzip compression level
-     */
+    /** Sets a CompressionStrategy using gzip (default level: 6). */
     @JvmOverloads
     fun gzipOnlyCompression(level: Int = 6) {
         cfg.pvt.compressionStrategy = CompressionStrategy(null, Gzip(level))
     }
 
-
-    /**
-     * Sets a CompressionStrategy using brotli.
-     * @param level the brotli compression level
-     */
+    /** Sets a CompressionStrategy using brotli (default level: 4). */
     @JvmOverloads
     fun brotliOnlyCompression(level: Int = 4) {
         cfg.pvt.compressionStrategy = CompressionStrategy(Brotli(level), null)
     }
 
-    /**
-     * Disable Compression
-     */
+    /** Disable Compression */
     fun disableCompression() {
         cfg.pvt.compressionStrategy = CompressionStrategy(null, null)
     }

--- a/javalin/src/main/java/io/javalin/config/HttpConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/HttpConfig.kt
@@ -5,6 +5,12 @@ import io.javalin.compression.CompressionStrategy
 import io.javalin.compression.Gzip
 import io.javalin.http.ContentType
 
+/**
+ * Configuration for the HTTP layer.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.http]
+ */
 class HttpConfig(private val cfg: JavalinConfig) {
     //@formatter:off
     @JvmField var generateEtags = false
@@ -14,25 +20,46 @@ class HttpConfig(private val cfg: JavalinConfig) {
     @JvmField var asyncTimeout = 0L
     //@formatter:on
 
+    /**
+     * Sets a custom CompressionStrategy.
+     * @param compressionStrategy the strategy to use
+     */
     fun customCompression(compressionStrategy: CompressionStrategy) {
         cfg.pvt.compressionStrategy = compressionStrategy
     }
 
+    /**
+     * Sets a CompressionStrategy using both gzip and brotli.
+     * @param gzipLevel the gzip compression level
+     * @param brotliLevel the brotli compression level
+     */
     @JvmOverloads
     fun brotliAndGzipCompression(gzipLevel: Int = 6, brotliLevel: Int = 4) {
         cfg.pvt.compressionStrategy = CompressionStrategy(Brotli(brotliLevel), Gzip(gzipLevel))
     }
 
+    /**
+     * Sets a CompressionStrategy using gzip
+     * @param level the gzip compression level
+     */
     @JvmOverloads
     fun gzipOnlyCompression(level: Int = 6) {
         cfg.pvt.compressionStrategy = CompressionStrategy(null, Gzip(level))
     }
 
+
+    /**
+     * Sets a CompressionStrategy using brotli.
+     * @param level the brotli compression level
+     */
     @JvmOverloads
     fun brotliOnlyCompression(level: Int = 4) {
         cfg.pvt.compressionStrategy = CompressionStrategy(Brotli(level), null)
     }
 
+    /**
+     * Disable Compression
+     */
     fun disableCompression() {
         cfg.pvt.compressionStrategy = CompressionStrategy(null, null)
     }

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -60,14 +60,11 @@ class JavalinConfig {
      * You can disable this behavior by setting this to false.
      */
     @JvmField var startupWatcherEnabled = true
-    /**
-     * This is "private", only use it if you know what you're doing
-     */
+    /** This is "private", only use it if you know what you're doing */
     @JvmField val pvt = PrivateConfig(this)
 
     /**
      * Adds an event listener to this Javalin Configuration.
-     * @param listener the listener
      * @see [EventConfig]
      */
     fun events(listener:Consumer<EventConfig>) { listener.accept(this.events) }

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -5,6 +5,7 @@
  */
 package io.javalin.config
 
+import io.javalin.Javalin
 import io.javalin.http.servlet.MAX_REQUEST_SIZE_KEY
 import io.javalin.http.util.AsyncExecutor
 import io.javalin.http.util.AsyncExecutor.Companion.ASYNC_EXECUTOR_KEY
@@ -23,19 +24,35 @@ import java.util.function.Consumer
 
 // this class should be abbreviated `cfg` in the source code.
 // `cfg.pvt` should be accessible, but usage should be discouraged (hence the naming)
+/**
+ * Javalin configuration class.
+ * @see [Javalin.create]
+ */
 class JavalinConfig {
     //@formatter:off
+    /** The http layer configuration: etags, request size, timeout, etc */
     @JvmField val http = HttpConfig(this)
+    /** The routing configuration: context path, slash treatment, etc */
     @JvmField val router = RouterConfig(this)
+    /** The embedded Jetty webserver configuration */
     @JvmField val jetty = JettyConfig(this)
+    /** Static files and webjars configuration */
     @JvmField val staticFiles = StaticFilesConfig(this)
+    /** Single Page Application roots configuration */
     @JvmField val spaRoot = SpaRootConfig(this)
+    /** Request Logger configuration: http and websocket loggers */
     @JvmField val requestLogger = RequestLoggerConfig(this)
+    /** Bundled plugins configuration: enable bundled plugins or add custom ones */
     @JvmField val bundledPlugins = BundledPluginsConfig(this)
+    /** Events configuration */
     @JvmField val events = EventConfig(this)
+    /** Vue Plugin configuration */
     @JvmField val vue = JavalinVueConfig()
+    /** Context resolver implementation configuration */
     @JvmField val contextResolver = ContextResolverConfig()
+    /** Use virtual threads (based on Java Project Loom) */
     @JvmField var useVirtualThreads = false
+    /** Show the Javalin banner in the logs */
     @JvmField var showJavalinBanner = true
     @JvmField var validation = ValidationConfig()
     /**
@@ -48,8 +65,23 @@ class JavalinConfig {
      */
     @JvmField val pvt = PrivateConfig(this)
 
+    /**
+     * Adds an event listener to this Javalin Configuration.
+     * @param listener the listener
+     * @see [EventConfig]
+     */
     fun events(listener:Consumer<EventConfig>) { listener.accept(this.events) }
+
+    /**
+     * Sets the [JsonMapper] to be used in this Javalin Configuration.
+     * @param jsonMapper the [JsonMapper]
+     */
     fun jsonMapper(jsonMapper: JsonMapper) { pvt.jsonMapper = jsonMapper }
+
+    /**
+     * Sets the [FileRenderer] to be used in this Javalin Configuration.
+     * @param fileRenderer the [FileRenderer]
+     */
     fun fileRenderer(fileRenderer: FileRenderer) { pvt.appAttributes[FILE_RENDERER_KEY] = fileRenderer }
     //@formatter:on
 
@@ -69,6 +101,11 @@ class JavalinConfig {
         }
     }
 
+    /**
+     * Register a plugin to this Javalin Configuration.
+     * @param T the type of the configuration class for the plugin
+     * @param plugin the [Plugin] to register
+     */
     fun <T> registerPlugin(plugin: Plugin<T>): Plugin<T> =
         plugin.also { pvt.pluginManager.register(plugin) }
 

--- a/javalin/src/main/java/io/javalin/config/JettyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JettyConfig.kt
@@ -11,7 +11,12 @@ import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory
 import java.util.function.BiFunction
 import java.util.function.Consumer
 
-/**  Configures the embedded Jetty webserver. */
+/**
+ * Configures the embedded Jetty webserver.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.jetty]
+ */
 class JettyConfig(private val cfg: JavalinConfig) {
     //@formatter:off
     @JvmField var defaultHost: String? = null

--- a/javalin/src/main/java/io/javalin/config/RequestLoggerConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RequestLoggerConfig.kt
@@ -4,12 +4,26 @@ import io.javalin.http.RequestLogger
 import io.javalin.websocket.WsConfig
 import java.util.function.Consumer
 
+/**
+ * Configuration for http requests and websocket loggers.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.requestLogger]
+ */
 class RequestLoggerConfig(private val cfg: JavalinConfig) {
 
+    /**
+     * Adds a request logger for HTTP requests.
+     * @param requestLogger the request logger
+     */
     fun http(requestLogger: RequestLogger) {
         cfg.pvt.requestLogger = requestLogger
     }
 
+    /**
+     * Adds a request logger for websocket requests.
+     * @param ws the request logger
+     */
     fun ws(ws: Consumer<WsConfig>) {
         val logger = WsConfig()
         ws.accept(logger)

--- a/javalin/src/main/java/io/javalin/config/RequestLoggerConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RequestLoggerConfig.kt
@@ -12,18 +12,12 @@ import java.util.function.Consumer
  */
 class RequestLoggerConfig(private val cfg: JavalinConfig) {
 
-    /**
-     * Adds a request logger for HTTP requests.
-     * @param requestLogger the request logger
-     */
+    /** Adds a request logger for HTTP requests. */
     fun http(requestLogger: RequestLogger) {
         cfg.pvt.requestLogger = requestLogger
     }
 
-    /**
-     * Adds a request logger for websocket requests.
-     * @param ws the request logger
-     */
+    /** Adds a request logger for websocket requests. */
     fun ws(ws: Consumer<WsConfig>) {
         val logger = WsConfig()
         ws.accept(logger)

--- a/javalin/src/main/java/io/javalin/config/RouterConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RouterConfig.kt
@@ -20,24 +20,13 @@ import java.util.function.Consumer
 class RouterConfig(internal val cfg: JavalinConfig) {
 
     // @formatter:off
-    /**
-     * The context path (ex '/blog' if you are hosting an app on a subpath, like 'mydomain.com/blog')
-     */
+    /** The context path (ex '/blog' if you are hosting an app on a subpath, like 'mydomain.com/blog') */
     @JvmField var contextPath = "/"
-
-    /**
-     * If true, treat '/path' and '/path/' as the same path (default: true).
-     */
+    /** If true, treat '/path' and '/path/' as the same path (default: true). */
     @JvmField var ignoreTrailingSlashes = true
-
-    /**
-     * If true, treat '/path//subpath' and '/path/subpath' as the same path (default: false).
-     */
+    /** If true, treat '/path//subpath' and '/path/subpath' as the same path (default: false). */
     @JvmField var treatMultipleSlashesAsSingleSlash = false
-
-    /**
-     * If true, treat '/PATH' and '/path' as the same path (default: false).
-     */
+    /** If true, treat '/PATH' and '/path' as the same path (default: false). */
     @JvmField var caseInsensitiveRoutes = false
     // @formatter:on
 

--- a/javalin/src/main/java/io/javalin/config/RouterConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RouterConfig.kt
@@ -11,12 +11,33 @@ import io.javalin.router.exception.JavaLangErrorHandler
 import io.javalin.util.JavalinLogger
 import java.util.function.Consumer
 
+/**
+ * Configuration for the Router.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.router]
+ */
 class RouterConfig(internal val cfg: JavalinConfig) {
 
     // @formatter:off
+    /**
+     * The context path (ex '/blog' if you are hosting an app on a subpath, like 'mydomain.com/blog')
+     */
     @JvmField var contextPath = "/"
+
+    /**
+     * If true, treat '/path' and '/path/' as the same path (default: true).
+     */
     @JvmField var ignoreTrailingSlashes = true
+
+    /**
+     * If true, treat '/path//subpath' and '/path/subpath' as the same path (default: false).
+     */
     @JvmField var treatMultipleSlashesAsSingleSlash = false
+
+    /**
+     * If true, treat '/PATH' and '/path' as the same path (default: false).
+     */
     @JvmField var caseInsensitiveRoutes = false
     // @formatter:on
 

--- a/javalin/src/main/java/io/javalin/config/SpaRootConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/SpaRootConfig.kt
@@ -1,8 +1,20 @@
 package io.javalin.config
 
 import io.javalin.http.Handler
+import io.javalin.http.SinglePageHandler
 import io.javalin.http.staticfiles.Location
 
+/**
+ * Configures a Single Page Application root.
+ *
+ * Single page application (SPA) mode is similar to static file handling.
+ * It runs after endpoint matching, and after static file handling. It’s
+ * basically a very fancy 404 mapper, which converts any 404’s into a
+ * specified page. You can define multiple single page handlers for your
+ * application by specifying different root paths.
+ *
+ * @see [SinglePageHandler]
+ */
 class SpaRootConfig(private val cfg: JavalinConfig) {
 
     @JvmOverloads

--- a/javalin/src/main/java/io/javalin/config/StaticFilesConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/StaticFilesConfig.kt
@@ -6,19 +6,41 @@ import io.javalin.http.staticfiles.StaticFileConfig
 import io.javalin.jetty.JettyResourceHandler
 import java.util.function.Consumer
 
+/**
+ * Configuration for static files and webjars.
+ *
+ * Static resource handling is done after endpoint matching,
+ * meaning your own GET endpoints have higher priority.
+ *
+ * @param cfg the parent Javalin Configuration
+ * @see [JavalinConfig.staticFiles]
+ */
 class StaticFilesConfig(private val cfg: JavalinConfig) {
 
+    /**
+     * Enable webjars access.
+     * They will be available at /webjars/name/version/file.ext.
+     */
     fun enableWebjars() = add { staticFiles ->
         staticFiles.directory = "META-INF/resources/webjars"
         staticFiles.headers = mapOf(Header.CACHE_CONTROL to "max-age=31622400")
     }
 
+    /**
+     * Adds the given directory as a static file containers.
+     * @param directory the directory where your files are located
+     * @param location the location of the static directory
+     */
     @JvmOverloads
     fun add(directory: String, location: Location = Location.CLASSPATH) = add { staticFiles ->
         staticFiles.directory = directory
         staticFiles.location = location
     }
 
+    /**
+     * Adds a static file through custom configuration.
+     * @param userConfig a lambda to configure advanced static files
+     */
     fun add(userConfig: Consumer<StaticFileConfig>) {
         if (cfg.pvt.resourceHandler == null) {
             cfg.pvt.resourceHandler = JettyResourceHandler(cfg.pvt)

--- a/javalin/src/main/java/io/javalin/config/StaticFilesConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/StaticFilesConfig.kt
@@ -17,10 +17,7 @@ import java.util.function.Consumer
  */
 class StaticFilesConfig(private val cfg: JavalinConfig) {
 
-    /**
-     * Enable webjars access.
-     * They will be available at /webjars/name/version/file.ext.
-     */
+    /** Enable webjars access. They will be available at /webjars/name/version/file.ext. */
     fun enableWebjars() = add { staticFiles ->
         staticFiles.directory = "META-INF/resources/webjars"
         staticFiles.headers = mapOf(Header.CACHE_CONTROL to "max-age=31622400")
@@ -29,7 +26,7 @@ class StaticFilesConfig(private val cfg: JavalinConfig) {
     /**
      * Adds the given directory as a static file containers.
      * @param directory the directory where your files are located
-     * @param location the location of the static directory
+     * @param location the location of the static directory (default: CLASSPATH)
      */
     @JvmOverloads
     fun add(directory: String, location: Location = Location.CLASSPATH) = add { staticFiles ->

--- a/javalin/src/main/java/io/javalin/event/EventManager.kt
+++ b/javalin/src/main/java/io/javalin/event/EventManager.kt
@@ -22,18 +22,11 @@ class EventManager {
     var handlerAddedHandlers = mutableSetOf<Consumer<HandlerMetaInfo>>()
     val wsHandlerAddedHandlers = mutableSetOf<Consumer<WsHandlerMetaInfo>>()
 
-    /**
-     * Fires a Javalin Lifecycle Event.
-     * @param javalinLifecycleEvent the event to send to listeners
-     */
-    fun fireEvent(javalinLifecycleEvent: JavalinLifecycleEvent) =
-        lifecycleHandlers[javalinLifecycleEvent]?.forEach { it.handleEvent() }
-
-    /**
-     * Fires an event telling listeners that a new HTTP handler has been added.
-     * @param metaInfo the Handler metadata information
-     */
+    /** Fires a Javalin Lifecycle Event to the listeners. */
+    fun fireEvent(javalinLifecycleEvent: JavalinLifecycleEvent) = lifecycleHandlers[javalinLifecycleEvent]?.forEach { it.handleEvent() }
+    /** Fires an event telling listeners that a new HTTP handler has been added.*/
     fun fireHandlerAddedEvent(metaInfo: HandlerMetaInfo) = handlerAddedHandlers.onEach { it.accept(metaInfo) }
+    /** Fires an event telling listeners that a new WebSocket handler has been added. */
     fun fireWsHandlerAddedEvent(metaInfo: WsHandlerMetaInfo) = wsHandlerAddedHandlers.onEach { it.accept(metaInfo) }
 
     internal fun addLifecycleEvent(event: JavalinLifecycleEvent, lifecycleEventListener: LifecycleEventListener) {
@@ -46,34 +39,17 @@ class EventManager {
  * The possible Javalin lifecycle event
  */
 enum class JavalinLifecycleEvent {
-    /**
-     * Event fired when attempting to start the Jetty Webserver
-     */
+    /** Event fired when attempting to start the Jetty Webserver */
     SERVER_STARTING,
-
-    /**
-     * Event fired when the Jetty Webserver was started successfully
-     */
+    /** Event fired when the Jetty Webserver was started successfully */
     SERVER_STARTED,
-
-    /**
-     * Event fired when an exception occurs while starting the Jetty Webserver
-     */
+    /** Event fired when an exception occurs while starting the Jetty Webserver */
     SERVER_START_FAILED,
-
-    /**
-     * Event fired when an exception occurs while stopping the Jetty Webserver
-     */
+    /** Event fired when an exception occurs while stopping the Jetty Webserver */
     SERVER_STOP_FAILED,
-
-    /**
-     * Event fired when attempting to stop the Jetty Webserver
-     */
+    /** Event fired when attempting to stop the Jetty Webserver */
     SERVER_STOPPING,
-
-    /**
-     * Event fired after the Jetty Webserver was stopped successfully
-     */
+    /** Event fired after the Jetty Webserver was stopped successfully */
     SERVER_STOPPED
 }
 

--- a/javalin/src/main/java/io/javalin/http/Cookie.kt
+++ b/javalin/src/main/java/io/javalin/http/Cookie.kt
@@ -6,14 +6,59 @@ import jakarta.servlet.http.Cookie as ServletCookie
 
 const val SAME_SITE = "SameSite"
 
+/**
+ * Value to define the `SameSite` property of a cookie.
+ */
 enum class SameSite(val value: String) {
+    /**
+     * Means that the browser sends the cookie with both cross-site and
+     * same-site requests.
+     */
     NONE("$SAME_SITE=None"),
+
+    /**
+     * Means that the browser sends the cookie only for same-site requests,
+     * that is, requests originating from the same site that set the cookie.
+     * If a request originates from a different domain or scheme (even with
+     * the same domain), no cookies with the SameSite=Strict attribute are sent.
+     */
     STRICT("$SAME_SITE=Strict"),
+
+    /**
+     * Means that the cookie is not sent on cross-site requests, such as on
+     * requests to load images or frames, but is sent when a user is navigating
+     * to the origin site from an external site (for example, when following a link).
+     * This is the default behavior if the SameSite attribute is not specified.
+     */
     LAX("$SAME_SITE=Lax");
 
     override fun toString() = this.value
 }
 
+/**
+ * An HTTP cookie (web cookie, browser cookie) is a small piece of data that a server
+ * sends to a user's web browser. The browser may store the cookie and send it back
+ * to the same server with later requests. Typically, an HTTP cookie is used to tell
+ * if two requests come from the same browser.
+ *
+ * @param name the name of the cookie
+ * @param value the value of the cookie
+ * @param path indicates the path that must exist in the requested URL for the browser to
+ * send the Cookie header. (default = "/")
+ * @param maxAge indicates the number of seconds until the cookie expires.
+ * A zero or negative number will expire the cookie immediately. (default = -1)
+ * @param secure indicates that the cookie is sent to the server only when a request is
+ * made with the https: scheme (except on localhost), and therefore, is more resistant
+ * to man-in-the-middle attacks (default: false)
+ * @param version the version of the protocol this cookie complies with (default: 0)
+ * @param isHttpOnly if true, forbids JavaScript from accessing the cookie, for example,
+ * through the `Document.cookie` property. (default: false)
+ * @param comment a comment that describes a cookie's purpose (default: null)
+ * @param domain defines the host to which the cookie will be sent. If null this attribute
+ * defaults to the host of the current document URL, not including subdomains. (default: null)
+ * @param sameSite controls whether or not a cookie is sent with cross-site requests,
+ * providing some protection against cross-site request forgery attacks (CSRF). (default: null)
+ */
 data class Cookie @JvmOverloads constructor(
     var name: String,
     var value: String,

--- a/javalin/src/main/java/io/javalin/http/Cookie.kt
+++ b/javalin/src/main/java/io/javalin/http/Cookie.kt
@@ -10,10 +10,7 @@ const val SAME_SITE = "SameSite"
  * Value to define the `SameSite` property of a cookie.
  */
 enum class SameSite(val value: String) {
-    /**
-     * Means that the browser sends the cookie with both cross-site and
-     * same-site requests.
-     */
+    /** Means that the browser sends the cookie with both cross-site and same-site requests.*/
     NONE("$SAME_SITE=None"),
 
     /**

--- a/javalin/src/main/java/io/javalin/http/ExceptionHandler.java
+++ b/javalin/src/main/java/io/javalin/http/ExceptionHandler.java
@@ -18,5 +18,11 @@ import org.jetbrains.annotations.NotNull;
  */
 @FunctionalInterface
 public interface ExceptionHandler<T extends Exception> {
+    /**
+     * Handles an exception thrown while handling a request
+     *
+     * @param exception the thrown exception
+     * @param ctx       the context of the request
+     */
     void handle(@NotNull T exception, @NotNull Context ctx);
 }

--- a/javalin/src/main/java/io/javalin/http/Handler.java
+++ b/javalin/src/main/java/io/javalin/http/Handler.java
@@ -17,5 +17,13 @@ import org.jetbrains.annotations.NotNull;
  */
 @FunctionalInterface
 public interface Handler {
+    /**
+     * Handles a request.
+     *
+     * @param ctx the current request's context. Use this to process the request's
+     *            parameter (query, form params, body, …) and build up the response
+     *            (status code, payload, …)
+     * @throws Exception an exception while handling the request
+     */
     void handle(@NotNull Context ctx) throws Exception;
 }

--- a/javalin/src/main/java/io/javalin/http/HandlerType.kt
+++ b/javalin/src/main/java/io/javalin/http/HandlerType.kt
@@ -6,23 +6,117 @@
 
 package io.javalin.http
 
+import io.javalin.router.JavalinDefaultRouting
+
+/**
+ * The possible Handler types one can use in Javalin.
+ * This includes all standard HTTM methods (e.g.: GET, POST, …),
+ * as well as Javalin specific operations.
+ * @param isHttpMethod whether the handler is a standard HTTP method.
+ */
 enum class HandlerType(val isHttpMethod: Boolean = true) {
 
+    /**
+     * The HTTP GET method requests a representation of the specified resource.
+     */
     GET,
+
+    /**
+     * The HTTP POST method sends data to the server. The type of the body of the
+     * request is indicated by the Content-Type header.
+     */
     POST,
+
+    /**
+     * The HTTP PUT request method creates a new resource or replaces a representation
+     * of the target resource with the request payload.
+     *
+     * The difference between PUT and POST is that PUT is idempotent: calling it once
+     * or several times successively has the same effect (that is no side effect), whereas
+     * successive identical POST requests may have additional effects, akin to placing
+     * an order several times.
+     */
     PUT,
+
+    /**
+     * The HTTP PATCH request method applies partial modifications to a resource.
+     *
+     * PATCH is somewhat analogous to the "update" concept found in CRUD (in general,
+     * HTTP is different than CRUD, and the two should not be confused).
+     */
     PATCH,
+
+    /**
+     * The HTTP DELETE request method deletes the specified resource.
+     */
     DELETE,
+
+    /**
+     * The HTTP HEAD method requests the headers that would be returned if
+     * the HEAD request's URL was instead requested with the HTTP GET method.
+     */
     HEAD,
+
+    /**
+     * The HTTP TRACE method performs a message loop-back test along the path to
+     * the target resource, providing a useful debugging mechanism.
+     */
     TRACE,
+
+    /**
+     * The HTTP CONNECT method starts two-way communications with the requested
+     * resource. It can be used to open a tunnel.
+     */
     CONNECT,
+
+    /**
+     * The HTTP OPTIONS method requests permitted communication options for a given URL
+     * or server. A client can specify a URL with this method, or an asterisk (*) to
+     * refer to the entire server.
+     */
     OPTIONS,
+
+    /**
+     * Javalin Specific: Before-handlers are matched before every request (including static files).
+     * @see [JavalinDefaultRouting.before]
+     */
     BEFORE(isHttpMethod = false),
+
+    /**
+     * Javalin specific: BeforeMatched-handlers run before a request finds a matching handler
+     * @see [JavalinDefaultRouting.beforeMatched]
+     */
     BEFORE_MATCHED(isHttpMethod = false),
+
+    /**
+     * Javalin specific: AfterMatched-handlers run after a request which found a matching handler
+     * @see [JavalinDefaultRouting.afterMatched]
+     */
     AFTER_MATCHED(isHttpMethod = false),
+
+    /**
+     * Javalin specific: handler ran before an http request is upgraded to websocket
+     * @see [JavalinDefaultRouting.wsBeforeUpgrade]
+     */
     WEBSOCKET_BEFORE_UPGRADE(isHttpMethod = false),
+
+    /**
+     *
+     * Javalin specific: handler ran after an http request is upgraded to websocket
+     * @see [JavalinDefaultRouting.wsAfterUpgrade]
+     */
     WEBSOCKET_AFTER_UPGRADE(isHttpMethod = false),
+
+    /**
+     * Javalin specific: After-handlers run after every request (even if an exception occurred)
+     * @see [JavalinDefaultRouting.after]
+     */
     AFTER(isHttpMethod = false),
+
+    /**
+     * Javalin specific: this corresponds to a handler that is not recognized using the
+     * [findByName] method.
+     */
     INVALID(isHttpMethod = false);
 
     companion object {

--- a/javalin/src/main/java/io/javalin/http/HandlerType.kt
+++ b/javalin/src/main/java/io/javalin/http/HandlerType.kt
@@ -16,15 +16,10 @@ import io.javalin.router.JavalinDefaultRouting
  */
 enum class HandlerType(val isHttpMethod: Boolean = true) {
 
-    /**
-     * The HTTP GET method requests a representation of the specified resource.
-     */
+    /** The HTTP GET method requests a representation of the specified resource. */
     GET,
 
-    /**
-     * The HTTP POST method sends data to the server. The type of the body of the
-     * request is indicated by the Content-Type header.
-     */
+    /** The HTTP POST method sends data to the server. The type of the body of the request is indicated by the Content-Type header.*/
     POST,
 
     /**
@@ -46,27 +41,16 @@ enum class HandlerType(val isHttpMethod: Boolean = true) {
      */
     PATCH,
 
-    /**
-     * The HTTP DELETE request method deletes the specified resource.
-     */
+    /** The HTTP DELETE request method deletes the specified resource. */
     DELETE,
 
-    /**
-     * The HTTP HEAD method requests the headers that would be returned if
-     * the HEAD request's URL was instead requested with the HTTP GET method.
-     */
+    /** The HTTP HEAD method requests the headers that would be returned if  the HEAD request's URL was instead requested with the HTTP GET method.*/
     HEAD,
 
-    /**
-     * The HTTP TRACE method performs a message loop-back test along the path to
-     * the target resource, providing a useful debugging mechanism.
-     */
+    /** The HTTP TRACE method performs a message loop-back test along the path to the target resource, providing a useful debugging mechanism.*/
     TRACE,
 
-    /**
-     * The HTTP CONNECT method starts two-way communications with the requested
-     * resource. It can be used to open a tunnel.
-     */
+    /** The HTTP CONNECT method starts two-way communications with the requested resource. It can be used to open a tunnel. */
     CONNECT,
 
     /**

--- a/javalin/src/main/java/io/javalin/http/HttpStatus.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpStatus.kt
@@ -1,89 +1,151 @@
 package io.javalin.http
 
+/** HTTP response status codes indicating whether a specific HTTP request has been successfully completed. */
 enum class HttpStatus(val code: Int, val message: String) {
+    /** This interim response indicates that the client should continue the request or ignore the response if the request is already finished. */
     CONTINUE(100, "Continue"),
+    /** This code is sent in response to an Upgrade request header from the client and indicates the protocol the server is switching to. */
     SWITCHING_PROTOCOLS(101, "Switching Protocols"),
+    /** This code indicates that the server has received and is processing the request, but no response is available yet. */
     PROCESSING(102, "Processing"),
+    /** This status code is primarily intended to be used with the Link header, letting the user agent start preloading resources while the server prepares a response or preconnect to an origin from which the page will need resources.*/
     EARLY_HINTS(103, "Early Hints"),
+
+    /** The request succeeded. */
     OK(200, "OK"),
+    /** The request succeeded, and a new resource was created as a result. This is typically the response sent after POST requests, or some PUT requests. */
     CREATED(201, "Created"),
+    /** The request has been received but not yet acted upon. It is noncommittal, since there is no way in HTTP to later send an asynchronous response indicating the outcome of the request. It is intended for cases where another process or server handles the request, or for batch processing. */
     ACCEPTED(202, "Accepted"),
+    /** This response code means the returned metadata is not exactly the same as is available from the origin server, but is collected from a local or a third-party copy. This is mostly used for mirrors or backups of another resource. Except for that specific case, the 200 OK response is preferred to this status. */
     NON_AUTHORITATIVE_INFORMATION(203, "Non Authoritative Information"),
+    /** There is no content to send for this request, but the headers may be useful. The user agent may update its cached headers for this resource with the new ones.*/
     NO_CONTENT(204, "No Content"),
+    /** Tells the user agent to reset the document which sent this request. */
     RESET_CONTENT(205, "Reset Content"),
+    /** This response code is used when the Range header is sent from the client to request only part of a resource. */
     PARTIAL_CONTENT(206, "Partial Content"),
+    /** Conveys information about multiple resources, for situations where multiple status codes might be appropriate. */
     MULTI_STATUS(207, "Multi-Status"),
+    /** Used inside a <dav:propstat> response element to avoid repeatedly enumerating the internal members of multiple bindings to the same collection. */
     ALREADY_REPORTED(208, "Already Reported"),
+    /** The server has fulfilled a GET request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance. */
     IM_USED(226, "IM Used"),
+
+    /** The request has more than one possible response. The user agent or user should choose one of them. */
     MULTIPLE_CHOICES(300, "Multiple Choices"),
+    /** The URL of the requested resource has been changed permanently. The new URL is given in the response. */
     MOVED_PERMANENTLY(301, "Moved Permanently"),
+    /** This response code means that the URI of requested resource has been changed temporarily. Further changes in the URI might be made in the future. Therefore, this same URI should be used by the client in future requests. */
     FOUND(302, "Found"),
+    /** The server sent this response to direct the client to get the requested resource at another URI with a GET request. */
     SEE_OTHER(303, "See Other"),
+    /** This is used for caching purposes. It tells the client that the response has not been modified, so the client can continue to use the same cached version of the response. */
     NOT_MODIFIED(304, "Not Modified"),
+    /** Defined in a previous version of the HTTP specification to indicate that a requested response must be accessed by a proxy. */
+    @Deprecated("It has been deprecated due to security concerns regarding in-band configuration of a proxy.")
     USE_PROXY(305, "Use Proxy"),
+    /** The server sends this response to direct the client to get the requested resource at another URI with the same method that was used in the prior request.  */
     TEMPORARY_REDIRECT(307, "Temporary Redirect"),
+    /** This means that the resource is now permanently located at another URI, specified by the Location: HTTP Response header. */
     PERMANENT_REDIRECT(308, "Permanent Redirect"),
+
+    /** The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing). */
     BAD_REQUEST(400, "Bad Request"),
+    /** Although the HTTP standard specifies "unauthorized", semantically this response means "unauthenticated". That is, the client must authenticate itself to get the requested response. */
     UNAUTHORIZED(401, "Unauthorized"),
+    /** This response code is reserved for future use. The initial aim for creating this code was using it for digital payment systems, however this status code is used very rarely and no standard convention exists. */
     PAYMENT_REQUIRED(402, "Payment Required"),
+    /** The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401 Unauthorized, the client's identity is known to the server. */
     FORBIDDEN(403, "Forbidden"),
+    /** The server cannot find the requested resource. In the browser, this means the URL is not recognized.  */
     NOT_FOUND(404, "Not Found"),
+    /** The request method is known by the server but is not supported by the target resource. For example, an API may not allow calling DELETE to remove a resource. */
     METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+    /** This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content that conforms to the criteria given by the user agent. */
     NOT_ACCEPTABLE(406, "Not Acceptable"),
+    /** This is similar to `401 Unauthorized` but authentication is needed to be done by a proxy. */
     PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
+    /** This response is sent on an idle connection by some servers, even without any previous request by the client. It means that the server would like to shut down this unused connection. */
     REQUEST_TIMEOUT(408, "Request Timeout"),
+    /** This response is sent when a request conflicts with the current state of the server. */
     CONFLICT(409, "Conflict"),
+    /** This response is sent when the requested content has been permanently deleted from server, with no forwarding address. */
     GONE(410, "Gone"),
+    /** Server rejected the request because the Content-Length header field is not defined and the server requires it. */
     LENGTH_REQUIRED(411, "Length Required"),
+    /** The client has indicated preconditions in its headers which the server does not meet. */
     PRECONDITION_FAILED(412, "Precondition Failed"),
+    /** Request entity is larger than limits defined by server. The server might close the connection or return an Retry-After header field.  */
     CONTENT_TOO_LARGE(413, "Content Too Large"),
+    /** The URI requested by the client is longer than the server is willing to interpret. */
     URI_TOO_LONG(414, "URI Too Long"),
+    /** The media format of the requested data is not supported by the server, so the server is rejecting the request. */
     UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
+    /** The range specified by the Range header field in the request cannot be fulfilled. It's possible that the range is outside the size of the target URI's data. */
     RANGE_NOT_SATISFIABLE(416, "Range Not Satisfiable"),
+    /** This response code means the expectation indicated by the Expect request header field cannot be met by the server. */
     EXPECTATION_FAILED(417, "Expectation Failed"),
+    /** The server refuses the attempt to brew coffee with a teapot. */
     IM_A_TEAPOT(418, "I'm a Teapot"),
+    /** Unofficial status code, used in Twitter API to indicate that the client is being rate limited for making too many requests.  */
     ENHANCE_YOUR_CALM(420, "Enhance your Calm"),
+    /** The request was directed at a server that is not able to produce a response. This can be sent by a server that is not configured to produce responses for the combination of scheme and authority that are included in the request URI. */
     MISDIRECTED_REQUEST(421, "Misdirected Request"),
+    /** The request was well-formed but was unable to be followed due to semantic errors. */
     UNPROCESSABLE_CONTENT(422, "Unprocessable Content"),
+    /** The resource that is being accessed is locked, meaning it can't be accessed. */
     LOCKED(423, "Locked"),
+    /** The request failed due to failure of a previous request. */
     FAILED_DEPENDENCY(424, "Failed Dependency"),
+    /** Indicates that the server is unwilling to risk processing a request that might be replayed. */
     TOO_EARLY(425, "Too Early"),
+    /** The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol. */
     UPGRADE_REQUIRED(426, "Upgrade Required"),
+    /** The origin server requires the request to be conditional. This response is intended to prevent the 'lost update' problem, where a client GETs a resource's state, modifies it and PUTs it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict. */
     PRECONDITION_REQUIRED(428, "Precondition Required"),
+    /** The user has sent too many requests in a given amount of time ("rate limiting"). */
     TOO_MANY_REQUESTS(429, "Too Many Requests"),
+    /** The server is unwilling to process the request because its header fields are too large. The request may be resubmitted after reducing the size of the request header fields. */
     REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
+    /** The user agent requested a resource that cannot legally be provided, such as a web page censored by a government. */
     UNAVAILABLE_FOR_LEGAL_REASONS(451, "Unavailable for Legal Reason"),
+
+    /** The server has encountered a situation it does not know how to handle. */
     INTERNAL_SERVER_ERROR(500, "Server Error"),
+    /** The request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are GET and HEAD. */
     NOT_IMPLEMENTED(501, "Not Implemented"),
+    /** This error response means that the server, while working as a gateway to get a response needed to handle the request, got an invalid response. */
     BAD_GATEWAY(502, "Bad Gateway"),
+    /** The server is not ready to handle the request. Common causes are a server that is down for maintenance or that is overloaded. */
     SERVICE_UNAVAILABLE(503, "Service Unavailable"),
+    /** This error response is given when the server is acting as a gateway and cannot get a response in time. */
     GATEWAY_TIMEOUT(504, "Gateway Timeout"),
+    /** The HTTP version used in the request is not supported by the server. */
     HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
+    /** The method could not be performed on the resource because the server is unable to store the representation needed to successfully complete the request. */
     INSUFFICIENT_STORAGE(507, "Insufficient Storage"),
+    /** The server detected an infinite loop while processing the request. */
     LOOP_DETECTED(508, "Loop Detected"),
+    /** Indicates that the client needs to authenticate to gain network access. */
     NETWORK_AUTHENTICATION_REQUIRED(511, "Network Authentication Required"),
+    /** An unknown status code */
     UNKNOWN(-1, "Unknown HTTP code");
 
-    fun isInformational(): Boolean =
-        code in 100..199
+    /** Checks if the status code is informational: the request was received, continuing process */
+    fun isInformational(): Boolean = code in 100..199
+    /** Checks if the status code indicates success: the request was successfully received, understood, and accepted */
+    fun isSuccess(): Boolean = code in 200..299
+    /** Checks if the status code indicates a redirection: further action needs to be taken in order to complete the request */
+    fun isRedirection(): Boolean = code in 300..399
+    /** Checks if the status code indicates a client error: the request contains bad syntax or cannot be fulfilled */
+    fun isClientError(): Boolean = code in 400..499
+    /** Checks if the status code indicates a server error: the server failed to fulfil an apparently valid request*/
+    fun isServerError(): Boolean = code in 500..599
+    /** Checks if the status code indicates an error. */
+    fun isError(): Boolean = isClientError() || isServerError()
 
-    fun isSuccess(): Boolean =
-        code in 200..299
-
-    fun isRedirection(): Boolean =
-        code in 300..399
-
-    fun isClientError(): Boolean =
-        code in 400..499
-
-    fun isServerError(): Boolean =
-        code in 500..599
-
-    fun isError(): Boolean =
-        isClientError() || isServerError()
-
-    override fun toString(): String =
-        "$code $message"
+    override fun toString(): String = "$code $message"
 
     companion object {
 

--- a/javalin/src/main/java/io/javalin/http/RequestLogger.java
+++ b/javalin/src/main/java/io/javalin/http/RequestLogger.java
@@ -16,5 +16,12 @@ import org.jetbrains.annotations.NotNull;
  */
 @FunctionalInterface
 public interface RequestLogger {
+    /**
+     * Handles a request
+     *
+     * @param ctx             the current request context
+     * @param executionTimeMs the requests' execution time in milliseconds
+     * @throws Exception any exception while logging information about the request
+     */
     void handle(@NotNull Context ctx, @NotNull Float executionTimeMs) throws Exception;
 }

--- a/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
@@ -1,12 +1,38 @@
 package io.javalin.http.staticfiles
 
+import io.javalin.config.StaticFilesConfig
 import io.javalin.http.ContentType
 import io.javalin.http.Header
 import jakarta.servlet.http.HttpServletRequest
 import org.eclipse.jetty.server.handler.ContextHandler.AliasCheck
 
-enum class Location { CLASSPATH, EXTERNAL; }
+/**
+ * The static files location
+ */
+enum class Location {
+    /**
+     * Static resources are available in the classpath (jar)
+     */
+    CLASSPATH,
 
+    /**
+     * Static resources are external (on the file system)
+     */
+    EXTERNAL;
+}
+
+/**
+ * The configuration for Static Files.
+ * @param hostedPath change to host files on a subpath, like '/assets' (default: '/')
+ * @param directory the directory where your files are located
+ * @param location Location.CLASSPATH (jar) or Location.EXTERNAL (file system) (default: CLASSPATH)
+ * @param precompress if the files should be pre-compressed and cached in memory (default: false)
+ * @param aliasCheck can be used to configure SymLinks
+ * @param headers headers that will be set for the static files
+ * @param skipFileFunction lambda to skip certain files in the dir, based on the HttpServletRequest
+ * @param mimeTypes configuration for file extension based Mime Types
+ * @see [StaticFilesConfig]
+ */
 data class StaticFileConfig(
     @JvmField var hostedPath: String = "/",
     @JvmField var directory: String = "/public",
@@ -18,23 +44,42 @@ data class StaticFileConfig(
     @JvmField val mimeTypes: MimeTypesConfig = MimeTypesConfig()
 ) {
     internal fun refinedToString(): String {
-        return this.toString().replace(", skipFileFunction=(jakarta.servlet.http.HttpServletRequest) -> kotlin.Boolean", "")
+        return this.toString()
+            .replace(", skipFileFunction=(jakarta.servlet.http.HttpServletRequest) -> kotlin.Boolean", "")
     }
 }
 
+/**
+ * Configures static files Mime Types based on file extensions.
+ */
 class MimeTypesConfig {
     private val extensionToMimeType: MutableMap<String, String> = mutableMapOf()
 
     fun getMapping(): Map<String, String> = extensionToMimeType.toMap()
 
+    /**
+     * Adds a known content type to this configuration.
+     * @param contentType the content type to add
+     */
     fun add(contentType: ContentType) {
         add(contentType.mimeType, *contentType.extensions)
     }
 
+    /**
+     * Adds a MimeType for custom file extensions.
+     * @param contentType the content type to add
+     * @param extensions the extensions to use the given content type
+     */
     fun add(contentType: ContentType, vararg extensions: String) {
         add(contentType.mimeType, *extensions)
     }
 
+
+    /**
+     * Adds a MimeType for custom file extensions.
+     * @param mimeType the mime type to add
+     * @param extensions the extensions to use the given mime type
+     */
     fun add(mimeType: String, vararg extensions: String) {
         extensions.forEach { ext ->
             extensionToMimeType[ext] = mimeType

--- a/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
@@ -6,13 +6,9 @@ import io.javalin.http.Header
 import jakarta.servlet.http.HttpServletRequest
 import org.eclipse.jetty.server.handler.ContextHandler.AliasCheck
 
-/**
- * The static files location
- */
+/** The static files location. */
 enum class Location {
-    /**
-     * Static resources are available in the classpath (jar)
-     */
+    /** Static resources are available in the classpath (jar) */
     CLASSPATH,
 
     /**
@@ -44,14 +40,11 @@ data class StaticFileConfig(
     @JvmField val mimeTypes: MimeTypesConfig = MimeTypesConfig()
 ) {
     internal fun refinedToString(): String {
-        return this.toString()
-            .replace(", skipFileFunction=(jakarta.servlet.http.HttpServletRequest) -> kotlin.Boolean", "")
+        return this.toString().replace(", skipFileFunction=(jakarta.servlet.http.HttpServletRequest) -> kotlin.Boolean", "")
     }
 }
 
-/**
- * Configures static files Mime Types based on file extensions.
- */
+/** Configures static files Mime Types based on file extensions.*/
 class MimeTypesConfig {
     private val extensionToMimeType: MutableMap<String, String> = mutableMapOf()
 

--- a/javalin/src/main/java/io/javalin/plugin/bundled/CorsPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/CorsPlugin.kt
@@ -23,6 +23,9 @@ import io.javalin.router.JavalinDefaultRouting.Companion.Default
 import java.util.*
 import java.util.function.Consumer
 
+/**
+ * Configuration for the [CorsPlugin]
+ */
 class CorsPluginConfig {
     internal val rules = mutableListOf<CorsRule>()
 
@@ -77,6 +80,9 @@ class CorsPluginConfig {
     }
 }
 
+/**
+ * The CORS plugin bundles the functionality to set CORS headers for some or all origins as required.
+ */
 class CorsPlugin(userConfig: Consumer<CorsPluginConfig>? = null) : Plugin<CorsPluginConfig>(userConfig, CorsPluginConfig()) {
 
     init {

--- a/javalin/src/main/java/io/javalin/plugin/bundled/CorsPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/CorsPlugin.kt
@@ -23,9 +23,7 @@ import io.javalin.router.JavalinDefaultRouting.Companion.Default
 import java.util.*
 import java.util.function.Consumer
 
-/**
- * Configuration for the [CorsPlugin]
- */
+/** Configuration for the [CorsPlugin]*/
 class CorsPluginConfig {
     internal val rules = mutableListOf<CorsRule>()
 
@@ -80,9 +78,7 @@ class CorsPluginConfig {
     }
 }
 
-/**
- * The CORS plugin bundles the functionality to set CORS headers for some or all origins as required.
- */
+/** The CORS plugin bundles the functionality to set CORS headers for some or all origins as required.*/
 class CorsPlugin(userConfig: Consumer<CorsPluginConfig>? = null) : Plugin<CorsPluginConfig>(userConfig, CorsPluginConfig()) {
 
     init {

--- a/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/DevLoggerPlugin.kt
@@ -12,6 +12,11 @@ import io.javalin.websocket.WsContext
 import java.util.*
 import java.util.stream.Stream
 
+/**
+ * The development debugging logger catches most of the interesting stuff about requests and responses,
+ * and logs it in an easy to read manner. It works both for HTTP and WebSocket requests. Only intended
+ * for use during development and/or debugging.
+ */
 internal open class DevLoggingPlugin : Plugin<Void>() {
 
     override fun onInitialize(config: JavalinConfig) {

--- a/javalin/src/main/java/io/javalin/plugin/bundled/GlobalHeadersPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/GlobalHeadersPlugin.kt
@@ -32,9 +32,7 @@ class GlobalHeadersPlugin(userConfig: Consumer<GlobalHeadersConfig>? = null) : P
 
 }
 
-/**
- * The Configuration for the [GlobalHeadersPlugin].
- */
+/** The Configuration for the [GlobalHeadersPlugin]. */
 class GlobalHeadersConfig {
 
     /** The headers to add to each request. */
@@ -57,18 +55,11 @@ class GlobalHeadersConfig {
             if (includeSubdomains) " ; includeSubDomains" else ""
     }
 
-    /**
-     * X-Frame-Options policy
-     */
+    /** X-Frame-Options policy */
     enum class XFrameOptions {
-        /**
-         * The page cannot be displayed in a frame, regardless of the site attempting to do so.
-         */
+        /** The page cannot be displayed in a frame, regardless of the site attempting to do so. */
         DENY,
-
-        /**
-         * The page can only be displayed if all ancestor frames are same origin to the page itself.
-         */
+        /** The page can only be displayed if all ancestor frames are same origin to the page itself. */
         SAMEORIGIN;
     }
 
@@ -134,33 +125,17 @@ class GlobalHeadersConfig {
         headers[Header.CONTENT_SECURITY_POLICY] = contentSecurityPolicy
     }
 
-    /**
-     *  X-Permitted-Cross-Domain-Policies
-     */
+    /** X-Permitted-Cross-Domain-Policies */
     enum class CrossDomainPolicy {
-        /**
-         * Will prevent the browser from MIME-sniffing a response away from the declared content-type.
-         */
+        /** Will prevent the browser from MIME-sniffing a response away from the declared content-type. */
         NONE,
-
-        /**
-         * Only this master policy file is allowed.
-         */
+        /** Only this master policy file is allowed. */
         MASTER_ONLY,
-
-        /**
-         * Only policy files served with Content-Type: text/x-cross-domain-policy are allowed.
-         */
+        /** Only policy files served with Content-Type: text/x-cross-domain-policy are allowed. */
         BY_CONTENT_TYPE,
-
-        /**
-         * Only policy files whose filenames are crossdomain.xml (i.e. URLs ending in /crossdomain.xml) are allowed.
-         */
+        /** Only policy files whose filenames are crossdomain.xml (i.e. URLs ending in /crossdomain.xml) are allowed. */
         BY_FTP_FILENAME,
-
-        /**
-         * All policy files on this target domain are allowed.
-         */
+        /** All policy files on this target domain are allowed. */
         ALL;
     }
 
@@ -179,57 +154,35 @@ class GlobalHeadersConfig {
         headers[Header.X_PERMITTED_CROSS_DOMAIN_POLICIES] = policy.name.toHttpHeaderValue()
     }
 
-    /**
-     * Referrer-Policy
-     */
+    /** Referrer-Policy */
     enum class ReferrerPolicy {
-        /**
-         * The Referer header will be omitted: sent requests do not include any referrer information.
-         */
+        /** The Referer header will be omitted: sent requests do not include any referrer information. */
         NO_REFERRER,
-
         /**
          * Send the origin, path, and querystring in Referer when the protocol security level stays
          * the same or improves (HTTP→HTTP, HTTP→HTTPS, HTTPS→HTTPS). Don't send the Referer header
          * for requests to less secure destinations (HTTPS→HTTP, HTTPS→file).
          */
         NO_REFERRER_WHEN_DOWNGRADE,
-
-        /**
-         * Send only the origin in the Referer header. For example, a document at
-         * https://example.com/page.html will send the referrer https://example.com/.
-         */
+        /** Send only the origin in the Referer header. For example, a document at https://example.com/page.html will send the referrer https://example.com/. */
         ORIGIN,
-
         /**
          * When performing a same-origin request to the same protocol level (HTTP→HTTP, HTTPS→HTTPS),
          * send the origin, path, and query string. Send only the origin for cross-origin requests
          * and requests to less secure destinations (HTTPS→HTTP).
          */
         ORIGIN_WHEN_CROSS_ORIGIN,
-
-        /**
-         * Send the origin, path, and query string for same-origin requests. Don't send the Referer
-         * header for cross-origin requests.
-         */
+        /** Send the origin, path, and query string for same-origin requests. Don't send the Referer header for cross-origin requests. */
         SAME_ORIGIN,
-
-        /**
-         * Send only the origin when the protocol security level stays the same (HTTPS→HTTPS).
-         * Don't send the Referer header to less secure destinations (HTTPS→HTTP).
-         */
+        /** Send only the origin when the protocol security level stays the same (HTTPS→HTTPS). Don't send the Referer header to less secure destinations (HTTPS→HTTP). */
         STRICT_ORIGIN,
-
         /**
          * Send the origin, path, and querystring when performing a same-origin request. For cross-origin
          * requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS).
          * Don't send the Referer header to less secure destinations (HTTPS→HTTP).
          */
         STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-
-        /**
-         * Send the origin, path, and query string when performing any request, regardless of security.
-         */
+        /** Send the origin, path, and query string when performing any request, regardless of security. */
         UNSAFE_URL;
     }
 
@@ -247,9 +200,7 @@ class GlobalHeadersConfig {
         headers[Header.REFERRER_POLICY] = policy.name.toHttpHeaderValue()
     }
 
-    /**
-     * Directive for the Clear-Site-Data header.
-     */
+    /** Directive for the Clear-Site-Data header. */
     enum class ClearSiteData(name: String, val headerValue: String = '"' + name + '"') {
         /**
          * Indicates that the server wishes to remove locally cached data (the browser cache) for
@@ -257,7 +208,6 @@ class GlobalHeadersConfig {
          * like pre-rendered pages, script caches, WebGL shader caches, or address bar suggestions.
          */
         CACHE("cache"),
-
         /**
          * Indicates that the server wishes to remove all cookies for the origin of the response URL.
          * HTTP authentication credentials are also cleared out. This affects the entire registered
@@ -265,7 +215,6 @@ class GlobalHeadersConfig {
          * will have cookies cleared.
          */
         COOKIES("cookies"),
-
         /**
          * Indicates that the server wishes to remove all DOM storage for the origin of the response URL.
          * This includes storage mechanisms such as:localStorage, sessionStorage, IndexedDB,
@@ -273,13 +222,8 @@ class GlobalHeadersConfig {
          * Plugin data.
          */
         STORAGE("storage"),
-
-        /**
-         * Indicates that the server wishes to reload all browsing contexts for the origin
-         * of the response.
-         */
+        /** Indicates that the server wishes to reload all browsing contexts for the origin of the response. */
         EXECUTION_CONTEXTS("executionContexts"),
-
         /**
          * Indicates that the server wishes to clear all types of data for the origin of
          * the response. If more data types are added in future versions of this header,
@@ -303,16 +247,10 @@ class GlobalHeadersConfig {
         headers[Header.CLEAR_SITE_DATA] = data.joinToString(",", transform = ClearSiteData::headerValue)
     }
 
-    /**
-     *  Cross-Origin-Embedder-Policy
-     */
+    /** Cross-Origin-Embedder-Policy */
     enum class CrossOriginEmbedderPolicy {
-        /**
-         * This is the default value. Allows the document to fetch cross-origin resources without
-         * giving explicit permission through the CORS protocol or the Cross-Origin-Resource-Policy header.
-         */
+        /** This is the default value. Allows the document to fetch cross-origin resources without giving explicit permission through the CORS protocol or the Cross-Origin-Resource-Policy header. */
         UNSAFE_NONE,
-
         /**
          * A document can only load resources from the same origin, or resources explicitly marked as
          * loadable from another origin. If a cross-origin resource supports CORS, the cross-origin
@@ -336,26 +274,13 @@ class GlobalHeadersConfig {
         headers[Header.CROSS_ORIGIN_EMBEDDER_POLICY] = policy.name.toHttpHeaderValue()
     }
 
-    /**
-     *  Cross-Origin-Opener-Policy
-     */
+    /** Cross-Origin-Opener-Policy */
     enum class CrossOriginOpenerPolicy {
-        /**
-         * This is the default value. Allows the document to be added to its opener's browsing
-         * context group unless the opener itself has a COOP of same-origin or same-origin-allow-popups.
-         */
+        /** This is the default value. Allows the document to be added to its opener's browsing context group unless the opener itself has a COOP of same-origin or same-origin-allow-popups. */
         UNSAFE_NONE,
-
-        /**
-         * Retains references to newly opened windows or tabs that either don't set COOP or that opt out
-         * of isolation by setting a COOP of unsafe-none.
-         */
+        /** Retains references to newly opened windows or tabs that either don't set COOP or that opt out of isolation by setting a COOP of unsafe-none. */
         SAME_ORIGIN_ALLOW_POPUPS,
-
-        /**
-         * Isolates the browsing context exclusively to same-origin documents. Cross-origin documents
-         * are not loaded in the same browsing context.
-         */
+        /** Isolates the browsing context exclusively to same-origin documents. Cross-origin documents are not loaded in the same browsing context. */
         SAME_ORIGIN;
     }
 
@@ -373,24 +298,13 @@ class GlobalHeadersConfig {
         headers[Header.CROSS_ORIGIN_OPENER_POLICY] = policy.name.toHttpHeaderValue()
     }
 
-    /**
-     * Cross-Origin Resource Policy
-     */
+    /** Cross-Origin Resource Policy */
     enum class CrossOriginResourcePolicy {
-        /**
-         * Only requests from the same Site can read the resource.
-         */
+        /** Only requests from the same Site can read the resource. */
         SAME_SITE,
-
-        /**
-         * Only requests from the same origin (i.e. scheme + host + port) can read the resource.
-         */
+        /** Only requests from the same origin (i.e. scheme + host + port) can read the resource. */
         SAME_ORIGIN,
-
-        /**
-         * Requests from any origin (both same-site and cross-site) can read the resource.
-         * This is useful when COEP is used.
-         */
+        /** Requests from any origin (both same-site and cross-site) can read the resource. This is useful when COEP is used. */
         CROSS_ORIGIN;
     }
 

--- a/javalin/src/main/java/io/javalin/plugin/bundled/GlobalHeadersPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/GlobalHeadersPlugin.kt
@@ -14,6 +14,10 @@ import java.time.Duration
 import java.util.Locale
 import java.util.function.Consumer
 
+/**
+ * A plugin to configure arbitrary headers, with a focus on the OWASP secure headers project
+ * https://owasp.org/www-project-secure-headers/
+ */
 class GlobalHeadersPlugin(userConfig: Consumer<GlobalHeadersConfig>? = null) : Plugin<GlobalHeadersConfig>(userConfig, GlobalHeadersConfig()) {
 
     override fun onStart(config: JavalinConfig) {
@@ -29,96 +33,379 @@ class GlobalHeadersPlugin(userConfig: Consumer<GlobalHeadersConfig>? = null) : P
 }
 
 /**
- * A plugin to configure arbitrary headers, with a focus on the OWASP secure headers project
- * https://owasp.org/www-project-secure-headers/
+ * The Configuration for the [GlobalHeadersPlugin].
  */
 class GlobalHeadersConfig {
 
+    /** The headers to add to each request. */
     val headers = mutableMapOf<String, String>()
 
-    // Strict-Transport-Security: max-age=31536000 ; includeSubDomains
+    /**
+     * Adds a Strict-Transport-Security header.
+     *
+     * The HTTP Strict-Transport-Security response header (often abbreviated as HSTS) informs browsers
+     * that the site should only be accessed using HTTPS, and that any future attempts to access it
+     * using HTTP should automatically be converted to HTTPS.
+     * e.g.: `Strict-Transport-Security: max-age=31536000 ; includeSubDomains`
+     *
+     * @param duration The time, in seconds, that the browser should remember that a site is only
+     * to be accessed using HTTPS.
+     * @param includeSubdomains if true, this rule applies to all of the site's subdomains as well.
+     */
     fun strictTransportSecurity(duration: Duration, includeSubdomains: Boolean) {
         headers[Header.STRICT_TRANSPORT_SECURITY] = "max-age=" + duration.seconds +
             if (includeSubdomains) " ; includeSubDomains" else ""
     }
 
-    // X-Frame-Options: deny | sameorigin | allow-from: DOMAIN
+    /**
+     * X-Frame-Options policy
+     */
     enum class XFrameOptions {
-        DENY, SAMEORIGIN;
+        /**
+         * The page cannot be displayed in a frame, regardless of the site attempting to do so.
+         */
+        DENY,
+
+        /**
+         * The page can only be displayed if all ancestor frames are same origin to the page itself.
+         */
+        SAMEORIGIN;
     }
 
+    /**
+     * Adds an X-Frame-Options header.
+     *
+     * The X-Frame-Options HTTP response header can be used to indicate whether or not a browser
+     * should be allowed to render a page in a <frame>, <iframe>, <embed> or <object>. Sites can use
+     * this to avoid click-jacking attacks, by ensuring that their content is not embedded into other sites.
+     *
+     * e.g.: `X-Frame-Options DENY | SAMEORIGIN`
+     *
+     * @param xFrameOptions the option to use
+     */
     fun xFrameOptions(xFrameOptions: XFrameOptions) {
         headers[Header.X_FRAME_OPTIONS] = xFrameOptions.name.toHttpHeaderValue()
     }
 
+    /**
+     * Adds an X-Frame-Options header.
+     *
+     * The X-Frame-Options HTTP response header can be used to indicate whether or not a browser
+     * should be allowed to render a page in a <frame>, <iframe>, <embed> or <object>. Sites can use
+     * this to avoid click-jacking attacks, by ensuring that their content is not embedded into other sites.
+     *
+     * e.g.: `X-Frame-Options ALLOW-FROM origin`
+     *
+     * @param domain the domain to allow
+     */
+    @Deprecated("This is an obsolete directive that no longer works in modern browsers.")
     fun xFrameOptions(domain: String) {
         headers[Header.X_FRAME_OPTIONS] = "allow-from: $domain"
     }
 
-    // X-Content-Type-Options: nosniff
+    /**
+     * Adds a "No Sniff" X-Content-Type-Options header.
+     *
+     * The X-Content-Type-Options response HTTP header is a marker used by the server to indicate
+     * that the MIME types advertised in the Content-Type headers should be followed and not be
+     * changed. The header allows you to avoid MIME type sniffing by saying that the MIME types
+     * are deliberately configured.
+     *
+     * Blocks a request if the request destination is of type style and the MIME type is not text/css,
+     * or of type script and the MIME type is not a JavaScript MIME type.
+     *
+     * i.e.: `X-Content-Type-Options: nosniff`
+     */
     fun xContentTypeOptionsNoSniff() {
         headers[Header.X_CONTENT_TYPE_OPTIONS] = "nosniff"
     }
 
-    // Content-Security-Policy: String... + JAVADOC
+    /**
+     * Adds the Content-Security-Policy header.
+     *
+     * The HTTP Content-Security-Policy response header allows website administrators to control
+     * resources the user agent is allowed to load for a given page. With a few exceptions, policies
+     * mostly involve specifying server origins and script endpoints. This helps guard against cross-site
+     * scripting attacks (Cross-site_scripting).
+     *
+     * e.g.: `Content-Security-Policy: <policy-directive>; <policy-directive>`
+     */
     fun contentSecurityPolicy(contentSecurityPolicy: String) {
         headers[Header.CONTENT_SECURITY_POLICY] = contentSecurityPolicy
     }
 
-    // X-Permitted-Cross-Domain-Policies: none | master-only | by-content-type | by-ftp-filename | all
+    /**
+     *  X-Permitted-Cross-Domain-Policies
+     */
     enum class CrossDomainPolicy {
-        NONE, MASTER_ONLY, BY_CONTENT_TYPE, BY_FTP_FILENAME, ALL;
+        /**
+         * Will prevent the browser from MIME-sniffing a response away from the declared content-type.
+         */
+        NONE,
+
+        /**
+         * Only this master policy file is allowed.
+         */
+        MASTER_ONLY,
+
+        /**
+         * Only policy files served with Content-Type: text/x-cross-domain-policy are allowed.
+         */
+        BY_CONTENT_TYPE,
+
+        /**
+         * Only policy files whose filenames are crossdomain.xml (i.e. URLs ending in /crossdomain.xml) are allowed.
+         */
+        BY_FTP_FILENAME,
+
+        /**
+         * All policy files on this target domain are allowed.
+         */
+        ALL;
     }
 
+    /**
+     * Adds the X-Permitted-Cross-Domain-Policies header.
+     *
+     * This header is used to limit which data external resources, such as Adobe Flash and PDF documents,
+     * can access on the domain. Failure to set the X-Permitted- Cross-Domain-Policies header to “none”
+     * value allows other domains to embed the application’s data in their content.
+     *
+     * e.g.: `X-Permitted-Cross-Domain-Policies: none | master-only | by-content-type | by-ftp-filename | all`
+     *
+     * @param policy the policy to use
+     */
     fun xPermittedCrossDomainPolicies(policy: CrossDomainPolicy) {
         headers[Header.X_PERMITTED_CROSS_DOMAIN_POLICIES] = policy.name.toHttpHeaderValue()
     }
 
-    // Referrer-Policy: no-referrer | no-referrer-when-downgrade | origin | origin-when-cross-origin | same-origin | strict-origin | strict-origin-when-cross-origin | unsafe-url
+    /**
+     * Referrer-Policy
+     */
     enum class ReferrerPolicy {
-        NO_REFERRER, NO_REFERRER_WHEN_DOWNGRADE, ORIGIN, ORIGIN_WHEN_CROSS_ORIGIN, SAME_ORIGIN, STRICT_ORIGIN, STRICT_ORIGIN_WHEN_CROSS_ORIGIN, UNSAFE_URL;
+        /**
+         * The Referer header will be omitted: sent requests do not include any referrer information.
+         */
+        NO_REFERRER,
+
+        /**
+         * Send the origin, path, and querystring in Referer when the protocol security level stays
+         * the same or improves (HTTP→HTTP, HTTP→HTTPS, HTTPS→HTTPS). Don't send the Referer header
+         * for requests to less secure destinations (HTTPS→HTTP, HTTPS→file).
+         */
+        NO_REFERRER_WHEN_DOWNGRADE,
+
+        /**
+         * Send only the origin in the Referer header. For example, a document at
+         * https://example.com/page.html will send the referrer https://example.com/.
+         */
+        ORIGIN,
+
+        /**
+         * When performing a same-origin request to the same protocol level (HTTP→HTTP, HTTPS→HTTPS),
+         * send the origin, path, and query string. Send only the origin for cross-origin requests
+         * and requests to less secure destinations (HTTPS→HTTP).
+         */
+        ORIGIN_WHEN_CROSS_ORIGIN,
+
+        /**
+         * Send the origin, path, and query string for same-origin requests. Don't send the Referer
+         * header for cross-origin requests.
+         */
+        SAME_ORIGIN,
+
+        /**
+         * Send only the origin when the protocol security level stays the same (HTTPS→HTTPS).
+         * Don't send the Referer header to less secure destinations (HTTPS→HTTP).
+         */
+        STRICT_ORIGIN,
+
+        /**
+         * Send the origin, path, and querystring when performing a same-origin request. For cross-origin
+         * requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS).
+         * Don't send the Referer header to less secure destinations (HTTPS→HTTP).
+         */
+        STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+
+        /**
+         * Send the origin, path, and query string when performing any request, regardless of security.
+         */
+        UNSAFE_URL;
     }
 
+    /**
+     * Adds a Referrer-Policy header.
+     *
+     * The Referrer-Policy HTTP header controls how much referrer information (sent with the Referer header)
+     * should be included with requests. Aside from the HTTP header, you can set this policy in HTML.
+     *
+     * e.g.: `Referrer-Policy: no-referrer`
+     *
+     * @param policy the policy to use
+     */
     fun referrerPolicy(policy: ReferrerPolicy) {
         headers[Header.REFERRER_POLICY] = policy.name.toHttpHeaderValue()
     }
 
-    // Clear-Site-Data: "cache" | "cookies" | "storage" | "executionContexts" | "*"
+    /**
+     * Directive for the Clear-Site-Data header.
+     */
     enum class ClearSiteData(name: String, val headerValue: String = '"' + name + '"') {
+        /**
+         * Indicates that the server wishes to remove locally cached data (the browser cache) for
+         * the origin of the response URL. Depending on the browser, this might also clear out things
+         * like pre-rendered pages, script caches, WebGL shader caches, or address bar suggestions.
+         */
         CACHE("cache"),
+
+        /**
+         * Indicates that the server wishes to remove all cookies for the origin of the response URL.
+         * HTTP authentication credentials are also cleared out. This affects the entire registered
+         * domain, including subdomains. So https://example.com as well as https://stage.example.com,
+         * will have cookies cleared.
+         */
         COOKIES("cookies"),
+
+        /**
+         * Indicates that the server wishes to remove all DOM storage for the origin of the response URL.
+         * This includes storage mechanisms such as:localStorage, sessionStorage, IndexedDB,
+         * Service worker registrations, Web SQL databases (deprecated), FileSystem API data,
+         * Plugin data.
+         */
         STORAGE("storage"),
+
+        /**
+         * Indicates that the server wishes to reload all browsing contexts for the origin
+         * of the response.
+         */
         EXECUTION_CONTEXTS("executionContexts"),
+
+        /**
+         * Indicates that the server wishes to clear all types of data for the origin of
+         * the response. If more data types are added in future versions of this header,
+         * they will also be covered by it.
+         */
         ANY("*");
     }
 
+    /**
+     * Adds a Clear-Site-Data header.
+     *
+     * The Clear-Site-Data header clears browsing data (cookies, storage, cache) associated with the
+     * requesting website. It allows web developers to have more control over the data stored by a
+     * client browser for their origins.
+     *
+     * e.g.: `Clear-Site-Data: "cache", "cookies"`
+     *
+     * @param data a vararg list of directives about which data should be cleared
+     */
     fun clearSiteData(vararg data: ClearSiteData) {
         headers[Header.CLEAR_SITE_DATA] = data.joinToString(",", transform = ClearSiteData::headerValue)
     }
 
-    // Cross-Origin-Embedder-Policy: require-corp | unsafe-none
+    /**
+     *  Cross-Origin-Embedder-Policy
+     */
     enum class CrossOriginEmbedderPolicy {
-        UNSAFE_NONE, REQUIRE_CORP;
+        /**
+         * This is the default value. Allows the document to fetch cross-origin resources without
+         * giving explicit permission through the CORS protocol or the Cross-Origin-Resource-Policy header.
+         */
+        UNSAFE_NONE,
+
+        /**
+         * A document can only load resources from the same origin, or resources explicitly marked as
+         * loadable from another origin. If a cross-origin resource supports CORS, the cross-origin
+         * attribute or the Cross-Origin-Resource-Policy header must be used to load it without
+         * being blocked by COEP.
+         */
+        REQUIRE_CORP;
     }
 
+    /**
+     * Adds a Cross-Origin-Embedder-Policy (COEP) header.
+     *
+     * The HTTP Cross-Origin-Embedder-Policy (COEP) response header configures embedding cross-origin
+     * resources into the document.
+     *
+     * e.g.: `Cross-Origin-Embedder-Policy: require-corp | unsafe-none`
+     *
+     * @param policy the policy to use
+     */
     fun crossOriginEmbedderPolicy(policy: CrossOriginEmbedderPolicy) {
         headers[Header.CROSS_ORIGIN_EMBEDDER_POLICY] = policy.name.toHttpHeaderValue()
     }
 
-    // Cross-Origin-Opener-Policy: unsafe-none	| same-origin-allow-popups	| same-origin
+    /**
+     *  Cross-Origin-Opener-Policy
+     */
     enum class CrossOriginOpenerPolicy {
-        UNSAFE_NONE, SAME_ORIGIN_ALLOW_POPUPS, SAME_ORIGIN;
+        /**
+         * This is the default value. Allows the document to be added to its opener's browsing
+         * context group unless the opener itself has a COOP of same-origin or same-origin-allow-popups.
+         */
+        UNSAFE_NONE,
+
+        /**
+         * Retains references to newly opened windows or tabs that either don't set COOP or that opt out
+         * of isolation by setting a COOP of unsafe-none.
+         */
+        SAME_ORIGIN_ALLOW_POPUPS,
+
+        /**
+         * Isolates the browsing context exclusively to same-origin documents. Cross-origin documents
+         * are not loaded in the same browsing context.
+         */
+        SAME_ORIGIN;
     }
 
+    /**
+     * Adds a Cross-Origin-Opener-Policy (COOP) header.
+     *
+     * The HTTP Cross-Origin-Opener-Policy (COOP) response header allows you to ensure a top-level
+     * document does not share a browsing context group with cross-origin documents.
+     *
+     * e.g.: Cross-Origin-Opener-Policy: unsafe-none | same-origin-allow-popups | same-origin`
+     *
+     * @param policy the policy to use
+     */
     fun crossOriginOpenerPolicy(policy: CrossOriginOpenerPolicy) {
         headers[Header.CROSS_ORIGIN_OPENER_POLICY] = policy.name.toHttpHeaderValue()
     }
 
-    // Cross-Origin-Resource-Policy: same-site | same-origin | cross-origin
+    /**
+     * Cross-Origin Resource Policy
+     */
     enum class CrossOriginResourcePolicy {
-        SAME_SITE, SAME_ORIGIN, CROSS_ORIGIN;
+        /**
+         * Only requests from the same Site can read the resource.
+         */
+        SAME_SITE,
+
+        /**
+         * Only requests from the same origin (i.e. scheme + host + port) can read the resource.
+         */
+        SAME_ORIGIN,
+
+        /**
+         * Requests from any origin (both same-site and cross-site) can read the resource.
+         * This is useful when COEP is used.
+         */
+        CROSS_ORIGIN;
     }
 
+    /**
+     * Adds a Cross-Origin Resource Policy (CORP) header.
+     *
+     * Cross-Origin Resource Policy is a policy set by the Cross-Origin-Resource-Policy HTTP header
+     * that lets websites and applications opt in to protection against certain requests from other
+     * origins (such as those issued with elements like <script> and <img>), to mitigate speculative
+     * side-channel attacks, like Spectre, as well as Cross-Site Script Inclusion attacks.
+     *
+     * e.g.: `Cross-Origin-Resource-Policy: same-site | same-origin | cross-origin`
+     *
+     * @param policy the policy to use
+     */
     fun crossOriginResourcePolicy(policy: CrossOriginResourcePolicy) {
         headers[Header.CROSS_ORIGIN_RESOURCE_POLICY] = policy.name.toHttpHeaderValue()
     }

--- a/javalin/src/main/java/io/javalin/plugin/bundled/HttpAllowedMethodsPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/HttpAllowedMethodsPlugin.kt
@@ -11,6 +11,14 @@ import io.javalin.http.HandlerType.OPTIONS
 import io.javalin.http.Header.ACCESS_CONTROL_ALLOW_METHODS
 import io.javalin.plugin.Plugin
 
+/**
+ * Plugin adding automatically the Access-Control-Allow-Methods when sending an OPTIONS request to a valid path.
+ *
+ * The Access-Control-Allow-Methods response header specifies one or more methods allowed when accessing
+ * a resource in response to a preflight request.
+ *
+ * e.g.: `Access-Control-Allow-Methods: POST, DELETE`
+ */
 open class HttpAllowedMethodsPlugin : Plugin<Void>() {
 
     override fun onStart(config: JavalinConfig) {

--- a/javalin/src/main/java/io/javalin/plugin/bundled/RouteOverviewPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/RouteOverviewPlugin.kt
@@ -17,10 +17,7 @@ class RouteOverviewPluginConfig {
     @JvmField var roles: Array<out RouteRole> = emptyArray()
 }
 
-/**
- * The route overview plugin provides you with a HTML and/or JSON overview of all the routes
- * registered on your Javalin application.
- */
+/** The route overview plugin provides you with a HTML and/or JSON overview of all the routes registered on your Javalin application. */
 class RouteOverviewPlugin(userConfig: Consumer<RouteOverviewPluginConfig>? = null) : Plugin<RouteOverviewPluginConfig>(userConfig, RouteOverviewPluginConfig()) {
 
     override fun onStart(config: JavalinConfig) {

--- a/javalin/src/main/java/io/javalin/plugin/bundled/RouteOverviewPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/RouteOverviewPlugin.kt
@@ -17,6 +17,10 @@ class RouteOverviewPluginConfig {
     @JvmField var roles: Array<out RouteRole> = emptyArray()
 }
 
+/**
+ * The route overview plugin provides you with a HTML and/or JSON overview of all the routes
+ * registered on your Javalin application.
+ */
 class RouteOverviewPlugin(userConfig: Consumer<RouteOverviewPluginConfig>? = null) : Plugin<RouteOverviewPluginConfig>(userConfig, RouteOverviewPluginConfig()) {
 
     override fun onStart(config: JavalinConfig) {

--- a/javalin/src/main/java/io/javalin/rendering/FileRenderer.kt
+++ b/javalin/src/main/java/io/javalin/rendering/FileRenderer.kt
@@ -11,6 +11,9 @@ import io.javalin.http.Context
  * Interface for creating renderers to be used with [Context.render].
  */
 fun interface FileRenderer {
+    /**
+     * Renders the given file
+     */
     fun render(filePath: String, model: Map<String, Any?>, context: Context): String
 }
 

--- a/javalin/src/main/java/io/javalin/rendering/FileRenderer.kt
+++ b/javalin/src/main/java/io/javalin/rendering/FileRenderer.kt
@@ -7,13 +7,9 @@ package io.javalin.rendering
 
 import io.javalin.http.Context
 
-/**
- * Interface for creating renderers to be used with [Context.render].
- */
+/** Interface for creating renderers to be used with [Context.render].  */
 fun interface FileRenderer {
-    /**
-     * Renders the given file
-     */
+    /** Renders the given file  */
     fun render(filePath: String, model: Map<String, Any?>, context: Context): String
 }
 

--- a/javalin/src/main/java/io/javalin/vue/JavalinVueConfig.kt
+++ b/javalin/src/main/java/io/javalin/vue/JavalinVueConfig.kt
@@ -1,5 +1,6 @@
 package io.javalin.vue
 
+import io.javalin.config.JavalinConfig
 import io.javalin.http.Context
 import io.javalin.http.servlet.isLocalhost
 import io.javalin.http.staticfiles.Location
@@ -8,6 +9,11 @@ import java.nio.file.Paths
 
 const val JAVALINVUE_CONFIG_KEY = "javalin-javalinvue-config"
 
+/**
+ * Configuration for the Vue plugin.
+ * @see [JavalinConfig.vue]
+ * @see [Online Doc](https://javalin.io/plugins/javalinvue)
+ */
 class JavalinVueConfig {
     //@formatter:off
     @get:JvmSynthetic @set:JvmSynthetic internal var pathMaster = VuePathMaster(this)


### PR DESCRIPTION
This PR adds Javadoc/KDoc documentation on public classes, data classes, functions and enums to make it easier to use from IDEs. 

Fixes #2016 

Specifically:  

- [x] JavalinConfig + all classes in the `io.javalin.config` package
- [x] Bundled plugin configs
- [x] EventManager
- [x] `RequestLogger#handle`, `Handler#handle`, `ExceptionHandler#handle`
- [x] `FileRenderer#render`
- [x] `Cookie` 
- [x] `ContentType`  and `HandlerType` enums (among others)

> [!NOTE]
> Most documentation text was copy-pasted from the [MDN Docs](https://developer.mozilla.org/en-US/docs) pages, and the Javalin documentation pages. 