### PR TITLE
[validation] Allow access to internal validation exception (#2047)

### DIFF
--- a/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
+++ b/javalin/src/main/java/io/javalin/validation/BaseValidator.kt
@@ -6,13 +6,14 @@
 
 package io.javalin.validation
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.javalin.util.JavalinLogger
 import io.javalin.util.javalinLazy
 
 typealias Check<T> = (T) -> Boolean
 
 data class Rule<T>(val fieldName: String, val check: Check<T?>, val error: ValidationError<T>)
-data class ValidationError<T> @JvmOverloads constructor(val message: String, val args: Map<String, Any?> = mapOf(), var value: Any? = null)
+data class ValidationError<T> @JvmOverloads constructor(val message: String, val args: Map<String, Any?> = mapOf(), var value: Any? = null, @JsonIgnore val privateDetails: Map<String, Any?>? = null)
 class ValidationException(val errors: Map<String, List<ValidationError<Any>>>) : RuntimeException()
 
 data class Params<T>(
@@ -32,7 +33,7 @@ open class BaseValidator<T> internal constructor(protected val params: Params<T>
         } catch (e: Exception) {
             if (this is BodyValidator) {
                 JavalinLogger.info("Couldn't deserialize body to ${params.clazz?.simpleName}", e)
-                return@javalinLazy mapOf(REQUEST_BODY to listOf(ValidationError("DESERIALIZATION_FAILED", value = params.stringValue)))
+                return@javalinLazy mapOf(REQUEST_BODY to listOf(ValidationError("DESERIALIZATION_FAILED", value = params.stringValue, privateDetails = mapOf("exception" to e))))
             } else {
                 JavalinLogger.info("Couldn't convert param '${params.fieldName}' with value '${params.stringValue}' to ${params.clazz?.simpleName}")
                 return@javalinLazy mapOf(params.fieldName to listOf(ValidationError("TYPE_CONVERSION_FAILED", value = params.stringValue)))


### PR DESCRIPTION
This PR should provide a backward-compatible way of accessing the parent exception for `DESERIALIZATION_FAILED` validation errors (see #2047).

Since the validation error may contain unwanted/sensible information, we don't want the exception to be automatically
serialized and returned to the end user.

This allows implementing a custom exception handler for generating custom error messages based on internal validation error for whoever is interested in this, without changing anything for existing users.
