### PR TITLE
[servlet] Handle endpoint not found exception via `EndpointNotFound`

### DIFF
--- a/javalin-testtools/src/test/java/io/javalin/testtools/JavaTest.java
+++ b/javalin-testtools/src/test/java/io/javalin/testtools/JavaTest.java
@@ -121,7 +121,7 @@ public class JavaTest {
     public void testing_full_app_works() {
         JavalinTest.test(new JavaApp().app, (server, client) -> {
             assertThat(client.get("/hello").body().string()).isEqualTo("Hello, app!");
-            assertThat(client.get("/hello/").body().string()).isEqualTo(NOT_FOUND.getMessage()); // JavaApp.app won't ignore trailing slashes
+            assertThat(client.get("/hello/").body().string()).isEqualTo("Endpoint GET /hello/ not found"); // JavaApp.app won't ignore trailing slashes
         });
     }
 

--- a/javalin-testtools/src/test/kotlin/io/javalin/testtools/KotlinTest.kt
+++ b/javalin-testtools/src/test/kotlin/io/javalin/testtools/KotlinTest.kt
@@ -100,7 +100,7 @@ class KotlinTest {
     @Test
     fun `testing full app works`() = JavalinTest.test(KotlinApp.app) { server, client ->
         assertThat(client.get("/hello").body?.string()).isEqualTo("Hello, app!");
-        assertThat(client.get("/hello/").body?.string()).isEqualTo(NOT_FOUND.message); // KotlinApp.app won't ignore trailing slashes
+        assertThat(client.get("/hello/").body?.string()).isEqualTo("Endpoint GET /hello/ not found"); // KotlinApp.app won't ignore trailing slashes
     }
 
     val javalinTest = TestTool(TestConfig(false))

--- a/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
@@ -7,6 +7,7 @@ import io.javalin.http.MethodNotAllowedResponse
 import io.javalin.http.NotFoundResponse
 import io.javalin.http.servlet.SubmitOrder.LAST
 import io.javalin.http.util.MethodNotAllowedUtil
+import io.javalin.router.EndpointNotFound
 import io.javalin.security.RouteRole
 import io.javalin.util.Util.firstOrNull
 import io.javalin.util.javalinLazy
@@ -57,7 +58,7 @@ object DefaultTasks {
             if (servlet.cfg.http.prefer405over404 && availableHandlerTypes.isNotEmpty()) {
                 throw MethodNotAllowedResponse(details = MethodNotAllowedUtil.getAvailableHandlerTypes(ctx, availableHandlerTypes))
             }
-            throw NotFoundResponse()
+            throw EndpointNotFound(method = ctx.method(), path = requestUri)
         })
     }
 

--- a/javalin/src/main/java/io/javalin/router/Endpoint.kt
+++ b/javalin/src/main/java/io/javalin/router/Endpoint.kt
@@ -3,7 +3,9 @@ package io.javalin.router
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.http.HandlerType
+import io.javalin.http.NotFoundResponse
 import io.javalin.security.RouteRole
