### PR TITLE
[cors] Use JDK's URI class

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/bundled/CorsUtils.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/CorsUtils.kt
@@ -1,5 +1,6 @@
 package io.javalin.plugin.bundled
 
+import java.net.URI
 import java.util.*
 
 internal object CorsUtils {
@@ -24,6 +25,8 @@ internal object CorsUtils {
             origin == "null" -> true
             // query strings are not a valid part of an origin
             "?" in origin -> false
+            // fragments are not a valid part of an origin
+            "#" in origin -> false
             // schemes are a required part of an origin
             schemeAndHostDelimiter <= 0 -> false
             !isSchemeValid(origin.subSequence(0, schemeAndHostDelimiter)) -> false
@@ -32,6 +35,30 @@ internal object CorsUtils {
             // if a port is specified is must consist of only digits
             portResult is PortResult.ErrorState -> false
             else -> true
+        }
+    }
+
+    internal fun isValidOriginJdk(origin: String): Boolean {
+        if (origin.isEmpty()) {
+            return false
+        }
+        if (origin == "null") {
+            return true
+        }
+        try {
+            val uri = URI(origin).parseServerAuthority()
+            if (uri.path.isNullOrEmpty().not()) {
+                return false
+            }
+            if (uri.query.isNullOrEmpty().not()) {
+                return false
+            }
+            if (uri.fragment.isNullOrEmpty().not()) {
+                return false
+            }
+            return true
+        } catch (e: Exception) {
+            return false
         }
     }
 

--- a/javalin/src/test/java/io/javalin/TestCorsUtils.kt
+++ b/javalin/src/test/java/io/javalin/TestCorsUtils.kt
@@ -8,87 +8,82 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EmptySource
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 private const val SHAN_ZERO: String = "\u1090" // ႐ MYANMAR SHAN DIGIT ZERO
 private const val BOLD_ZERO: String = "\uD835\uDFCE" // 𝟎 MATHEMATICAL BOLD DIGIT ZERO
+
+internal object CorsArguments {
+    @JvmStatic
+    fun singleSpace(): Stream<String> = Stream.of(" ")
+}
 
 
 class TestCorsUtils {
     @Nested
     inner class IsSchemeValid {
-        @Test
-        fun `accepts valid schemes`() {
-            listOf("http", "https", "hi", "ftp", "sftp", "c007", "a.b.c", "a+b", "a-b").forEach {
-                assertThat(CorsUtils.isSchemeValid(it)).describedAs(it).isTrue
-            }
+
+        @ParameterizedTest
+        @CsvSource(value = ["http", "https", "hi", "ftp", "sftp", "c007", "a.b.c", "a+b", "a-b"])
+        fun `accepts valid schemes`(scheme: String) {
+            assertThat(CorsUtils.isSchemeValid(scheme)).describedAs(scheme).isTrue
         }
 
-        @Test
-        fun `rejects invalid schemes`() {
-            listOf("", " ", "forbidden_underscore", "no-#", "no%", "c-${SHAN_ZERO}", "c-${BOLD_ZERO}").forEach {
-                assertThat(CorsUtils.isSchemeValid(it)).describedAs(it).isFalse
-            }
+        @ParameterizedTest
+        @EmptySource
+        @MethodSource("io.javalin.CorsArguments#singleSpace")
+        @CsvSource(value = ["forbidden_underscore", "no-#", "no%", "c-${SHAN_ZERO}", "c-${BOLD_ZERO}"])
+        fun `rejects invalid schemes`(scheme: String) {
+            assertThat(CorsUtils.isSchemeValid(scheme)).describedAs(scheme).isFalse
         }
     }
 
     @Nested
     inner class IsValidOrigin {
-        @Test
-        fun `accepts valid origins`() {
-            listOf("null", "https://example.com", "https://example.com:8443").forEach {
-                assertThat(CorsUtils.isValidOrigin(it)).describedAs(it).isTrue
-            }
+        @ParameterizedTest
+        @CsvSource(value = ["null", "https://example.com", "https://example.com:8443"])
+        fun `accepts valid origins`(origin: String) {
+            assertThat(CorsUtils.isValidOrigin(origin)).describedAs(origin).isTrue
         }
 
-        @Test
-        fun `rejects invalid origins`() {
-            listOf(
-                "",
-                "https://example.com/",
-                "https://example.com?query=true",
-                "https://example.com:fakeport",
-                "https://example.com:8${SHAN_ZERO}",
-                "https://example.com:8${BOLD_ZERO}"
-            ).forEach {
-                assertThat(CorsUtils.isValidOrigin(it)).describedAs(it).isFalse
-            }
+        @ParameterizedTest
+        @EmptySource
+        @CsvSource(value = ["https://example.com/", "https://example.com?query=true", "https://example.com:fakeport", "https://example.com:8${SHAN_ZERO}", "https://example.com:8${BOLD_ZERO}"])
+        fun `rejects invalid origins`(it: String) {
+            assertThat(CorsUtils.isValidOrigin(it)).describedAs(it).isFalse
         }
     }
 
     @Nested
     inner class ExtractPort {
-        @Test
-        fun `can extract port if specified`() {
-            listOf(
-                "https://example.com:80" to 80,
-                "https://example.com:8443" to 8443
-            ).forEach { (origin, port) ->
-                val portResult = CorsUtils.extractPort(origin) as? PortResult.PortSpecified
-                assertThat(portResult).describedAs("cast successful").isNotNull
-                assertThat(portResult!!.port).describedAs("port").isEqualTo(port)
-                assertThat(portResult.fromSchemeDefault).describedAs("scheme default").isFalse
-            }
+        @ParameterizedTest
+        @CsvSource(
+            value = ["https://example.com:80,80", "https://example.com:8443,8443"]
+        )
+        fun `can extract port if specified`(origin: String, port: Int) {
+            val portResult = CorsUtils.extractPort(origin) as? PortResult.PortSpecified
+            assertThat(portResult).describedAs("cast successful").isNotNull
+            assertThat(portResult!!.port).describedAs("port").isEqualTo(port)
+            assertThat(portResult.fromSchemeDefault).describedAs("scheme default").isFalse
         }
 
-        @Test
-        fun `returns errors for invalid origins`() {
-            listOf(
-                "",
-                "example.com"
-            ).forEach {
-                assertThat(CorsUtils.extractPort(it)).isEqualTo(PortResult.ErrorState.InvalidOrigin)
-            }
+        @ParameterizedTest
+        @EmptySource
+        @CsvSource(value = ["example.com"])
+        fun `returns errors for invalid origins`(origin: String) {
+            assertThat(CorsUtils.extractPort(origin)).isEqualTo(PortResult.ErrorState.InvalidOrigin)
         }
 
-        @Test
-        fun `returns special error for invalid port values`() {
-            listOf(
-                "https://example.com:fakeport",
-                "https://example.com:8${SHAN_ZERO}",
-                "https://example.com:8${BOLD_ZERO}"
-            ).forEach {
-                assertThat(CorsUtils.extractPort(it)).describedAs(it).isEqualTo(PortResult.ErrorState.InvalidPort)
-            }
+        @ParameterizedTest
+        @CsvSource(
+            value = ["https://example.com:fakeport", "https://example.com:8${SHAN_ZERO}", "https://example.com:8${BOLD_ZERO}"]
+        )
+        fun `returns special error for invalid port values`(origin: String) {
+            assertThat(CorsUtils.extractPort(origin)).describedAs(origin).isEqualTo(PortResult.ErrorState.InvalidPort)
         }
 
         @Test
@@ -206,18 +201,12 @@ class TestCorsUtils {
 
     @Nested
     inner class AddSchemeIfMissing {
-        @Test
-        fun works() {
-            listOf(
-                "*" to "*",
-                "null" to "null",
-                "example.com" to "https://example.com",
-                "example.com:8080" to "https://example.com:8080",
-                "EXAMPLE.COM" to "https://example.com",
-                "HTTPS://EXAMPLE.COM/" to "https://example.com"
-            ).forEach { (input, expected) ->
-                assertThat(CorsUtils.addSchemeIfMissing(input, "https")).describedAs(input).isEqualTo(expected)
-            }
+        @ParameterizedTest
+        @CsvSource(
+            value = ["*,*", "null,null", "example.com,https://example.com", "example.com:8080,https://example.com:8080", "EXAMPLE.COM,https://example.com", "HTTPS://EXAMPLE.COM/,https://example.com"]
+        )
+        fun works(input: String, expected: String) {
+            assertThat(CorsUtils.addSchemeIfMissing(input, "https")).describedAs(input).isEqualTo(expected)
         }
     }
 
@@ -225,26 +214,22 @@ class TestCorsUtils {
     inner class WildcardRequirements {
         @Test
         fun `no wildcard origins are okay`() {
-            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://example.com"))
-                .isEqualTo(WildcardResult.NoWildcardDetected)
+            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://example.com")).isEqualTo(WildcardResult.NoWildcardDetected)
         }
 
         @Test
         fun `wildcards at the start of the host are accepted`() {
-            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://*.example.com"))
-                .isEqualTo(WildcardResult.WildcardOkay)
+            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://*.example.com")).isEqualTo(WildcardResult.WildcardOkay)
         }
 
         @Test
         fun `at most one wildcard is allowed`() {
-            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://*.look.*.multiple.wildcards.com"))
-                .isEqualTo(WildcardResult.ErrorState.TooManyWildcards)
+            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://*.look.*.multiple.wildcards.com")).isEqualTo(WildcardResult.ErrorState.TooManyWildcards)
         }
 
         @Test
         fun `wildcards in the middle are not accepted`() {
-            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://subsub.*.example.com"))
-                .isEqualTo(WildcardResult.ErrorState.WildcardNotAtTheStartOfTheHost)
+            assertThat(CorsUtils.originFulfillsWildcardRequirements("https://subsub.*.example.com")).isEqualTo(WildcardResult.ErrorState.WildcardNotAtTheStartOfTheHost)
         }
     }
 }

--- a/javalin/src/test/java/io/javalin/TestCorsUtils.kt
+++ b/javalin/src/test/java/io/javalin/TestCorsUtils.kt
@@ -52,9 +52,22 @@ class TestCorsUtils {
 
         @ParameterizedTest
         @EmptySource
-        @CsvSource(value = ["https://example.com/", "https://example.com?query=true", "https://example.com:fakeport", "https://example.com:8${SHAN_ZERO}", "https://example.com:8${BOLD_ZERO}"])
+        @CsvSource(value = ["https://example.com/", "https://example.com?query=true", "https://example.com:fakeport", "https://example.com:8${SHAN_ZERO}", "https://example.com:8${BOLD_ZERO}", "https://example.com#fragment"])
         fun `rejects invalid origins`(it: String) {
             assertThat(CorsUtils.isValidOrigin(it)).describedAs(it).isFalse
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = ["null", "https://example.com", "https://example.com:8443"])
+        fun `accepts valid origins JDK`(origin: String) {
+            assertThat(CorsUtils.isValidOriginJdk(origin)).describedAs(origin).isTrue
+        }
+
+        @ParameterizedTest
+        @EmptySource
+        @CsvSource(value = ["https://example.com/", "https://example.com?query=true", "https://example.com:fakeport", "https://example.com:8${SHAN_ZERO}", "https://example.com:8${BOLD_ZERO}", "https://example.com#fragment"])
+        fun `rejects invalid origins JDK`(it: String) {
+            assertThat(CorsUtils.isValidOriginJdk(it)).describedAs(it).isFalse
         }
     }
 


### PR DESCRIPTION
Todos:

- [ ] tests for IPv4 addresses as an origin
- [ ] tests for IPv6 addresses as an origin
- [ ] harden port extraction especially for IPv6 addresses
- [ ] Use URI class for port logic
- [ ] complete plugin tests for IP address based origins

Fixes #2138 (once its done)