### PR TITLE
[core] Improve `HttpStatus.forStatus` by using map lookup

### DIFF
--- a/javalin/src/main/java/io/javalin/http/HttpStatus.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpStatus.kt
@@ -149,7 +149,7 @@ enum class HttpStatus(val code: Int, val message: String) {
 
     companion object {
 
-        private val statusMap = values().associateBy { it.code }
+        private val statusMap = HttpStatus.entries.associateBy { it.code }
 
         @JvmStatic
         fun forStatus(status: Int): HttpStatus = statusMap[status] ?: UNKNOWN

--- a/javalin/src/main/java/io/javalin/http/HttpStatus.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpStatus.kt
@@ -149,9 +149,10 @@ enum class HttpStatus(val code: Int, val message: String) {
 
     companion object {
 
+        private val statusMap = values().associateBy { it.code }
+
         @JvmStatic
-        fun forStatus(status: Int): HttpStatus =
-            HttpStatus.entries.find { it.code == status } ?: UNKNOWN
+        fun forStatus(status: Int): HttpStatus = statusMap[status] ?: UNKNOWN
 
     }
 


### PR DESCRIPTION
The current `HttpStatus.forStatus` implementation appears to be a brute force search:
https://github.com/javalin/javalin/blob/2b63b76fd4b262c4eb8ff5187926e83bd2dd6129/javalin/src/main/java/io/javalin/http/HttpStatus.kt#L153-L154
This PR changes the `HttpStatus.forStatus` implementation to use a map lookup, similar to [`HandlerType.findByName`](https://github.com/javalin/javalin/blob/2b63b76fd4b262c4eb8ff5187926e83bd2dd6129/javalin/src/main/java/io/javalin/http/HandlerType.kt#L106-L112).