### PR TITLE
disable Loom by default and make its config field visible to Java

### DIFF
--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -19,8 +19,8 @@ import kotlin.concurrent.withLock
 object ConcurrencyUtil {
 
     @Suppress("MemberVisibilityCanBePrivate")
-    // Determines if Javalin should use Loom. By default true, set it to false to disable Loom integration.
-    var useLoom = true
+    // Determines if Javalin should use Loom. By default false, set it to true to enable Loom integration.
+    @JvmField var useLoom = false
 
     @JvmStatic
     fun executorService(name: String): ExecutorService = when (useLoom && isLoomAvailable()) {


### PR DESCRIPTION
Actually disable Loom in Javalin 5 as said in #2011 and expose the corresponding config field to Java.

I don't have much Kotlin knowledge, if the field should be exposed in a different way than with `@JvmField`, let me know, but locally this works for me.