### PR TITLE
[core] Fix `Cookie` `maxAge` docs

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Cookie.kt
+++ b/javalin/src/main/java/io/javalin/http/Cookie.kt
@@ -43,7 +43,8 @@ enum class SameSite(val value: String) {
  * @param path indicates the path that must exist in the requested URL for the browser to
  * send the Cookie header. (default = "/")
  * @param maxAge indicates the number of seconds until the cookie expires.
- * A zero or negative number will expire the cookie immediately. (default = -1)
+ * A negative value means that the cookie is not stored persistently and will be deleted
+ * when the Web browser exits. A zero value causes the cookie to be deleted. (default = -1)
  * @param secure indicates that the cookie is sent to the server only when a request is
  * made with the https: scheme (except on localhost), and therefore, is more resistant
  * to man-in-the-middle attacks (default: false)


### PR DESCRIPTION
The existing docs are incorrect regarding negative numbers for `Cookie` `maxAge`. This PR copies the docs from [here](https://jakarta.ee/specifications/servlet/4.0/apidocs/javax/servlet/http/cookie#setMaxAge-int-) to fix it.