### PR TITLE
Fix virtual threads enabled bug on native images for graalVM

### DIFF
--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -128,34 +128,38 @@ open class NamedThreadFactory(protected val prefix: String) : ThreadFactory {
 }
 
 open class NamedVirtualThreadFactory(prefix: String) : NamedThreadFactory(prefix) {
-    override fun newThread(runnable: Runnable): Thread = ReflectiveVirtualThreadBuilder()
+    override fun newThread(runnable: Runnable): Thread = VirtualThreadBuilder.create()
         .name("$prefix-Virtual-${threadCount.getAndIncrement()}")
         .unstarted(runnable)
 }
 
-open class ReflectiveVirtualThreadBuilder {
+class VirtualThreadBuilder {
 
-    protected companion object {
-        val OF_VIRTUAL: MethodHandle
-        val NAME: MethodHandle
-        val UNSTARTED: MethodHandle
+    companion object {
+        fun create(): Builder = BuilderImpl()
+        private val builderClass = Class.forName("java.lang.Thread\$Builder\$OfVirtual")
+        private val nameMethod = builderClass.getMethod("name", String::class.java)
+        private val unstartedMethod = builderClass.getMethod("unstarted", Runnable::class.java)
+        private val ofVirtualMethod = Thread::class.java.getMethod("ofVirtual")
+    }
 
-        init {
-            val builderClass = Class.forName("java.lang.Thread\$Builder\$OfVirtual")
-            val handles = MethodHandles.publicLookup()
-            OF_VIRTUAL = handles.findStatic(Thread::class.java, "ofVirtual", MethodType.methodType(builderClass))
-            NAME = handles.findVirtual(builderClass, "name", MethodType.methodType(builderClass, String::class.java))
-            UNSTARTED = handles.findVirtual(builderClass, "unstarted", MethodType.methodType(Thread::class.java, Runnable::class.java))
+    interface Builder {
+        fun name(name: String): Builder
+        fun unstarted(runnable: Runnable): Thread
+    }
+
+    private class BuilderImpl : Builder {
+
+        private val ofVirtual = ofVirtualMethod.invoke(null)
+
+        override fun name(name: String): Builder {
+            nameMethod.invoke(ofVirtual, name)
+            return this
+        }
+
+        override fun unstarted(runnable: Runnable): Thread {
+            return unstartedMethod
+                .invoke(ofVirtual, runnable) as Thread
         }
     }
-
-    protected var virtualBuilder: Any = OF_VIRTUAL.invoke()
-
-    fun name(name: String): ReflectiveVirtualThreadBuilder = also {
-        this.virtualBuilder = NAME.invoke(virtualBuilder, name)
-    }
-
-    fun unstarted(runnable: Runnable): Thread =
-        UNSTARTED.invoke(virtualBuilder, runnable) as Thread
-
 }

--- a/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java/io/javalin/util/ConcurrencyUtil.kt
@@ -2,9 +2,6 @@ package io.javalin.util
 
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.eclipse.jetty.util.thread.ThreadPool
-import java.lang.invoke.MethodHandle
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.MethodType
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -133,15 +130,11 @@ open class NamedVirtualThreadFactory(prefix: String) : NamedThreadFactory(prefix
         .unstarted(runnable)
 }
 
-class VirtualThreadBuilder {
-
-    companion object {
-        fun create(): Builder = BuilderImpl()
-        private val builderClass = Class.forName("java.lang.Thread\$Builder\$OfVirtual")
-        private val nameMethod = builderClass.getMethod("name", String::class.java)
-        private val unstartedMethod = builderClass.getMethod("unstarted", Runnable::class.java)
-        private val ofVirtualMethod = Thread::class.java.getMethod("ofVirtual")
-    }
+object VirtualThreadBuilder {
+    private val builderClass = Class.forName("java.lang.Thread\$Builder\$OfVirtual")
+    private val nameMethod = builderClass.getMethod("name", String::class.java)
+    private val unstartedMethod = builderClass.getMethod("unstarted", Runnable::class.java)
+    private val ofVirtualMethod = Thread::class.java.getMethod("ofVirtual")
 
     interface Builder {
         fun name(name: String): Builder
@@ -149,7 +142,6 @@ class VirtualThreadBuilder {
     }
 
     private class BuilderImpl : Builder {
-
         private val ofVirtual = ofVirtualMethod.invoke(null)
 
         override fun name(name: String): Builder {
@@ -158,8 +150,9 @@ class VirtualThreadBuilder {
         }
 
         override fun unstarted(runnable: Runnable): Thread {
-            return unstartedMethod
-                .invoke(ofVirtual, runnable) as Thread
+            return unstartedMethod.invoke(ofVirtual, runnable) as Thread
         }
     }
+
+    fun create(): Builder = BuilderImpl()
 }


### PR DESCRIPTION
Relevant issue: #2192 

Fix proposed on issue.

Created a new class (VirtualThreadBuilder) for fixing virtual threads enabled bug on native images for graalVM. 