### PR TITLE
[routing] Mark RouterConfig.mount(JavalinDefaultRouting) as low priority function

### DIFF
--- a/javalin/src/main/java/io/javalin/config/RouterConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RouterConfig.kt
@@ -45,6 +45,7 @@ class RouterConfig(internal val cfg: JavalinConfig) {
         initializer.initialize(cfg, cfg.pvt.internalRouter) { setup.accept(this) }
     }
 
+    @LowPriorityInOverloadResolution
     fun mount(setup: Consumer<JavalinDefaultRouting>): RouterConfig =
         mount(Default, setup)
 


### PR DESCRIPTION
It allows to overload this method with extension function in other module. We already use this for the other mount function.