### PR TITLE
[cors] Check for dot in client side host when using wildcard hosts (5.x)

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/bundled/CorsUtils.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/CorsUtils.kt
@@ -135,6 +135,10 @@ internal object CorsUtils {
         if (!serverOrigin.host.startsWith("*.")) {
             return false
         }
+        // the above lines imply a requirement of at least one dot in the origin header sent by the client
+        if ('.' !in clientOrigin.host) {
+            return false
+        }
         val serverHostBase = serverOrigin.host.removePrefix("*.")
         val clientHostBase = clientOrigin.host.split('.', limit = 2)[1]
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
         <junit.version>5.7.2</junit.version>
         <mockito.version>4.6.1</mockito.version>
         <unirest.version>3.13.10</unirest.version>
-        <selenium.chrome.driver.version>4.11.0</selenium.chrome.driver.version>
-        <webdrivermanager.version>5.5.0</webdrivermanager.version>
+        <selenium.chrome.driver.version>4.18.1</selenium.chrome.driver.version>
+        <webdrivermanager.version>5.6.4</webdrivermanager.version>
         <swagger.ui.version>4.10.3</swagger.ui.version> <!-- used for testing webjars -->
     </properties>
 


### PR DESCRIPTION
Backport of #2133 for Javalin 5 as discussed on Discord.