### PR TITLE
Fix SeekableWriter.kt on file download resumption for non audio/video…

### DIFF
--- a/javalin/src/main/java/io/javalin/http/util/SeekableWriter.kt
+++ b/javalin/src/main/java/io/javalin/http/util/SeekableWriter.kt
@@ -23,18 +23,15 @@ object SeekableWriter {
         val requestedRange = ctx.header(Header.RANGE)!!.split("=")[1].split("-").filter { it.isNotEmpty() }
         val from = requestedRange[0].toLong()
         val to = when {
-            // file is recognized as audio or video
             isAudioOrVideoFile -> when {
                 from + chunkSize > totalBytes -> totalBytes - 1 // chunk bigger than file, write all
                 requestedRange.size == 2 -> requestedRange[1].toLong() // chunk smaller than file, to/from specified
-                else -> from + chunkSize - 1 // chunk smaller than file, to/from not specified
+                else -> from + chunkSize - 1
             }
             else -> (totalBytes - 1)
         }
         val contentLength = when {
-            // video/audio type file
             isAudioOrVideoFile -> min(to - from + 1, totalBytes)
-            // non audio video file
             else -> (totalBytes - from)
         }
 

--- a/javalin/src/main/java/io/javalin/http/util/SeekableWriter.kt
+++ b/javalin/src/main/java/io/javalin/http/util/SeekableWriter.kt
@@ -37,7 +37,13 @@ object SeekableWriter {
             // non audio video file
             else -> (totalBytes - from)
         }
-        ctx.status(HttpStatus.PARTIAL_CONTENT)
+
+        val status = when {
+            audioOrVideo -> HttpStatus.PARTIAL_CONTENT
+            else -> HttpStatus.OK
+        }
+
+        ctx.status(status)
         ctx.header(Header.CONTENT_TYPE, contentType)
         ctx.header(Header.ACCEPT_RANGES, "bytes")
         ctx.header(Header.CONTENT_RANGE, "bytes $from-$to/$totalBytes")

--- a/javalin/src/main/java/io/javalin/http/util/SeekableWriter.kt
+++ b/javalin/src/main/java/io/javalin/http/util/SeekableWriter.kt
@@ -11,7 +11,7 @@ object SeekableWriter {
     var chunkSize = 128000
     fun write(ctx: Context, inputStream: InputStream, contentType: String, totalBytes: Long) = ctx.async {
         val uncompressedStream = ctx.res().outputStream
-        val audioOrVideo = contentType.isAV()
+        val audioOrVideo = contentType.isAudioOrVideo()
         ctx.header(Header.ACCEPT_RANGES, "bytes")
         if (ctx.header(Header.RANGE) == null) {
             ctx.header(Header.CONTENT_TYPE, contentType)
@@ -31,11 +31,11 @@ object SeekableWriter {
             }
             false -> (totalBytes - 1)
         }
-        val contentLength = when (audioOrVideo) {
+        val contentLength = when {
             // video/audio type file
-            true -> min(to - from + 1, totalBytes)
-            // non a/v file
-            false -> (totalBytes - from)
+            audioOrVideo -> min(to - from + 1, totalBytes)
+            // non audio video file
+            else -> (totalBytes - from)
         }
         ctx.status(HttpStatus.PARTIAL_CONTENT)
         ctx.header(Header.CONTENT_TYPE, contentType)
@@ -59,7 +59,7 @@ object SeekableWriter {
         }
     }
 
-    private fun String.isAV(): Boolean {
+    private fun String.isAudioOrVideo(): Boolean {
         return this.startsWith("audio/") || this.startsWith("video/")
     }
 }

--- a/javalin/src/test/java/io/javalin/TestResponse.kt
+++ b/javalin/src/test/java/io/javalin/TestResponse.kt
@@ -29,7 +29,6 @@ import java.io.File
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import javax.swing.text.AbstractDocument.Content
 
 class TestResponse {
 

--- a/javalin/src/test/java/io/javalin/TestResponse.kt
+++ b/javalin/src/test/java/io/javalin/TestResponse.kt
@@ -205,9 +205,9 @@ class TestResponse {
     }
 
     @Test
-    fun `seekable - range works and input stream closed`() = TestUtil.test { app, http ->
+    fun `seekable - av range works and input stream closed`() = TestUtil.test { app, http ->
         val input = getSeekableInput()
-        app.get("/seekable") { it.writeSeekableStream(input, ContentType.PLAIN) }
+        app.get("/seekable") { it.writeSeekableStream(input, ContentType.VIDEO_MPEG.toString()) }
         val response = Unirest.get(http.origin + "/seekable")
             .headers(mapOf(Header.RANGE to "bytes=${SeekableWriter.chunkSize}-${SeekableWriter.chunkSize * 2 - 1}"))
             .asString()
@@ -217,10 +217,10 @@ class TestResponse {
     }
 
     @Test
-    fun `seekable - no-range works and input stream closed`() = TestUtil.test { app, http ->
+    fun `seekable - av no-range works and input stream closed`() = TestUtil.test { app, http ->
         val input = getSeekableInput()
         val available = input.available()
-        app.get("/seekable-2") { it.writeSeekableStream(input, ContentType.PLAIN) }
+        app.get("/seekable-2") { it.writeSeekableStream(input, ContentType.VIDEO_MPEG.toString()) }
         val response = Unirest.get(http.origin + "/seekable-2").asString()
         assertThat(response.body.length).isEqualTo(available)
         assertThat(input.closedLatch.await(2, TimeUnit.SECONDS)).isTrue()
@@ -228,8 +228,8 @@ class TestResponse {
     }
 
     @Test
-    fun `seekable - overreaching range works`() = TestUtil.test { app, http ->
-        app.get("/seekable-3") { it.writeSeekableStream(getSeekableInput(), ContentType.PLAIN) }
+    fun `seekable - av overreaching range works`() = TestUtil.test { app, http ->
+        app.get("/seekable-3") { it.writeSeekableStream(getSeekableInput(), ContentType.VIDEO_MPEG.toString()) }
         val response = Unirest.get(http.origin + "/seekable-3")
             .headers(mapOf(Header.RANGE to "bytes=0-${SeekableWriter.chunkSize * 4}"))
             .asBytes()
@@ -237,8 +237,8 @@ class TestResponse {
     }
 
     @Test
-    fun `seekable - file smaller than chunksize works`() = TestUtil.test { app, http ->
-        app.get("/seekable-4") { it.writeSeekableStream(getSeekableInput(repeats = 50), ContentType.PLAIN) }
+    fun `seekable - av file smaller than chunksize works`() = TestUtil.test { app, http ->
+        app.get("/seekable-4") { it.writeSeekableStream(getSeekableInput(repeats = 50), ContentType.VIDEO_MPEG.toString()) }
         val response = Unirest.get(http.origin + "/seekable-4")
             .headers(mapOf(Header.RANGE to "bytes=0-${SeekableWriter.chunkSize}"))
             .asString().body
@@ -246,10 +246,10 @@ class TestResponse {
     }
 
     @Test
-    fun `seekable - large file works`() = TestUtil.test { app, http ->
+    fun `seekable - av large file works`() = TestUtil.test { app, http ->
         val prefixSize = 1L shl 31 //2GB
         val contentSize = 100L
-        app.get("/seekable-5") { it.writeSeekableStream(LargeSeekableInput(prefixSize, contentSize), ContentType.PLAIN, prefixSize + contentSize) }
+        app.get("/seekable-5") { it.writeSeekableStream(LargeSeekableInput(prefixSize, contentSize), ContentType.VIDEO_MPEG.toString(), prefixSize + contentSize) }
         val response = Unirest.get(http.origin + "/seekable-5")
             .headers(mapOf(Header.RANGE to "bytes=${prefixSize}-${prefixSize + contentSize - 1}"))
             .asString()
@@ -262,7 +262,7 @@ class TestResponse {
 
     @Test
     fun `GH-1956 seekable request with no RANGE header contains Content-Length and Accept-Ranges`() = TestUtil.test { app, http ->
-        app.get("/seekable-6") { it.writeSeekableStream(getSeekableInput(), ContentType.PLAIN) }
+        app.get("/seekable-6") { it.writeSeekableStream(getSeekableInput(), ContentType.VIDEO_MPEG.toString()) }
         val response = Unirest.get(http.origin + "/seekable-6").asString()
         assertThat(response.headers[Header.CONTENT_LENGTH]?.get(0)).isGreaterThan("0")
         assertThat(response.headers[Header.ACCEPT_RANGES]?.get(0)).isEqualTo("bytes")


### PR DESCRIPTION
Fix SeekableWriter.kt on file download resumption for non audio/video files

Relevant issue: https://github.com/javalin/javalin/issues/2359

Please note: 
2. In the case where you are trying to download a video or audio file directly this error will still occur. Fixing this is pretty non-trivial, as such the implementation for more advanced considerations is not currently implemented in the PR.

Possible solutions to also fix audio/video download resuming as well:

1. Examine [`Sec-Fetch-Dest`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest) header, which will contain "audio" or "video" when a browser is requesting chunked video/audio segments.
   * This is a new header, not all browsers or clients will support it, we cannot guarantee support
2. Examine `Accept` header, which will contain specific mime types corresponding to the video/audio formats the browser is expecting.
   * This header varies drastically based on browser capabilities but in general browsers will use "Accept: \*/\*" for download requests and "Accept: \<expected format\>" I chose not to implement in this PR due to the extensive testing that will need to be done to ensure it works correctly.

