### PR TITLE
Introduce context extending plugins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 200
 
 [*.java]
 ij_java_names_count_to_use_import_on_demand = 999

--- a/javalin-utils/javalin-context-mock/src/main/java/io/javalin/mock/ContextMock.kt
+++ b/javalin-utils/javalin-context-mock/src/main/java/io/javalin/mock/ContextMock.kt
@@ -129,6 +129,7 @@ class ContextMock private constructor(
     private fun createServletContextConfig(): JavalinServletContextConfig =
         JavalinServletContextConfig(
             appDataManager = mockConfig.javalinConfig.pvt.appDataManager,
+            pluginManager = mockConfig.javalinConfig.pvt.pluginManager,
             compressionStrategy = mockConfig.javalinConfig.pvt.compressionStrategy,
             defaultContentType = mockConfig.javalinConfig.http.defaultContentType,
             jsonMapper = mockConfig.javalinConfig.pvt.jsonMapper.value,

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -12,7 +12,6 @@ import io.javalin.http.util.AsyncExecutor.Companion.AsyncExecutorKey
 import io.javalin.json.JsonMapper
 import io.javalin.plugin.ContextExtendingPlugin
 import io.javalin.plugin.Plugin
-import io.javalin.plugin.PluginKey
 import io.javalin.rendering.FileRenderer
 import io.javalin.rendering.FileRenderer.Companion.FileRendererKey
 import io.javalin.rendering.NotImplementedRenderer
@@ -94,15 +93,6 @@ class JavalinConfig {
      */
     fun <CFG> registerPlugin(plugin: Plugin<CFG>): Plugin<CFG> =
         plugin.also { pvt.pluginManager.register(plugin) }
-
-    /**
-     * Register a context-extending plugin to this Javalin Configuration.
-     * @param T the type of the plugin
-     * @param key the [PluginKey] to use to reference this plugin
-     * @param plugin the [Plugin] to register
-     */
-    fun <T: ContextExtendingPlugin<*, *>> registerPlugin(pluginKey: PluginKey<T>, plugin: T): T =
-        plugin.also { pvt.pluginManager.register(pluginKey, plugin) }
 
     /**
      * Register a new component resolver.

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -10,7 +10,9 @@ import io.javalin.config.ContextResolverConfig.Companion.ContextResolverKey
 import io.javalin.http.servlet.MaxRequestSize.MaxRequestSizeKey
 import io.javalin.http.util.AsyncExecutor.Companion.AsyncExecutorKey
 import io.javalin.json.JsonMapper
+import io.javalin.plugin.ContextExtendingPlugin
 import io.javalin.plugin.Plugin
+import io.javalin.plugin.PluginKey
 import io.javalin.rendering.FileRenderer
 import io.javalin.rendering.FileRenderer.Companion.FileRendererKey
 import io.javalin.rendering.NotImplementedRenderer
@@ -86,11 +88,21 @@ class JavalinConfig {
 
     /**
      * Register a plugin to this Javalin Configuration.
+     * If registering a ContextExtendingPlugin, this will use register the plugin's ancestor classes as well.
      * @param CFG the type of the configuration class for the plugin
      * @param plugin the [Plugin] to register
      */
     fun <CFG> registerPlugin(plugin: Plugin<CFG>): Plugin<CFG> =
         plugin.also { pvt.pluginManager.register(plugin) }
+
+    /**
+     * Register a context-extending plugin to this Javalin Configuration.
+     * @param T the type of the plugin
+     * @param key the [PluginKey] to use to reference this plugin
+     * @param plugin the [Plugin] to register
+     */
+    fun <T: ContextExtendingPlugin<*, *>> registerPlugin(pluginKey: PluginKey<T>, plugin: T): T =
+        plugin.also { pvt.pluginManager.register(pluginKey, plugin) }
 
     /**
      * Register a new component resolver.

--- a/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinConfig.kt
@@ -10,7 +10,6 @@ import io.javalin.config.ContextResolverConfig.Companion.ContextResolverKey
 import io.javalin.http.servlet.MaxRequestSize.MaxRequestSizeKey
 import io.javalin.http.util.AsyncExecutor.Companion.AsyncExecutorKey
 import io.javalin.json.JsonMapper
-import io.javalin.plugin.ContextExtendingPlugin
 import io.javalin.plugin.Plugin
 import io.javalin.rendering.FileRenderer
 import io.javalin.rendering.FileRenderer.Companion.FileRendererKey
@@ -87,7 +86,6 @@ class JavalinConfig {
 
     /**
      * Register a plugin to this Javalin Configuration.
-     * If registering a ContextExtendingPlugin, this will use register the plugin's ancestor classes as well.
      * @param CFG the type of the configuration class for the plugin
      * @param plugin the [Plugin] to register
      */

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -87,8 +87,8 @@ interface Context {
 
     /** Fetch the context extension for a plugin */
     fun <T> with(key: PluginKey<out ContextExtendingPlugin<*, T>>): T
-    fun <T> with(klass: Class<out ContextExtendingPlugin<*, T>>): T
-    fun <T> with(klass: KClass<out ContextExtendingPlugin<*, T>>): T = with(klass.java)
+    fun <T> with(clazz: Class<out ContextExtendingPlugin<*, T>>): T
+    fun <T> with(clazz: KClass<out ContextExtendingPlugin<*, T>>): T = with(clazz.java)
 
     ///////////////////////////////////////////////////////////////
     // Request-ish methods

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -25,7 +25,6 @@ import io.javalin.http.util.MultipartUtil
 import io.javalin.http.util.SeekableWriter
 import io.javalin.json.JsonMapper
 import io.javalin.plugin.ContextExtendingPlugin
-import io.javalin.plugin.PluginKey
 import io.javalin.rendering.FileRenderer.Companion.FileRendererKey
 import io.javalin.security.BasicAuthCredentials
 import io.javalin.security.RouteRole
@@ -86,7 +85,6 @@ interface Context {
     ///////////////////////////////////////////////////////////////
 
     /** Fetch the context extension for a plugin */
-    fun <T> with(key: PluginKey<out ContextExtendingPlugin<*, T>>): T
     fun <T> with(clazz: Class<out ContextExtendingPlugin<*, T>>): T
     fun <T> with(clazz: KClass<out ContextExtendingPlugin<*, T>>): T = with(clazz.java)
 

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -24,6 +24,8 @@ import io.javalin.http.util.CookieStore
 import io.javalin.http.util.MultipartUtil
 import io.javalin.http.util.SeekableWriter
 import io.javalin.json.JsonMapper
+import io.javalin.plugin.ContextExtendingPlugin
+import io.javalin.plugin.PluginKey
 import io.javalin.rendering.FileRenderer.Companion.FileRendererKey
 import io.javalin.security.BasicAuthCredentials
 import io.javalin.security.RouteRole
@@ -42,6 +44,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 import java.util.function.Supplier
 import java.util.stream.Stream
+import kotlin.reflect.KClass
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
@@ -77,6 +80,15 @@ interface Context {
 
     /** Get configured [JsonMapper] */
     fun jsonMapper(): JsonMapper
+
+    ///////////////////////////////////////////////////////////////
+    // Plugin-related methods
+    ///////////////////////////////////////////////////////////////
+
+    /** Fetch the context extension for a plugin */
+    fun <T> with(key: PluginKey<out ContextExtendingPlugin<*, T>>): T
+    fun <T> with(klass: Class<out ContextExtendingPlugin<*, T>>): T
+    fun <T> with(klass: KClass<out ContextExtendingPlugin<*, T>>): T = with(klass.java)
 
     ///////////////////////////////////////////////////////////////
     // Request-ish methods

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -21,6 +21,9 @@ import io.javalin.http.HttpStatus
 import io.javalin.http.HttpStatus.CONTENT_TOO_LARGE
 import io.javalin.router.ParsedEndpoint
 import io.javalin.json.JsonMapper
+import io.javalin.plugin.ContextExtendingPlugin
+import io.javalin.plugin.PluginKey
+import io.javalin.plugin.PluginManager
 import io.javalin.security.BasicAuthCredentials
 import io.javalin.security.RouteRole
 import io.javalin.util.JavalinLogger
@@ -41,6 +44,7 @@ import java.util.stream.Stream
 
 data class JavalinServletContextConfig(
     val appDataManager: AppDataManager,
+    val pluginManager: PluginManager,
     val compressionStrategy: CompressionStrategy,
     val requestLoggerEnabled: Boolean,
     val defaultContentType: String,
@@ -50,6 +54,7 @@ data class JavalinServletContextConfig(
         fun of(cfg: JavalinConfig): JavalinServletContextConfig =
             JavalinServletContextConfig(
                 appDataManager = cfg.pvt.appDataManager,
+                pluginManager = cfg.pvt.pluginManager,
                 compressionStrategy = cfg.pvt.compressionStrategy,
                 requestLoggerEnabled = cfg.pvt.requestLogger != null,
                 defaultContentType = cfg.http.defaultContentType,
@@ -101,6 +106,9 @@ class JavalinServletContext(
     override fun res(): HttpServletResponse = res
 
     override fun <T> appData(key: Key<T>): T = cfg.appDataManager.get(key)
+
+    override fun <T> with(key: PluginKey<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(key as PluginKey<ContextExtendingPlugin<*, T>>).withContextExtension(this)
+    override fun <T> with(klass: Class<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(klass).withContextExtension(this)
 
     override fun jsonMapper(): JsonMapper = cfg.jsonMapper
 

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -22,7 +22,6 @@ import io.javalin.http.HttpStatus.CONTENT_TOO_LARGE
 import io.javalin.router.ParsedEndpoint
 import io.javalin.json.JsonMapper
 import io.javalin.plugin.ContextExtendingPlugin
-import io.javalin.plugin.PluginKey
 import io.javalin.plugin.PluginManager
 import io.javalin.security.BasicAuthCredentials
 import io.javalin.security.RouteRole
@@ -107,9 +106,7 @@ class JavalinServletContext(
 
     override fun <T> appData(key: Key<T>): T = cfg.appDataManager.get(key)
 
-    override fun <T> with(key: PluginKey<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(key as PluginKey<ContextExtendingPlugin<*, T>>).withContextExtension(this)
-
-    override fun <T> with(clazz: Class<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(clazz).withContextExtension(this)
+    override fun <T> with(clazz: Class<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.getContextPlugin(clazz).withContextExtension(this)
 
     override fun jsonMapper(): JsonMapper = cfg.jsonMapper
 

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -60,7 +60,7 @@ data class JavalinServletContextConfig(
                 defaultContentType = cfg.http.defaultContentType,
                 jsonMapper = cfg.pvt.jsonMapper.value,
             )
-        }
+    }
 }
 
 class JavalinServletContext(
@@ -108,7 +108,8 @@ class JavalinServletContext(
     override fun <T> appData(key: Key<T>): T = cfg.appDataManager.get(key)
 
     override fun <T> with(key: PluginKey<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(key as PluginKey<ContextExtendingPlugin<*, T>>).withContextExtension(this)
-    override fun <T> with(klass: Class<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(klass).withContextExtension(this)
+
+    override fun <T> with(clazz: Class<out ContextExtendingPlugin<*, T>>) = cfg.pluginManager.fromKey(clazz).withContextExtension(this)
 
     override fun jsonMapper(): JsonMapper = cfg.jsonMapper
 
@@ -147,6 +148,7 @@ class JavalinServletContext(
     internal val outputStreamWrapper = javalinLazy(SYNCHRONIZED) {
         CompressedOutputStream(minSizeForCompression, cfg.compressionStrategy, this)
     }
+
     override fun outputStream(): ServletOutputStream = outputStreamWrapper.value
 
     override fun minSizeForCompression(minSizeForCompression: Int) = also {

--- a/javalin/src/main/java/io/javalin/plugin/PluginApi.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginApi.kt
@@ -1,6 +1,7 @@
 package io.javalin.plugin
 
 import io.javalin.config.JavalinConfig
+import io.javalin.http.Context
 import java.util.function.Consumer
 
 enum class PluginPriority {
@@ -53,4 +54,17 @@ abstract class Plugin<CONFIG>(userConfig: Consumer<CONFIG>? = null, defaultConfi
         }
         defaultConfig.also { userConfig?.accept(it) }
     }
+}
+
+/**
+ * This class allows registering multiple copies of a repeatable context extending plugin. Instances of this class can
+ * then be used to fetch extensions from the correct instance of the plugin in handlers.
+ */
+class PluginKey<T : ContextExtendingPlugin<*, *>>
+
+abstract class ContextExtendingPlugin<CONFIG, CTX_EXT>(
+    userConfig: Consumer<CONFIG>? = null,
+    defaultConfig: CONFIG? = null
+) : Plugin<CONFIG>(userConfig, defaultConfig) {
+    abstract fun withContextExtension(context: Context): CTX_EXT
 }

--- a/javalin/src/main/java/io/javalin/plugin/PluginApi.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginApi.kt
@@ -56,15 +56,12 @@ abstract class Plugin<CONFIG>(userConfig: Consumer<CONFIG>? = null, defaultConfi
     }
 }
 
-/**
- * This class allows registering multiple copies of a repeatable context extending plugin. Instances of this class can
- * then be used to fetch extensions from the correct instance of the plugin in handlers.
- */
-class PluginKey<T : ContextExtendingPlugin<*, *>>
-
 abstract class ContextExtendingPlugin<CONFIG, CTX_EXT>(
     userConfig: Consumer<CONFIG>? = null,
     defaultConfig: CONFIG? = null
 ) : Plugin<CONFIG>(userConfig, defaultConfig) {
+    /** Context extending plugins cannot be repeatable, as they are keyed by class */
+    final override fun repeatable(): Boolean = false
+
     abstract fun withContextExtension(context: Context): CTX_EXT
 }

--- a/javalin/src/main/java/io/javalin/plugin/PluginExceptions.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginExceptions.kt
@@ -6,7 +6,5 @@ abstract class PluginException(pluginClass: Class<out Plugin<*>>, override val m
 data class PluginAlreadyRegisteredException(val plugin: Plugin<*>) :
     PluginException(plugin::class.java, "${plugin.name()} is already registered")
 
-data class PluginKeyAlreadyRegisteredException(val plugin: Plugin<*>) :
-    PluginException(plugin::class.java, "${plugin.name()} is already registered with the same key")
-
-class PluginNotRegisteredException : IllegalStateException("Requested plugin was not registered at startup")
+class PluginNotRegisteredException(pluginClass: Class<out Plugin<*>>) :
+    PluginException(pluginClass, "${pluginClass.canonicalName} was not registered as a plugin at startup")

--- a/javalin/src/main/java/io/javalin/plugin/PluginExceptions.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginExceptions.kt
@@ -9,4 +9,4 @@ data class PluginAlreadyRegisteredException(val plugin: Plugin<*>) :
 data class PluginKeyAlreadyRegisteredException(val plugin: Plugin<*>) :
     PluginException(plugin::class.java, "${plugin.name()} is already registered with the same key")
 
-class PluginNotRegisteredException : RuntimeException("Requested plugin was not registered at startup")
+class PluginNotRegisteredException : IllegalStateException("Requested plugin was not registered at startup")

--- a/javalin/src/main/java/io/javalin/plugin/PluginExceptions.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginExceptions.kt
@@ -5,3 +5,8 @@ abstract class PluginException(pluginClass: Class<out Plugin<*>>, override val m
 
 data class PluginAlreadyRegisteredException(val plugin: Plugin<*>) :
     PluginException(plugin::class.java, "${plugin.name()} is already registered")
+
+data class PluginKeyAlreadyRegisteredException(val plugin: Plugin<*>) :
+    PluginException(plugin::class.java, "${plugin.name()} is already registered with the same key")
+
+class PluginNotRegisteredException : RuntimeException("Requested plugin was not registered at startup")

--- a/javalin/src/main/java/io/javalin/plugin/PluginManager.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginManager.kt
@@ -20,7 +20,7 @@ class PluginManager internal constructor(private val cfg: JavalinConfig) {
         if (!plugin.repeatable() && plugins.any { it.javaClass == plugin.javaClass }) {
             throw PluginAlreadyRegisteredException(plugin)
         }
-        if(plugin is ContextExtendingPlugin<*, *>) {
+        if (plugin is ContextExtendingPlugin<*, *>) {
             register(null, plugin)
         } else {
             plugins.add(plugin)
@@ -32,8 +32,8 @@ class PluginManager internal constructor(private val cfg: JavalinConfig) {
         var theKey = pluginKey
         // Ensure we map all superclasses that aren't ContextExtendingPlugin since we don't really know which one is "most correct"
         val theClasses: MutableList<Class<*>> = mutableListOf(plugin.javaClass)
-        theClasses.addAll(plugin::class.supertypes.filter {  it.isSubtypeOf(typeOf<ContextExtendingPlugin<*,*>>()) && it.classifier != ContextExtendingPlugin::class }.map { it.jvmErasure.java })
-        if(theClasses.any { contextPluginClasses.containsKey(it) }) {
+        theClasses.addAll(plugin::class.supertypes.filter {it.isSubtypeOf(typeOf<ContextExtendingPlugin<*, *>>()) && it.classifier != ContextExtendingPlugin::class }.map { it.jvmErasure.java })
+        if (theClasses.any { contextPluginClasses.containsKey(it) }) {
             throw PluginKeyAlreadyRegisteredException(plugin)
         }
         if (theKey == null) {
@@ -83,7 +83,7 @@ class PluginManager internal constructor(private val cfg: JavalinConfig) {
     }
 
     fun <T> fromKey(clazz: Class<out ContextExtendingPlugin<*, T>>): ContextExtendingPlugin<*, T> {
-        val pluginKey: PluginKey<ContextExtendingPlugin<*, T>> = (contextPluginClasses[clazz] ?: throw PluginNotRegisteredException()) as PluginKey<ContextExtendingPlugin<*, T>>
+        val pluginKey: PluginKey<ContextExtendingPlugin<*, T>> = (contextPluginClasses[clazz]?: throw PluginNotRegisteredException()) as PluginKey<ContextExtendingPlugin<*, T>>
         return fromKey(pluginKey)
     }
 }

--- a/javalin/src/main/java/io/javalin/plugin/PluginManager.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginManager.kt
@@ -13,44 +13,13 @@ class PluginManager internal constructor(private val cfg: JavalinConfig) {
     private val plugins = mutableListOf<Plugin<*>>()
     private val initializedPlugins = mutableListOf<Plugin<*>>()
     private val enabledPlugins = mutableListOf<Plugin<*>>()
-    private val contextPlugins = mutableMapOf<PluginKey<*>, ContextExtendingPlugin<*, *>>()
-    private val contextPluginClasses = mutableMapOf<Class<*>, PluginKey<*>>()
 
     fun register(plugin: Plugin<*>) {
         if (!plugin.repeatable() && plugins.any { it.javaClass == plugin.javaClass }) {
             throw PluginAlreadyRegisteredException(plugin)
         }
-        if (plugin is ContextExtendingPlugin<*, *>) {
-            register(null, plugin)
-        } else {
-            plugins.add(plugin)
-            initializePlugins()
-        }
-    }
-
-    fun <T : ContextExtendingPlugin<*, *>> register(pluginKey: PluginKey<T>?, plugin: T) {
-        var theKey = pluginKey
-        // Ensure we map all superclasses that aren't ContextExtendingPlugin since we don't really know which one is "most correct"
-        val theClasses: MutableList<Class<*>> = mutableListOf(plugin.javaClass)
-        theClasses.addAll(plugin::class.supertypes.filter {it.isSubtypeOf(typeOf<ContextExtendingPlugin<*, *>>()) && it.classifier != ContextExtendingPlugin::class }.map { it.jvmErasure.java })
-        if (theClasses.any { contextPluginClasses.containsKey(it) }) {
-            throw PluginKeyAlreadyRegisteredException(plugin)
-        }
-        if (theKey == null) {
-            theKey = PluginKey()
-            theClasses.forEach {
-                contextPluginClasses[it] = theKey
-            }
-            // If using class keys make sure it wasn't registered without a class key
-            if (plugins.any { it.javaClass == plugin.javaClass }) {
-                throw PluginAlreadyRegisteredException(plugin)
-            }
-        } else if (contextPlugins.containsKey(theKey)) {
-            throw PluginKeyAlreadyRegisteredException(plugin)
-        }
         plugins.add(plugin)
         initializePlugins()
-        contextPlugins[theKey] = plugin
     }
 
     private fun initializePlugins() {
@@ -78,12 +47,7 @@ class PluginManager internal constructor(private val cfg: JavalinConfig) {
             }
     }
 
-    fun <T> fromKey(pluginKey: PluginKey<out ContextExtendingPlugin<*, T>>): ContextExtendingPlugin<*, T> {
-        return (contextPlugins[pluginKey] ?: throw PluginNotRegisteredException()) as ContextExtendingPlugin<*, T>
-    }
-
-    fun <T> fromKey(clazz: Class<out ContextExtendingPlugin<*, T>>): ContextExtendingPlugin<*, T> {
-        val pluginKey: PluginKey<ContextExtendingPlugin<*, T>> = (contextPluginClasses[clazz]?: throw PluginNotRegisteredException()) as PluginKey<ContextExtendingPlugin<*, T>>
-        return fromKey(pluginKey)
+    fun <T> getContextPlugin(clazz: Class<out ContextExtendingPlugin<*, T>>): ContextExtendingPlugin<*, T> {
+        return (plugins.find { it.javaClass == clazz } ?: throw PluginNotRegisteredException(clazz)) as ContextExtendingPlugin<*, T>
     }
 }

--- a/javalin/src/main/java/io/javalin/plugin/PluginManager.kt
+++ b/javalin/src/main/java/io/javalin/plugin/PluginManager.kt
@@ -1,19 +1,56 @@
 package io.javalin.plugin
 
 import io.javalin.config.JavalinConfig
+import io.javalin.util.parentClass
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.full.isSupertypeOf
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.typeOf
 
 class PluginManager internal constructor(private val cfg: JavalinConfig) {
 
     private val plugins = mutableListOf<Plugin<*>>()
     private val initializedPlugins = mutableListOf<Plugin<*>>()
     private val enabledPlugins = mutableListOf<Plugin<*>>()
+    private val contextPlugins = mutableMapOf<PluginKey<*>, ContextExtendingPlugin<*, *>>()
+    private val contextPluginClasses = mutableMapOf<Class<*>, PluginKey<*>>()
 
     fun register(plugin: Plugin<*>) {
         if (!plugin.repeatable() && plugins.any { it.javaClass == plugin.javaClass }) {
             throw PluginAlreadyRegisteredException(plugin)
         }
+        if(plugin is ContextExtendingPlugin<*, *>) {
+            register(null, plugin)
+        } else {
+            plugins.add(plugin)
+            initializePlugins()
+        }
+    }
+
+    fun <T : ContextExtendingPlugin<*, *>> register(pluginKey: PluginKey<T>?, plugin: T) {
+        var theKey = pluginKey
+        // Ensure we map all superclasses that aren't ContextExtendingPlugin since we don't really know which one is "most correct"
+        val theClasses: MutableList<Class<*>> = mutableListOf(plugin.javaClass)
+        theClasses.addAll(plugin::class.supertypes.filter {  it.isSubtypeOf(typeOf<ContextExtendingPlugin<*,*>>()) && it.classifier != ContextExtendingPlugin::class }.map { it.jvmErasure.java })
+        if(theClasses.any { contextPluginClasses.containsKey(it) }) {
+            throw PluginKeyAlreadyRegisteredException(plugin)
+        }
+        if (theKey == null) {
+            theKey = PluginKey()
+            theClasses.forEach {
+                contextPluginClasses[it] = theKey
+            }
+            // If using class keys make sure it wasn't registered without a class key
+            if (plugins.any { it.javaClass == plugin.javaClass }) {
+                throw PluginAlreadyRegisteredException(plugin)
+            }
+        } else if (contextPlugins.containsKey(theKey)) {
+            throw PluginKeyAlreadyRegisteredException(plugin)
+        }
         plugins.add(plugin)
         initializePlugins()
+        contextPlugins[theKey] = plugin
     }
 
     private fun initializePlugins() {
@@ -41,4 +78,12 @@ class PluginManager internal constructor(private val cfg: JavalinConfig) {
             }
     }
 
+    fun <T> fromKey(pluginKey: PluginKey<out ContextExtendingPlugin<*, T>>): ContextExtendingPlugin<*, T> {
+        return (contextPlugins[pluginKey] ?: throw PluginNotRegisteredException()) as ContextExtendingPlugin<*, T>
+    }
+
+    fun <T> fromKey(clazz: Class<out ContextExtendingPlugin<*, T>>): ContextExtendingPlugin<*, T> {
+        val pluginKey: PluginKey<ContextExtendingPlugin<*, T>> = (contextPluginClasses[clazz] ?: throw PluginNotRegisteredException()) as PluginKey<ContextExtendingPlugin<*, T>>
+        return fromKey(pluginKey)
+    }
 }

--- a/javalin/src/test/java/io/javalin/TestPlugins.kt
+++ b/javalin/src/test/java/io/javalin/TestPlugins.kt
@@ -1,10 +1,16 @@
 package io.javalin
 
 import io.javalin.config.JavalinConfig
+import io.javalin.http.Context
+import io.javalin.http.HttpStatus
+import io.javalin.plugin.ContextExtendingPlugin
 import io.javalin.plugin.Plugin
 import io.javalin.plugin.PluginAlreadyRegisteredException
+import io.javalin.plugin.PluginKey
+import io.javalin.plugin.PluginKeyAlreadyRegisteredException
 import io.javalin.plugin.PluginPriority.EARLY
 import io.javalin.plugin.PluginPriority.LATE
+import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -30,6 +36,22 @@ class TestPlugins {
             calls.add(Calls.START)
         }
     }
+
+    class TestContextExtendingPluginExtension(val context: Context) {
+        fun fancyPath(): String {
+            return context.path() + "_FANCY"
+        }
+    }
+
+    open inner class TestContextExtendingPlugin : ContextExtendingPlugin<Void, TestContextExtendingPluginExtension>() {
+        override fun repeatable(): Boolean  = true
+
+        override fun withContextExtension(context: Context): TestContextExtendingPluginExtension {
+            return TestContextExtendingPluginExtension(context)
+        }
+    }
+
+    var contextPluginKey = PluginKey<TestContextExtendingPlugin>()
 
     @BeforeEach
     fun resetCalls() {
@@ -93,6 +115,67 @@ class TestPlugins {
             assertDoesNotThrow {
                 it.registerPlugin(MultiInstanceTestPlugin())
                 it.registerPlugin(MultiInstanceTestPlugin())
+            }
+        }
+    }
+
+    @Test
+    fun `registerPlugin allows registering context-extending plugins with only classes`() {
+        Javalin.create {
+            it.registerPlugin(TestContextExtendingPlugin())
+
+            assertThatThrownBy {  it.registerPlugin(contextPluginKey, TestContextExtendingPlugin()) }
+                .isInstanceOf(PluginKeyAlreadyRegisteredException::class.java)
+                .hasMessageContaining("TestContextExtendingPlugin is already registered with the same key")
+
+            assertDoesNotThrow {
+                it.pvt.pluginManager.fromKey(TestContextExtendingPlugin::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `registerPlugin registers superclasses of plugins`() {
+        Javalin.create {
+            it.registerPlugin(object : TestContextExtendingPlugin() {
+                fun customFunction() {}
+            })
+
+            assertThatThrownBy { it.registerPlugin(contextPluginKey, TestContextExtendingPlugin()) }
+                .isInstanceOf(PluginKeyAlreadyRegisteredException::class.java)
+                .hasMessageContaining("TestContextExtendingPlugin is already registered with the same key")
+
+            assertDoesNotThrow {
+                it.pvt.pluginManager.fromKey(TestContextExtendingPlugin::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `registerPlugin allows registering context-extending plugins with only keys`() {
+        Javalin.create {
+            it.registerPlugin(contextPluginKey, TestContextExtendingPlugin())
+
+            assertThatThrownBy { it.registerPlugin(TestContextExtendingPlugin()) }
+                .isInstanceOf(PluginAlreadyRegisteredException::class.java)
+                .hasMessageContaining("TestContextExtendingPlugin is already registered")
+
+            assertDoesNotThrow {
+                it.pvt.pluginManager.fromKey(contextPluginKey)
+            }
+        }
+    }
+
+    @Test
+    fun `registerPlugin allows registering context-extending plugins with multiple keys`() {
+        Javalin.create {
+            it.registerPlugin(contextPluginKey, TestContextExtendingPlugin())
+            val anotherPluginKey = PluginKey<TestContextExtendingPlugin>()
+            it.registerPlugin(anotherPluginKey, TestContextExtendingPlugin())
+
+            assertDoesNotThrow {
+                it.pvt.pluginManager.fromKey(contextPluginKey)
+                it.pvt.pluginManager.fromKey(anotherPluginKey)
             }
         }
     }
@@ -196,6 +279,38 @@ class TestPlugins {
         assertThatThrownBy { Javalin.create{ it.registerPlugin(ThrowingPlugin()) }.start() }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Plugin io.javalin.ThrowingPlugin has no config.")
+    }
+
+    @Test
+    fun `Context-extending plugins can be accessed through the Context by class`() = TestUtil.test(Javalin.create {
+        it.registerPlugin(TestContextExtendingPlugin())
+    }) { app, http ->
+        app.get("/abcd") { it.result(it.with(TestContextExtendingPlugin::class).fancyPath()) }
+        assertThat(http.getBody("/abcd")).isEqualTo("/abcd_FANCY")
+    }
+
+    @Test
+    fun `Context-extending anonymous plugins can be accessed through the Context by class`() = TestUtil.test(Javalin.create {
+        it.registerPlugin(object : TestContextExtendingPlugin() {
+            fun myFunction() {}
+        })
+    }) { app, http ->
+        app.get("/abcd") { it.result(it.with(TestContextExtendingPlugin::class).fancyPath()) }
+        assertThat(http.getBody("/abcd")).isEqualTo("/abcd_FANCY")
+    }
+
+    @Test
+    fun `Context-extending plugins can be accessed through the Context by key`() = TestUtil.test(Javalin.create {
+        it.registerPlugin(contextPluginKey, TestContextExtendingPlugin())
+    }) { app, http ->
+        app.get("/abcd") { it.result(it.with(contextPluginKey).fancyPath()) }
+        assertThat(http.getBody("/abcd")).isEqualTo("/abcd_FANCY")
+    }
+
+    @Test
+    fun `Context-extending plugins throw if they are not registered`() = TestUtil.test(Javalin.create {}) { app, http ->
+        app.get("/abcd") { it.result(it.with(contextPluginKey).fancyPath()) }
+        assertThat(http.get("/abcd").status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.code)
     }
 }
 

--- a/javalin/src/test/java/io/javalin/TestPlugins.kt
+++ b/javalin/src/test/java/io/javalin/TestPlugins.kt
@@ -35,15 +35,13 @@ class TestPlugins {
         }
     }
 
-    class TestContextExtendingPluginExtension(val context: Context) {
-        fun fancyPath(): String {
-            return context.path() + "_FANCY"
-        }
-    }
+    open inner class TestContextExtendingPlugin : ContextExtendingPlugin<Void, TestContextExtendingPlugin.Extension>() {
+        override fun withContextExtension(context: Context) = Extension(context)
 
-    open inner class TestContextExtendingPlugin : ContextExtendingPlugin<Void, TestContextExtendingPluginExtension>() {
-        override fun withContextExtension(context: Context): TestContextExtendingPluginExtension {
-            return TestContextExtendingPluginExtension(context)
+        inner class Extension(val context: Context) {
+            fun fancyPath(): String {
+                return context.path() + "_FANCY"
+            }
         }
     }
 

--- a/javalin/src/test/java/io/javalin/TestPlugins.kt
+++ b/javalin/src/test/java/io/javalin/TestPlugins.kt
@@ -44,7 +44,7 @@ class TestPlugins {
     }
 
     open inner class TestContextExtendingPlugin : ContextExtendingPlugin<Void, TestContextExtendingPluginExtension>() {
-        override fun repeatable(): Boolean  = true
+        override fun repeatable(): Boolean = true
 
         override fun withContextExtension(context: Context): TestContextExtendingPluginExtension {
             return TestContextExtendingPluginExtension(context)
@@ -124,7 +124,7 @@ class TestPlugins {
         Javalin.create {
             it.registerPlugin(TestContextExtendingPlugin())
 
-            assertThatThrownBy {  it.registerPlugin(contextPluginKey, TestContextExtendingPlugin()) }
+            assertThatThrownBy { it.registerPlugin(contextPluginKey, TestContextExtendingPlugin()) }
                 .isInstanceOf(PluginKeyAlreadyRegisteredException::class.java)
                 .hasMessageContaining("TestContextExtendingPlugin is already registered with the same key")
 
@@ -269,6 +269,7 @@ class TestPlugins {
         class MyPlugin(userConfig: Consumer<PluginConfig>) : Plugin<PluginConfig>(userConfig, PluginConfig()) {
             val value = pluginConfig.value
         }
+
         val myPlugin = JavalinConfig().registerPlugin(MyPlugin { it.value = "Hello" }) as MyPlugin
         assertThat(myPlugin.value).isEqualTo("Hello")
     }
@@ -276,7 +277,7 @@ class TestPlugins {
 
     @Test
     fun `pluginConfig throws if defaultConfig is null`() {
-        assertThatThrownBy { Javalin.create{ it.registerPlugin(ThrowingPlugin()) }.start() }
+        assertThatThrownBy { Javalin.create { it.registerPlugin(ThrowingPlugin()) }.start() }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Plugin io.javalin.ThrowingPlugin has no config.")
     }
@@ -290,14 +291,15 @@ class TestPlugins {
     }
 
     @Test
-    fun `Context-extending anonymous plugins can be accessed through the Context by class`() = TestUtil.test(Javalin.create {
-        it.registerPlugin(object : TestContextExtendingPlugin() {
-            fun myFunction() {}
-        })
-    }) { app, http ->
-        app.get("/abcd") { it.result(it.with(TestContextExtendingPlugin::class).fancyPath()) }
-        assertThat(http.getBody("/abcd")).isEqualTo("/abcd_FANCY")
-    }
+    fun `Context-extending anonymous plugins can be accessed through the Context by class`() =
+        TestUtil.test(Javalin.create {
+            it.registerPlugin(object : TestContextExtendingPlugin() {
+                fun myFunction() {}
+            })
+        }) { app, http ->
+            app.get("/abcd") { it.result(it.with(TestContextExtendingPlugin::class).fancyPath()) }
+            assertThat(http.getBody("/abcd")).isEqualTo("/abcd_FANCY")
+        }
 
     @Test
     fun `Context-extending plugins can be accessed through the Context by key`() = TestUtil.test(Javalin.create {

--- a/javalin/src/test/java/io/javalin/TestPublicApi_Java.java
+++ b/javalin/src/test/java/io/javalin/TestPublicApi_Java.java
@@ -3,7 +3,6 @@ package io.javalin;
 import io.javalin.config.Key;
 import io.javalin.http.*;
 import io.javalin.plugin.ContextExtendingPlugin;
-import io.javalin.plugin.PluginKey;
 import io.javalin.plugin.bundled.CorsPlugin;
 import io.javalin.validation.ValidationError;
 import io.javalin.validation.Validator;
@@ -29,14 +28,6 @@ public class TestPublicApi_Java {
         }
     }
 
-    static public PluginKey<TestContextExtendingPlugin2> pluginKey = new PluginKey<>();
-
-    static public class TestContextExtendingPlugin2 extends ContextExtendingPlugin<Void, String> {
-        public String withContextExtension(Context context) {
-            return context.path();
-        }
-    }
-
     public static void main(String[] args) {
         Javalin.create(/*config*/)
             .get("/", ctx -> ctx.result("Hello World"))
@@ -52,7 +43,6 @@ public class TestPublicApi_Java {
                 });
             }));
             config.registerPlugin(new TestContextExtendingPlugin());
-            config.registerPlugin(pluginKey, new TestContextExtendingPlugin2());
             config.http.asyncTimeout = 10_000L;
             config.router.apiBuilder(() -> {
                 path("users", () -> {
@@ -230,7 +220,6 @@ public class TestPublicApi_Java {
             ctx.endpointHandlerPath();
             ctx.cookieStore();
             ctx.with(TestContextExtendingPlugin.class);
-            ctx.with(pluginKey);
         });
     }
 

--- a/javalin/src/test/java/io/javalin/TestPublicApi_Java.java
+++ b/javalin/src/test/java/io/javalin/TestPublicApi_Java.java
@@ -1,11 +1,10 @@
 package io.javalin;
 
 import io.javalin.config.Key;
-import io.javalin.http.ContentType;
-import io.javalin.http.Cookie;
-import io.javalin.http.HttpStatus;
+import io.javalin.http.*;
+import io.javalin.plugin.ContextExtendingPlugin;
+import io.javalin.plugin.PluginKey;
 import io.javalin.plugin.bundled.CorsPlugin;
-import io.javalin.http.Context;
 import io.javalin.validation.ValidationError;
 import io.javalin.validation.Validator;
 import io.javalin.websocket.WsConfig;
@@ -24,6 +23,19 @@ import static io.javalin.apibuilder.ApiBuilder.ws;
 
 // @formatter:off
 public class TestPublicApi_Java {
+    static public class TestContextExtendingPlugin extends ContextExtendingPlugin<Void, HandlerType> {
+        public HandlerType withContextExtension(Context context) {
+            return context.method();
+        }
+    }
+
+    static public PluginKey<TestContextExtendingPlugin2> pluginKey = new PluginKey<>();
+
+    static public class TestContextExtendingPlugin2 extends ContextExtendingPlugin<Void, String> {
+        public String withContextExtension(Context context) {
+            return context.path();
+        }
+    }
 
     public static void main(String[] args) {
         Javalin.create(/*config*/)
@@ -39,6 +51,8 @@ public class TestPublicApi_Java {
                     rule.allowHost("https://images.local");
                 });
             }));
+            config.registerPlugin(new TestContextExtendingPlugin());
+            config.registerPlugin(pluginKey, new TestContextExtendingPlugin2());
             config.http.asyncTimeout = 10_000L;
             config.router.apiBuilder(() -> {
                 path("users", () -> {
@@ -215,6 +229,8 @@ public class TestPublicApi_Java {
             ctx.matchedPath();
             ctx.endpointHandlerPath();
             ctx.cookieStore();
+            ctx.with(TestContextExtendingPlugin.class);
+            ctx.with(pluginKey);
         });
     }
 


### PR DESCRIPTION
This is another attempt at the concept of #2054

This PR introduces the `ContextExtendingPlugin` interface, which extends the normal `Plugin` interface and adds a required `withContextExtension` method which consumes a `Context` object and returns a "context extension", which can be an object of any type but is intended to be a context-related object to use fluently like `ctx.with(MyCustomRenderingPlugin).fancyRender(model)`

`with` was chosen as the method name because it makes the expression read fluidly.  Plugins are almost always named like `WhateverPlugin`, so it's easy to tell when reading usages that it is plugin related, and it reads more fluently and less repetitively than `ctx.plugin(MyCustomRenderingPlugin).fancyRender(model)`.  The way this is coupled to plugins and uses the class of the plugin rather than the class of the returned extension should encourage usage for "pluggable Javalin-integrated functionality" rather than for plain DI, which was one of the concerns with the class-oriented API in the original attempts.
