### PR TITLE
[cors] Disallow anyHost + allowCredentials

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/bundled/CorsPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/CorsPlugin.kt
@@ -82,7 +82,7 @@ class CorsPlugin(userConfig: Consumer<CorsPluginConfig>? = null) : Plugin<CorsPl
 
     init {
         require(pluginConfig.rules.isNotEmpty()) {
-            "At least one cors config has to be provided. Use CorsContainer.add() to add one."
+            "At least one cors config has to be provided. Use CorsPluginConfig.addRule() to add one."
         }
     }
 
@@ -96,6 +96,12 @@ class CorsPlugin(userConfig: Consumer<CorsPluginConfig>? = null) : Plugin<CorsPl
                 }
                 require(origins.isEmpty() || !corsRule.reflectClientOrigin) {
                     "Cannot set `allowedOrigins` if `reflectClientOrigin` is true"
+                }
+                require(!("*" in origins && corsRule.allowCredentials)) {
+                    """
+                        |Cannot use `anyHost()` / Origin: * if `allowCredentials` is true as that is rejected by all browsers.
+                        |Please use either an explicit list of allowed origins via `allowHost()` or use `reflectClientOrigin = true` without any origins.
+                        |Docs: https://javalin.io/plugins/cors""".trimMargin()
                 }
 
                 val validOptionStatusCodes = listOf(HttpStatus.NOT_FOUND, HttpStatus.METHOD_NOT_ALLOWED)

--- a/javalin/src/test/java/io/javalin/TestCors.kt
+++ b/javalin/src/test/java/io/javalin/TestCors.kt
@@ -36,7 +36,7 @@ class TestCors {
         fun `throws for zero configurations`() {
             assertThatExceptionOfType(IllegalArgumentException::class.java)
                 .isThrownBy { Javalin.create { it.registerPlugin(CorsPlugin()) } }
-                .withMessageStartingWith("At least one cors config has to be provided. Use CorsContainer.add() to add one.")
+                .withMessageStartingWith("At least one cors config has to be provided. Use CorsPluginConfig.addRule() to add one.")
         }
 
         @Test
@@ -58,6 +58,20 @@ class TestCors {
                     })
                 }
             }.withMessageStartingWith("Cannot set `allowedOrigins` if `reflectClientOrigin` is true")
+        }
+
+        @Test
+        fun `throws for combination of anyHost and allowCredentials true`() {
+            assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
+                Javalin.create { config ->
+                    config.registerPlugin(CorsPlugin({ cors ->
+                        cors.addRule {
+                            it.anyHost()
+                            it.allowCredentials = true
+                        }
+                    }))
+                }
+            }.withMessageStartingWith("Cannot use `anyHost()` / Origin: * if `allowCredentials` is true as that is rejected by all browsers.")
         }
 
         @Test


### PR DESCRIPTION
While helping people with CORS this is one thing I have seen people use and then getting confused as to why it doesn't work. This is already documented in the cors plugin page but catching this on startup should be a better experience.

This is technically a breaking change but as browsers already reject this combination should be considered a bug fix as we adopt the browser behaviour, leading to a better experience as you now get immediate feedback on what went wrong instead of having to debug this in a browser.