### PR TITLE
Handle invalid urlencoding in bodies

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -192,10 +192,15 @@ fun getRequestCharset(ctx: Context) = ctx.req().getHeader(Header.CONTENT_TYPE)?.
 }
 
 fun splitKeyValueStringAndGroupByKey(string: String, charset: String): Map<String, List<String>> {
-    return if (string.isEmpty()) mapOf() else string.split("&").map { it.split("=", limit = 2) }.groupBy(
-        { URLDecoder.decode(it[0], charset) },
-        { if (it.size > 1) URLDecoder.decode(it[1], charset) else "" }
-    ).mapValues { it.value.toList() }
+    return try {
+        if (string.isEmpty()) mapOf() else string.split("&").map { it.split("=", limit = 2) }.groupBy(
+            { URLDecoder.decode(it[0], charset) },
+            { if (it.size > 1) URLDecoder.decode(it[1], charset) else "" }
+        ).mapValues { it.value.toList() }
+    } catch(e: IllegalArgumentException) {
+        // Presumably the body had invalid URL encoding and isn't really a key-value string
+        mapOf()
+    }
 }
 
 fun pathParamOrThrow(pathParams: Map<String, String?>, key: String, url: String) =

--- a/javalin/src/test/java/io/javalin/TestBodyReading.kt
+++ b/javalin/src/test/java/io/javalin/TestBodyReading.kt
@@ -56,6 +56,13 @@ class TestBodyReading {
         assertThat(response.body).isEqualTo("♚♛♜♜♝♝♞♞♟♟♟♟♟♟♟♟")
     }
 
+    @Test
+    fun `reading invalid form-params without contentType works`() = TestUtil.test { app, http ->
+        app.post("/") { it.result((it.formParam("fp") == null).toString()) }
+        val response = http.post("/").body("fp=%+").asString()
+        assertThat(response.body).isEqualTo("true")
+    }
+
     @Test // not sure why this does so much...
     fun `query-params and form-params behave the same`() = TestUtil.test { app, http ->
         app.post("/") { ctx ->


### PR DESCRIPTION
Bodies may exist but not contain valid form params for some requests,
and we should handle trying to read params from those requests gracefully