### PR TITLE
[http] Add config option for response buffer size with a new default

### DIFF
--- a/javalin/src/main/java/io/javalin/config/HttpConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/HttpConfig.kt
@@ -17,6 +17,7 @@ class HttpConfig(private val cfg: JavalinConfig) {
     @JvmField var prefer405over404 = false
     @JvmField var strictContentTypes = false
     @JvmField var maxRequestSize = 1_000_000L // increase this or use inputstream to handle large requests
+    @JvmField var responseBufferSize = 32_768
     @JvmField var defaultContentType = ContentType.PLAIN
     @JvmField var asyncTimeout = 0L
     //@formatter:on

--- a/javalin/src/main/java/io/javalin/config/HttpConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/HttpConfig.kt
@@ -17,7 +17,7 @@ class HttpConfig(private val cfg: JavalinConfig) {
     @JvmField var prefer405over404 = false
     @JvmField var strictContentTypes = false
     @JvmField var maxRequestSize = 1_000_000L // increase this or use inputstream to handle large requests
-    @JvmField var responseBufferSize = 32_768
+    @JvmField var responseBufferSize: Int? = null
     @JvmField var defaultContentType = ContentType.PLAIN
     @JvmField var asyncTimeout = 0L
     //@formatter:on

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -109,7 +109,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
             if (responseWritten.getAndSet(true)) return // prevent writing more than once, it's required because timeout listener can terminate the flow at any time
             resultInputStream()?.use { resultStream ->
                 val etagWritten = ETagGenerator.tryWriteEtagAndClose(cfg.http.generateEtags, this, resultStream)
-                if (!etagWritten) resultStream.copyTo(outputStream(), cfg.http.responseBufferSize)
+                if (!etagWritten) resultStream.copyTo(outputStream(), cfg.http.responseBufferSize ?: 32_768) // default should never happen, we add a fallback just in case
             }
             cfg.pvt.requestLogger?.handle(this, executionTimeMs())
         } catch (throwable: Throwable) {

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -109,7 +109,7 @@ class JavalinServlet(val cfg: JavalinConfig) : HttpServlet() {
             if (responseWritten.getAndSet(true)) return // prevent writing more than once, it's required because timeout listener can terminate the flow at any time
             resultInputStream()?.use { resultStream ->
                 val etagWritten = ETagGenerator.tryWriteEtagAndClose(cfg.http.generateEtags, this, resultStream)
-                if (!etagWritten) resultStream.copyTo(outputStream(), 4096)
+                if (!etagWritten) resultStream.copyTo(outputStream(), cfg.http.responseBufferSize)
             }
             cfg.pvt.requestLogger?.handle(this, executionTimeMs())
         } catch (throwable: Throwable) {

--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -79,6 +79,10 @@ class JettyServer(private val cfg: JavalinConfig) {
             })
             val httpConfiguration = defaultHttpConfiguration()
             cfg.pvt.jetty.httpConfigurationConfigs.forEach { it.accept(httpConfiguration) } // apply user config (before connectors)
+            // use the jetty value, either the default or something the user has specified with the cfg.jetty.modifyHttpConfiguration option if there is no value set with the new api.
+            if (cfg.http.responseBufferSize == null) {
+                cfg.http.responseBufferSize = httpConfiguration.outputBufferSize
+            }
             cfg.pvt.jetty.connectors.map { it.apply(this, httpConfiguration) }.forEach(this::addConnector) // add user connectors
             if (connectors.isEmpty()) { // add default connector if no connectors are specified
                 connectors = arrayOf(ServerConnector(server, HttpConnectionFactory(httpConfiguration)).apply {

--- a/javalin/src/test/java/io/javalin/TestCustomJettyHttpConfiguration.kt
+++ b/javalin/src/test/java/io/javalin/TestCustomJettyHttpConfiguration.kt
@@ -79,4 +79,31 @@ class TestCustomJettyHttpConfiguration {
 
     }
 
+    @Test
+    fun `responseBufferSize - default is set to the jetty default for outputBufferSize`() = TestUtil.test { app, http ->
+        val firstHttpConnectionFactory = app.jettyServer().server().connectors.firstNotNullOfOrNull { (it as? ServerConnector)?.defaultConnectionFactory as? HttpConnectionFactory }
+        assertThat(app.unsafeConfig().http.responseBufferSize)
+            .isNotNull
+            .isEqualTo(firstHttpConnectionFactory?.httpConfiguration?.outputBufferSize)
+    }
+
+    @Test
+    fun `responseBufferSize - outputBufferSize set via jetty httpConfiguration is respected`() = TestUtil.test(Javalin.create { config ->
+        config.jetty.modifyHttpConfiguration { http -> http.outputBufferSize = 42_007 }
+    }) { app, http ->
+        assertThat(app.unsafeConfig().http.responseBufferSize)
+            .isNotNull
+            .isEqualTo(42_007)
+    }
+
+    @Test
+    fun `responseBufferSize - setting the javalin option has a higher priority than the jetty option`() = TestUtil.test(Javalin.create { config ->
+        config.http.responseBufferSize = 777_777
+        config.jetty.modifyHttpConfiguration { http -> http.outputBufferSize = 555_555 }
+    }) { app, http ->
+        assertThat(app.unsafeConfig().http.responseBufferSize)
+            .isNotNull
+            .isEqualTo(777_777)
+    }
+
 }


### PR DESCRIPTION
As discussed on Discord:
This PR adds a config option for the response buffer size that used to be the [Kotlin default of 8kb](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/src/kotlin/io/Constants.kt#L13) and was set explicitly to 4096.
The new default is the same what Jetty has by default.

Link to the small discussion on Discord: https://discord.com/channels/804862058528505896/805106384977920040/1336426384981102663