### PR TITLE
Update Dependabot to actually group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     labels:
       - "dependencies"
     target-branch: "master"
+    groups:
+      dependencies:
+        patterns:
+        - "*"
 
 
   - package-ecosystem: "github-actions"
@@ -23,3 +27,7 @@ updates:
     labels:
       - "dependencies"
     target-branch: "master"
+    groups:
+      dependencies:
+        patterns:
+        - "*"


### PR DESCRIPTION
Now dependabot should create a single PR for the dependency updates. Example dependabot PR: https://github.com/SentryMan/avaje-javalin-api-example/pull/50