### PR TITLE
Give StaticFileConfig a proper toString

### DIFF
--- a/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
@@ -78,4 +78,6 @@ class MimeTypesConfig {
             extensionToMimeType[ext] = mimeType
         }
     }
+
+    override fun toString(): String = extensionToMimeType.toString()
 }


### PR DESCRIPTION
This gets invoked and presented on the console during startup, and shows which mimetypes are registered for a file extension. Previously, the message included something like 

```
2024-01-09 21:20:03,840 INFO  i.j.Javalin Static file handler added: StaticFileConfig(
hostedPath=/, directory=src/main/resources/public, location=EXTERNAL, precompress=false, 
aliasCheck=null, headers={Cache-Control=max-age=0}, 
mimeTypes=io.javalin.http.staticfiles.MimeTypesConfig@46d567cb). 
File system location: 'src/main/resources/public'
```
Note the **mimeTypes=io.javalin.http.staticfiles.MimeTypesConfig@46d567cb**.

It now is formatted as `mimeTypes={csv=text/csv}`, or just `{}` if it's empty.