### PR TITLE
Static resources: Print the absolute path when there's a problem

### DIFF
--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
@@ -30,9 +30,10 @@ class TestStaticFilesEdgeCases {
 
     @Test
     fun `server doesn't start for non-existent external folder`() = TestUtil.runLogLess {
+        val workingDirectory = System.getProperty("user.dir")
         assertThatExceptionOfType(RuntimeException::class.java)
             .isThrownBy { Javalin.create { it.staticFiles.add("external-fake-folder", Location.EXTERNAL) }.start(0) }
-            .withMessageContaining("Static resource directory with path: 'external-fake-folder' does not exist.")
+            .withMessageContaining("Static resource directory with path: '$workingDirectory/external-fake-folder' does not exist.")
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import kotlin.io.path.Path
 
 class TestStaticFilesEdgeCases {
 
@@ -30,10 +31,11 @@ class TestStaticFilesEdgeCases {
 
     @Test
     fun `server doesn't start for non-existent external folder`() = TestUtil.runLogLess {
-        val workingDirectory = System.getProperty("user.dir")
+        val workingDirectory = Path(System.getProperty("user.dir"))
+        val fullExternalFakeFolderPath = workingDirectory.resolve("external-fake-folder")
         assertThatExceptionOfType(RuntimeException::class.java)
             .isThrownBy { Javalin.create { it.staticFiles.add("external-fake-folder", Location.EXTERNAL) }.start(0) }
-            .withMessageContaining("Static resource directory with path: '$workingDirectory/external-fake-folder' does not exist.")
+            .withMessageContaining("Static resource directory with path: '$fullExternalFakeFolderPath' does not exist.")
     }
 
     @Test


### PR DESCRIPTION
When the requested, external, static resource path doesn't exist print the normalized absolute path, rather than the value provided by the user. The path may be missing due to an incorrect working directory or other issue that exists at a level higher than the relative path the user gave.