### PR TITLE
Add config to enforce content types strictly

### DIFF
--- a/javalin-utils/javalin-context-mock/src/main/java/io/javalin/mock/ContextMock.kt
+++ b/javalin-utils/javalin-context-mock/src/main/java/io/javalin/mock/ContextMock.kt
@@ -135,6 +135,7 @@ class ContextMock private constructor(
             defaultContentType = mockConfig.javalinConfig.http.defaultContentType,
             jsonMapper = mockConfig.javalinConfig.pvt.jsonMapper.value,
             requestLoggerEnabled = false,
+            strictFormContentTypes = false,
         )
 
 }

--- a/javalin-utils/javalin-context-mock/src/main/java/io/javalin/mock/ContextMock.kt
+++ b/javalin-utils/javalin-context-mock/src/main/java/io/javalin/mock/ContextMock.kt
@@ -135,7 +135,7 @@ class ContextMock private constructor(
             defaultContentType = mockConfig.javalinConfig.http.defaultContentType,
             jsonMapper = mockConfig.javalinConfig.pvt.jsonMapper.value,
             requestLoggerEnabled = false,
-            strictFormContentTypes = false,
+            strictContentTypes = false,
         )
 
 }

--- a/javalin/src/main/java/io/javalin/config/HttpConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/HttpConfig.kt
@@ -15,6 +15,7 @@ class HttpConfig(private val cfg: JavalinConfig) {
     //@formatter:off
     @JvmField var generateEtags = false
     @JvmField var prefer405over404 = false
+    @JvmField var strictFormContentTypes = false
     @JvmField var maxRequestSize = 1_000_000L // increase this or use inputstream to handle large requests
     @JvmField var defaultContentType = ContentType.PLAIN
     @JvmField var asyncTimeout = 0L

--- a/javalin/src/main/java/io/javalin/config/HttpConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/HttpConfig.kt
@@ -15,7 +15,7 @@ class HttpConfig(private val cfg: JavalinConfig) {
     //@formatter:off
     @JvmField var generateEtags = false
     @JvmField var prefer405over404 = false
-    @JvmField var strictFormContentTypes = false
+    @JvmField var strictContentTypes = false
     @JvmField var maxRequestSize = 1_000_000L // increase this or use inputstream to handle large requests
     @JvmField var defaultContentType = ContentType.PLAIN
     @JvmField var asyncTimeout = 0L

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -280,16 +280,16 @@ interface Context {
     fun basicAuthCredentials(): BasicAuthCredentials? = getBasicAuthCredentials(header(Header.AUTHORIZATION))
 
     /** Returns true if request is multipart. */
-    fun isMultipart(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("multipart/") == true
+    fun isMultipart(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.startsWith("multipart/") == true
 
     /** Returns true if request is multipart/form-data. */
-    fun isMultipartFormData(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("multipart/form-data") == true
+    fun isMultipartFormData(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.startsWith("multipart/form-data") == true
 
     /** Returns true if request is application/x-www-form-urlencoded. */
-    fun isFormUrlencoded(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/x-www-form-urlencoded") == true
+    fun isFormUrlencoded(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.startsWith("application/x-www-form-urlencoded") == true
 
     /** Returns true if request is application/json. */
-    fun isJson(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/json") == true
+    fun isJson(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.startsWith("application/json") == true
 
     /** Gets first [UploadedFile] for the specified name, or null. */
     fun uploadedFile(fileName: String): UploadedFile? = uploadedFiles(fileName).firstOrNull()

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -175,8 +175,11 @@ interface Context {
     /** Gets a map with all the form param keys and values. */
     fun formParamMap(): Map<String, List<String>> = when {
         isMultipartFormData() -> MultipartUtil.getFieldMap(req())
-        else -> splitKeyValueStringAndGroupByKey(body(), characterEncoding() ?: "UTF-8")
+        isFormUrlencoded() || !strictFormContentTypes() -> splitKeyValueStringAndGroupByKey(body(), characterEncoding() ?: "UTF-8")
+        else -> mapOf()
     }
+
+    fun strictFormContentTypes(): Boolean
 
     /**
      * Gets a path param by name (ex: pathParam("param").
@@ -275,6 +278,9 @@ interface Context {
 
     /** Returns true if request is multipart/form-data. */
     fun isMultipartFormData(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("multipart/form-data") == true
+
+    /** Returns true if request is application/x-www-form-urlencoded. */
+    fun isFormUrlencoded(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/x-www-form-urlencoded") == true
 
     /** Gets first [UploadedFile] for the specified name, or null. */
     fun uploadedFile(fileName: String): UploadedFile? = uploadedFiles(fileName).firstOrNull()

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -288,7 +288,7 @@ interface Context {
     /** Returns true if request is application/x-www-form-urlencoded. */
     fun isFormUrlencoded(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/x-www-form-urlencoded") == true
 
-    /** Returns true if request is application/x-www-form-urlencoded. */
+    /** Returns true if request is application/json. */
     fun isJson(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/json") == true
 
     /** Gets first [UploadedFile] for the specified name, or null. */

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -149,13 +149,19 @@ interface Context {
     }
 
     /** Maps a JSON body to a Java/Kotlin class using the registered [io.javalin.json.JsonMapper] */
-    fun <T> bodyAsClass(type: Type): T = jsonMapper().fromJsonString(body(), type)
+    fun <T> bodyAsClass(type: Type): T =  when {
+        isJson() || !strictContentTypes() -> jsonMapper().fromJsonString(body(), type)
+        else -> throw BadRequestResponse("Content-Type is not application/json")
+    }
 
     /** Maps a JSON body to a Java/Kotlin class using the registered [io.javalin.json.JsonMapper] */
     fun <T> bodyAsClass(clazz: Class<T>): T = bodyAsClass(type = clazz as Type)
 
     /** Maps a JSON body to a Java/Kotlin class using the registered [io.javalin.json.JsonMapper] */
-    fun <T> bodyStreamAsClass(type: Type): T = jsonMapper().fromJsonStream(req().inputStream, type)
+    fun <T> bodyStreamAsClass(type: Type): T = when {
+        isJson() || !strictContentTypes() -> jsonMapper().fromJsonStream(req().inputStream, type)
+        else -> throw BadRequestResponse("Content-Type is not application/json")
+    }
 
     /** Gets the underlying [InputStream] for the request body */
     fun bodyInputStream(): InputStream = req().inputStream
@@ -175,11 +181,11 @@ interface Context {
     /** Gets a map with all the form param keys and values. */
     fun formParamMap(): Map<String, List<String>> = when {
         isMultipartFormData() -> MultipartUtil.getFieldMap(req())
-        isFormUrlencoded() || !strictFormContentTypes() -> splitKeyValueStringAndGroupByKey(body(), characterEncoding() ?: "UTF-8")
+        isFormUrlencoded() || !strictContentTypes() -> splitKeyValueStringAndGroupByKey(body(), characterEncoding() ?: "UTF-8")
         else -> mapOf()
     }
 
-    fun strictFormContentTypes(): Boolean
+    fun strictContentTypes(): Boolean
 
     /**
      * Gets a path param by name (ex: pathParam("param").
@@ -281,6 +287,9 @@ interface Context {
 
     /** Returns true if request is application/x-www-form-urlencoded. */
     fun isFormUrlencoded(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/x-www-form-urlencoded") == true
+
+    /** Returns true if request is application/x-www-form-urlencoded. */
+    fun isJson(): Boolean = header(Header.CONTENT_TYPE)?.lowercase(Locale.ROOT)?.contains("application/json") == true
 
     /** Gets first [UploadedFile] for the specified name, or null. */
     fun uploadedFile(fileName: String): UploadedFile? = uploadedFiles(fileName).firstOrNull()

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -47,7 +47,8 @@ data class JavalinServletContextConfig(
     val compressionStrategy: CompressionStrategy,
     val requestLoggerEnabled: Boolean,
     val defaultContentType: String,
-    val jsonMapper: JsonMapper
+    val jsonMapper: JsonMapper,
+    val strictFormContentTypes: Boolean
 ) {
     companion object {
         fun of(cfg: JavalinConfig): JavalinServletContextConfig =
@@ -58,6 +59,7 @@ data class JavalinServletContextConfig(
                 requestLoggerEnabled = cfg.pvt.requestLogger != null,
                 defaultContentType = cfg.http.defaultContentType,
                 jsonMapper = cfg.pvt.jsonMapper.value,
+                strictFormContentTypes = cfg.http.strictFormContentTypes,
             )
     }
 }
@@ -136,6 +138,10 @@ class JavalinServletContext(
     /** using an additional map lazily so no new objects are created whenever ctx.formParam*() is called */
     private val formParams by javalinLazy { super.formParamMap() }
     override fun formParamMap(): Map<String, List<String>> = formParams
+
+    override fun strictFormContentTypes(): Boolean {
+        return cfg.strictFormContentTypes
+    }
 
     override fun pathParamMap(): Map<String, String> = Collections.unmodifiableMap(pathParamMap)
     override fun pathParam(key: String): String = pathParamOrThrow(pathParamMap, key, matchedPath)

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -48,7 +48,7 @@ data class JavalinServletContextConfig(
     val requestLoggerEnabled: Boolean,
     val defaultContentType: String,
     val jsonMapper: JsonMapper,
-    val strictFormContentTypes: Boolean
+    val strictContentTypes: Boolean
 ) {
     companion object {
         fun of(cfg: JavalinConfig): JavalinServletContextConfig =
@@ -59,7 +59,7 @@ data class JavalinServletContextConfig(
                 requestLoggerEnabled = cfg.pvt.requestLogger != null,
                 defaultContentType = cfg.http.defaultContentType,
                 jsonMapper = cfg.pvt.jsonMapper.value,
-                strictFormContentTypes = cfg.http.strictFormContentTypes,
+                strictContentTypes = cfg.http.strictContentTypes,
             )
     }
 }
@@ -139,8 +139,8 @@ class JavalinServletContext(
     private val formParams by javalinLazy { super.formParamMap() }
     override fun formParamMap(): Map<String, List<String>> = formParams
 
-    override fun strictFormContentTypes(): Boolean {
-        return cfg.strictFormContentTypes
+    override fun strictContentTypes(): Boolean {
+        return cfg.strictContentTypes
     }
 
     override fun pathParamMap(): Map<String, String> = Collections.unmodifiableMap(pathParamMap)

--- a/javalin/src/test/java/io/javalin/TestBodyReading.kt
+++ b/javalin/src/test/java/io/javalin/TestBodyReading.kt
@@ -14,6 +14,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 class TestBodyReading {
+    private val strictContentTypeJavalin = Javalin.create { cfg -> cfg.http.strictFormContentTypes = true }
 
     @Test
     fun `reading body as bytes works`() = TestUtil.test { app, http ->
@@ -61,6 +62,20 @@ class TestBodyReading {
         app.post("/") { it.result((it.formParam("fp") == null).toString()) }
         val response = http.post("/").body("fp=%+").asString()
         assertThat(response.body).isEqualTo("true")
+    }
+
+    @Test
+    fun `reading form-params with strictFormContentTypes and without contentType returns nothing`() = TestUtil.test(strictContentTypeJavalin) { app, http ->
+        app.post("/") { it.result((it.formParam("fp") == null).toString()) }
+        val response = http.post("/").body("fp=param").asString()
+        assertThat(response.body).isEqualTo("true")
+    }
+
+    @Test
+    fun `reading form-params with strictFormContentTypes and without contentType works`() = TestUtil.test(strictContentTypeJavalin) { app, http ->
+        app.post("/") { it.result((it.formParam("fp")).toString()) }
+        val response = http.post("/").contentType("application/x-www-form-urlencoded").body("fp=param").asString()
+        assertThat(response.body).isEqualTo("param")
     }
 
     @Test // not sure why this does so much...

--- a/javalin/src/test/java/io/javalin/TestBodyReading.kt
+++ b/javalin/src/test/java/io/javalin/TestBodyReading.kt
@@ -14,7 +14,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 class TestBodyReading {
-    private val strictContentTypeJavalin = Javalin.create { cfg -> cfg.http.strictFormContentTypes = true }
+    private val strictContentTypeJavalin = Javalin.create { cfg -> cfg.http.strictContentTypes = true }
 
     @Test
     fun `reading body as bytes works`() = TestUtil.test { app, http ->
@@ -65,14 +65,14 @@ class TestBodyReading {
     }
 
     @Test
-    fun `reading form-params with strictFormContentTypes and without contentType returns nothing`() = TestUtil.test(strictContentTypeJavalin) { app, http ->
+    fun `reading form-params with strictContentTypes and without contentType returns nothing`() = TestUtil.test(strictContentTypeJavalin) { app, http ->
         app.post("/") { it.result((it.formParam("fp") == null).toString()) }
         val response = http.post("/").body("fp=param").asString()
         assertThat(response.body).isEqualTo("true")
     }
 
     @Test
-    fun `reading form-params with strictFormContentTypes and without contentType works`() = TestUtil.test(strictContentTypeJavalin) { app, http ->
+    fun `reading form-params with strictContentTypes and without contentType works`() = TestUtil.test(strictContentTypeJavalin) { app, http ->
         app.post("/") { it.result((it.formParam("fp")).toString()) }
         val response = http.post("/").contentType("application/x-www-form-urlencoded").body("fp=param").asString()
         assertThat(response.body).isEqualTo("param")

--- a/javalin/src/test/java/io/javalin/TestConfiguration.kt
+++ b/javalin/src/test/java/io/javalin/TestConfiguration.kt
@@ -42,7 +42,7 @@ class TestConfiguration {
             it.bundledPlugins.enableRouteOverview("/test")
             it.bundledPlugins.enableSslRedirects()
             it.http.prefer405over404 = false
-            it.http.strictFormContentTypes = true
+            it.http.strictContentTypes = true
             it.requestLogger.http { ctx, timeInMs -> }
             it.requestLogger.ws { ws -> }
             it.showJavalinBanner = false

--- a/javalin/src/test/java/io/javalin/TestConfiguration.kt
+++ b/javalin/src/test/java/io/javalin/TestConfiguration.kt
@@ -42,6 +42,7 @@ class TestConfiguration {
             it.bundledPlugins.enableRouteOverview("/test")
             it.bundledPlugins.enableSslRedirects()
             it.http.prefer405over404 = false
+            it.http.strictFormContentTypes = true
             it.requestLogger.http { ctx, timeInMs -> }
             it.requestLogger.ws { ws -> }
             it.showJavalinBanner = false

--- a/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi.kt
@@ -30,6 +30,7 @@ class TestJavalinInstanceAndConfigApi {
             app.http.maxRequestSize = 10_000L
             app.http.generateEtags = true
             app.http.prefer405over404 = true
+            app.http.strictFormContentTypes = true
             app.http.customCompression(CompressionStrategy())
             app.http.brotliAndGzipCompression(3)
             app.http.brotliOnlyCompression(3)

--- a/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi.kt
@@ -30,7 +30,7 @@ class TestJavalinInstanceAndConfigApi {
             app.http.maxRequestSize = 10_000L
             app.http.generateEtags = true
             app.http.prefer405over404 = true
-            app.http.strictFormContentTypes = true
+            app.http.strictContentTypes = true
             app.http.customCompression(CompressionStrategy())
             app.http.brotliAndGzipCompression(3)
             app.http.brotliOnlyCompression(3)

--- a/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi_Java.java
+++ b/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi_Java.java
@@ -30,6 +30,7 @@ public class TestJavalinInstanceAndConfigApi_Java {
             app.http.maxRequestSize = 10_000L;
             app.http.generateEtags = true;
             app.http.prefer405over404 = true;
+            app.http.strictFormContentTypes = true;
             app.http.customCompression(new CompressionStrategy());
             app.http.brotliAndGzipCompression(3);
             app.http.brotliOnlyCompression(3);

--- a/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi_Java.java
+++ b/javalin/src/test/java/io/javalin/TestJavalinInstanceAndConfigApi_Java.java
@@ -30,7 +30,7 @@ public class TestJavalinInstanceAndConfigApi_Java {
             app.http.maxRequestSize = 10_000L;
             app.http.generateEtags = true;
             app.http.prefer405over404 = true;
-            app.http.strictFormContentTypes = true;
+            app.http.strictContentTypes = true;
             app.http.customCompression(new CompressionStrategy());
             app.http.brotliAndGzipCompression(3);
             app.http.brotliOnlyCompression(3);


### PR DESCRIPTION
This is valuable for being able to unconditionally use formParams
in an application without risking consuming the body stream on
requests where the client did not send form params.

For bodyAsClass/bodyStreamAsClass, this will throw a BadRequestResponse when trying to convert a non-JSON body to a class.  For formParams and friends, the formParam list will be empty when trying to read form params from a request with a non-form-param content type.
 
