### PR TITLE
Handle invalid http verbs in micrometer plugin

### DIFF
--- a/javalin-micrometer/src/main/java/io/javalin/micrometer/MicrometerPlugin.kt
+++ b/javalin-micrometer/src/main/java/io/javalin/micrometer/MicrometerPlugin.kt
@@ -65,7 +65,7 @@ class MicrometerPlugin(config: Consumer<MicrometerPluginConfig>) : Plugin<Microm
                     }
                     val pathInfo = request.pathInfo.removePrefix(config.router.contextPath).prefixIfNot("/")
                     response.setHeader(EXCEPTION_HEADER, null)
-                    val handlerType = HandlerType.valueOf(request.method)
+                    val handlerType = HandlerType.findByName(request.method)
                     val uri = internalRouter.findHttpHandlerEntries(handlerType, pathInfo)
                         .map { it.endpoint.path }
                         .map { if (it == "/" || it.isBlank()) "root" else it }

--- a/javalin-micrometer/src/test/kotlin/io/javalin/micrometer/MicrometerPluginTest.kt
+++ b/javalin-micrometer/src/test/kotlin/io/javalin/micrometer/MicrometerPluginTest.kt
@@ -227,6 +227,28 @@ class MicrometerPluginTest {
         assertThat(notFoundCountGeneric).isEqualTo(requestCount.toLong())
     }
 
+    @Test
+    fun invalidMethod() = JavalinTest.test(setupApp(tagNotFoundMappedPaths = true)) { app, http ->
+        val requestCount = (2..9).random()
+        app.get("/hello") { ctx ->
+            ctx.status(OK)
+        }
+        repeat(requestCount) {
+            http.request("/hello") { b -> b.method("POSTS", null) }
+        }
+
+        val notFoundCountGeneric = meterRegistry.get("jetty.server.requests")
+            .tag("uri", "NOT_FOUND")
+            .tag("method", "POSTS")
+            .tag("exception", "None")
+            .tag("status", "404")
+            .tag("outcome", "CLIENT_ERROR")
+            .timer()
+            .count()
+
+        assertThat(notFoundCountGeneric).isEqualTo(requestCount.toLong())
+    }
+
     private fun setupApp(
         tagRedirectPaths: Boolean = false,
         tagNotFoundMappedPaths: Boolean = false,


### PR DESCRIPTION
When requests come in with invalid methods (e.g. POSTS instead of POST) the exisitng  plugin fails to find the method and throws an exception (meaning no metrics are emitted).

Change to use the existng `findByName` method so that metrics are emitted. 

Created an issue https://github.com/javalin/javalin/issues/2366 to track this.