### PR TITLE
[config] Add a possibility to disable startup watcher

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -88,7 +88,10 @@ public class Javalin implements JavalinDefaultRoutingApi<Javalin> {
      * @see Javalin#start()
      */
     public static Javalin createAndStart(Consumer<JavalinConfig> config) {
-        return create(config).start();
+        return create(cfg -> {
+            cfg.startupWatcherEnabled = false;
+            config.accept(cfg);
+        }).start();
     }
 
     // Get JavalinServlet (can be attached to other servlet containers)

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -37,6 +37,11 @@ class JavalinConfig {
     @JvmField var useVirtualThreads = false
     @JvmField var showJavalinBanner = true
     /**
+     * By default, Javalin will print a warning after 5s if you create a Javalin instance without starting it.
+     * You can disable this behavior by setting this to false.
+     */
+    @JvmField var startupWatcherEnabled = true
+    /**
      * This is "private", only use it if you know what you're doing
      */
     @JvmField val pvt = PrivateConfig(this)

--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -32,20 +32,22 @@ import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS
 import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.util.thread.ThreadPool
-import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer
 
 class JettyServer(private val cfg: JavalinConfig) {
 
     init {
         MimeTypes.getInferredEncodings()[ContentType.PLAIN] = Charsets.UTF_8.name() // set default encoding for text/plain
-        Thread {
-            Thread.sleep(5000)
-            if (!started) {
-                JavalinLogger.startup("It looks like you created a Javalin instance, but you never started it.")
-                JavalinLogger.startup("Try: Javalin app = Javalin.create().start();")
-                JavalinLogger.startup("For more help, visit https://javalin.io/documentation#server-setup")
-            }
-        }.start()
+
+        if (cfg.startupWatcherEnabled) {
+            Thread {
+                Thread.sleep(5000)
+                if (!started) {
+                    JavalinLogger.startup("It looks like you created a Javalin instance, but you never started it.")
+                    JavalinLogger.startup("Try: Javalin app = Javalin.create().start();")
+                    JavalinLogger.startup("For more help, visit https://javalin.io/documentation#server-setup")
+                }
+            }.start()
+        }
     }
 
     fun server() = cfg.pvt.jetty.server ?: defaultServer(cfg.jetty.threadPool).also { cfg.pvt.jetty.server = it } // make sure config has access to the update server instance


### PR DESCRIPTION
Currently, Javalin notifies users that the app instance hasn't been started. Indeed, it is user-friendly behavior for `app.create().start()`, but has some drawbacks:

1. It spawns a new thread just for that one functionality - it's problematic for apps that try to run on low resources, the startup procedure of JVM, libraries & the app itself highly pressures GC & heap at this particular time
2. On slow machines, like e.g. concurrent tests on CI on ARM targets may not be able to actually start a server in 5s (especially when config scope grows and e.g. tries to establish a connection to db)
3. It's not useful anymore for `createAndStart` 