### PR TITLE
Check for dot in client side host when using wildcard hosts

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/bundled/CorsUtils.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/CorsUtils.kt
@@ -135,6 +135,10 @@ internal object CorsUtils {
         if (!serverOrigin.host.startsWith("*.")) {
             return false
         }
+        // the above lines imply a requirement of at least one dot in the origin header sent by the client
+        if ('.' !in clientOrigin.host) {
+            return false
+        }
         val serverHostBase = serverOrigin.host.removePrefix("*.")
         val clientHostBase = clientOrigin.host.split('.', limit = 2)[1]
 

--- a/javalin/src/test/java/io/javalin/TestCors.kt
+++ b/javalin/src/test/java/io/javalin/TestCors.kt
@@ -427,6 +427,23 @@ class TestCors {
                 .isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
             assertThat(getResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("https://example.com")
         }
+
+        @Test
+        fun `GH-2104 client sends dotless origin - wildcard configured`() = TestUtil.test(Javalin.create { cfg ->
+            cfg.bundledPlugins.enableCors { cors ->
+                cors.addRule {
+                    it.allowHost("*.example.com")
+                }
+            }
+        }) { app, http ->
+            app.get("/") { it.result("Hello") }
+
+            val response = http.get("/", mapOf(ORIGIN to "https://single"))
+            assertThat(response.status)
+                .describedAs("get status code")
+                .isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isEmpty()
+        }
     }
 
     @Nested


### PR DESCRIPTION
This fixes the Exception as described in #2104.

Will do another PR soon to rewrite it using the JDK's URI class.

Fixes #2104 