+import org.eclipse.jetty.http.HttpMethod
 
 /**
  * Represents an HTTP endpoint in the application.
@@ -39,3 +41,8 @@ open class Endpoint @JvmOverloads constructor(
 fun interface EndpointExecutor {
     fun execute(endpoint: Endpoint): Context
 }
+
+class EndpointNotFound(
+    method: HandlerType,
+    path: String
+) : NotFoundResponse("Endpoint ${method.name} $path not found")

--- a/javalin/src/main/java/io/javalin/router/matcher/ParserExceptions.kt
+++ b/javalin/src/main/java/io/javalin/router/matcher/ParserExceptions.kt
@@ -1,6 +1,5 @@
 package io.javalin.router.matcher
 
-
 class MissingBracketsException(segment: String, val path: String) : IllegalArgumentException(
     "This segment '$segment' is missing some brackets! Found in path '$path'"
 )

--- a/javalin/src/test/java/io/javalin/TestBeforeAfterMatched.kt
+++ b/javalin/src/test/java/io/javalin/TestBeforeAfterMatched.kt
@@ -39,7 +39,7 @@ class TestBeforeAfterMatched {
             response,
             path,
             404,
-            "Endpoint $path not found",
+            "Endpoint GET $path not found",
             "",
             "",
             ""
@@ -57,7 +57,7 @@ class TestBeforeAfterMatched {
             response,
             path,
             404,
-            "Endpoint $path not found",
+            "Endpoint GET $path not found",
             "",
             "",
             ""
@@ -75,7 +75,7 @@ class TestBeforeAfterMatched {
             response,
             path,
             404,
-            "Endpoint $path not found",
+            "Endpoint GET $path not found",
             "",
             "",
             ""

--- a/javalin/src/test/java/io/javalin/TestBeforeAfterMatched.kt
+++ b/javalin/src/test/java/io/javalin/TestBeforeAfterMatched.kt
@@ -24,7 +24,7 @@ class TestBeforeAfterMatched {
         app.afterMatched { it.result(it.result() + "-after-matched") }
         app.after { it.result(it.result() + "!") }
 
-        assertThat(http.getBody("/other-path")).isEqualToIgnoringCase("Not Found!")
+        assertThat(http.getBody("/other-path")).isEqualToIgnoringCase("Endpoint GET /other-path not found!")
         assertThat(http.getBody("/hello")).isEqualTo("before-matched-hello-after-matched!")
     }
 
@@ -39,7 +39,7 @@ class TestBeforeAfterMatched {
             response,
             path,
             404,
-            "Not Found",
+            "Endpoint $path not found",
             "",
             "",
             ""
@@ -57,7 +57,7 @@ class TestBeforeAfterMatched {
             response,
             path,
             404,
-            "Not Found",
+            "Endpoint $path not found",
             "",
             "",
             ""
@@ -75,7 +75,7 @@ class TestBeforeAfterMatched {
             response,
             path,
             404,
-            "Not Found",
+            "Endpoint $path not found",
             "",
             "",
             ""
@@ -177,7 +177,7 @@ class TestBeforeAfterMatched {
             it.skipRemainingHandlers()
         }
         app.get("/hello") { it.result("hello") }
-        assertThat(http.getBody("/other-path")).isEqualToIgnoringCase("Not Found")
+        assertThat(http.getBody("/other-path")).isEqualToIgnoringCase("Endpoint GET /other-path not found")
         assertThat(http.getBody("/hello")).isEqualTo("static-before")
     }
 

--- a/javalin/src/test/java/io/javalin/TestFilters.kt
+++ b/javalin/src/test/java/io/javalin/TestFilters.kt
@@ -30,7 +30,7 @@ class TestFilters {
         app.before(TestUtil.okHandler)
         val response = http.call(HttpMethod.GET, "/hello")
         assertThat(response.httpCode()).isEqualTo(NOT_FOUND)
-        assertThat(response.body).isEqualTo(NOT_FOUND.message)
+        assertThat(response.body).isEqualTo("Endpoint GET /hello not found")
     }
 
     @Test
@@ -38,7 +38,7 @@ class TestFilters {
         app.before(TestUtil.okHandler)
         val response = http.call(HttpMethod.POST, "/hello")
         assertThat(response.httpCode()).isEqualTo(NOT_FOUND)
-        assertThat(response.body).isEqualTo(NOT_FOUND.message)
+        assertThat(response.body).isEqualTo("Endpoint POST /hello not found")
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestTrailingSlashes.kt
+++ b/javalin/src/test/java/io/javalin/TestTrailingSlashes.kt
@@ -18,10 +18,11 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.net.URLEncoder
 
-class TestTrailingSlashes {
+internal class TestTrailingSlashes {
+
     private val okHttp = OkHttpClient().newBuilder().build()
-    fun OkHttpClient.getBody(path: String) = this.newCall(Request.Builder().url(path).get().build()).execute().body!!.string()
-    val javalin = Javalin.create { it.router.ignoreTrailingSlashes = false; }
+    private fun OkHttpClient.getBody(path: String) = this.newCall(Request.Builder().url(path).get().build()).execute().body!!.string()
+    private val javalin = Javalin.create { it.router.ignoreTrailingSlashes = false; }
 
     @Test
     fun `trailing slashes are ignored by default`() = TestUtil.test { app, http ->
@@ -92,10 +93,10 @@ class TestTrailingSlashes {
     @Test
     fun `case sensitive urls work`() = TestUtil.test(javalin) { app, http ->
         app.get("/My-Url") { it.result("OK") }
-        assertThat(http.getBody("/MY-URL")).isEqualTo(NOT_FOUND.message)
+        assertThat(http.getBody("/MY-URL")).isEqualTo("Endpoint GET /MY-URL not found")
         assertThat(http.getBody("/My-Url")).isEqualTo("OK")
         app.get("/My-Url/") { it.result("OK/") }
-        assertThat(http.getBody("/MY-URL/")).isEqualTo(NOT_FOUND.message)
+        assertThat(http.getBody("/MY-URL/")).isEqualTo("Endpoint GET /MY-URL/ not found")
         assertThat(http.getBody("/My-Url/")).isEqualTo("OK/")
     }
 
@@ -155,7 +156,7 @@ class TestTrailingSlashes {
     ) { app, http ->
         assertThat(http.getBody("/test/path-param")).isEqualTo("path-param")
         assertThat(http.getBody("/test/path-param/")).isEqualTo("path-param/")
-        assertThat(http.getBody("/test/")).isEqualTo(NOT_FOUND.message)
+        assertThat(http.getBody("/test/")).isEqualTo("Endpoint GET /test/ not found")
         assertThat(http.getBody("/test")).isEqualTo("test")
     }
 

--- a/javalin/src/test/java/io/javalin/staticfiles/TestSinglePageMode.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestSinglePageMode.kt
@@ -89,8 +89,8 @@ class TestSinglePageMode {
 
     @Test
     fun `SinglePageHandler doesn't affect JSON requests - classpath`() = TestUtil.test(rootSinglePageApp_classPath) { _, http ->
-        assertThat(http.jsonGet("/").body).contains(NOT_FOUND.message)
-        assertThat(http.jsonGet("/not-a-file.html").body).contains(NOT_FOUND.message)
+        assertThat(http.jsonGet("/").body).contains("Endpoint GET / not found")
+        assertThat(http.jsonGet("/not-a-file.html").body).contains("Endpoint GET /not-a-file.html not found")
         assertThat(http.jsonGet("/not-a-file.html").httpCode()).isEqualTo(NOT_FOUND)
     }
 
@@ -111,7 +111,7 @@ class TestSinglePageMode {
 
     @Test
     fun `SinglePageHandler works for just subpaths - classpath`() = TestUtil.test(dualSinglePageApp_classPath) { _, http ->
-        assertThat(http.htmlGet("/").body).contains(NOT_FOUND.message)
+        assertThat(http.htmlGet("/").body).contains("Endpoint GET / not found")
         assertThat(http.htmlGet("/").httpCode()).isEqualTo(NOT_FOUND)
         assertThat(http.htmlGet("/admin").body).contains("Secret file")
         assertThat(http.htmlGet("/admin/not-a-path").body).contains("Secret file")

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticDirectorySlash.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticDirectorySlash.kt
@@ -20,8 +20,8 @@ class TestStaticDirectorySlash {
     private val normalJavalin: Javalin by lazy { Javalin.create { it.staticFiles.add("public", Location.CLASSPATH) } }
 
     private val precompressingJavalin: Javalin by lazy {
-        Javalin.create {
-            it.staticFiles.add {
+        Javalin.create { cfg ->
+            cfg.staticFiles.add {
                 it.directory = "public"
                 it.location = Location.CLASSPATH
                 it.precompress = true
@@ -45,13 +45,13 @@ class TestStaticDirectorySlash {
     @Test
     fun `normal Javalin serves files but serves directory if it is a directory`() = TestUtil.test(normalJavalin) { _, http ->
         assertThat(http.getBody("/file")).isEqualTo("TESTFILE") // ok, is file = no slash
-        assertThat(http.getBody("/file/")).isEqualTo(NOT_FOUND.message) // nope, has slash must be directory
+        assertThat(http.getBody("/file/")).isEqualTo("Endpoint GET /file/ not found") // nope, has slash must be directory
     }
 
     @Test
     fun `precompressing Javalin serves files but serves directory if it is a directory`() = TestUtil.test(precompressingJavalin) { _, http ->
         assertThat(http.getBody("/file")).isEqualTo("TESTFILE") // ok, is file = no slash
-        assertThat(http.getBody("/file/")).isEqualTo(NOT_FOUND.message) // nope, has slash must be directory
+        assertThat(http.getBody("/file/")).isEqualTo("Endpoint GET /file/ not found") // nope, has slash must be directory
     }
 
 }

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
@@ -172,7 +172,7 @@ class TestStaticFiles {
     @Test
     fun `directory root returns simple 404 if there is no welcome file`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
         assertThat(http.get("/").httpCode()).isEqualTo(NOT_FOUND)
-        assertThat(http.getBody("/")).isEqualTo(NOT_FOUND.message)
+        assertThat(http.getBody("/")).isEqualTo("Endpoint GET / not found")
     }
 
     @Test


### PR DESCRIPTION
Pros:

1. Provides an easy way to distinguish a non-existing endpoint from a non-existing resource/or other Handler-related response
2. Returns useful error message `Endpoint {http method} {uri} not found` instead of a generic `Not found` value
3. I've simplified & improved `ExceptionMapper` implementation, because it wasn't handling parent classes properly 

Cons:
1. A small change in the previous behavior (error message)

Requested on Discord. 