### PR TITLE
Map client aborts to 499 and timeouts to 408.

### DIFF
--- a/javalin/src/main/java/io/javalin/config/JettyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JettyConfig.kt
@@ -23,6 +23,10 @@ class JettyConfig(private val cfg: JavalinConfig) {
     @JvmField var defaultPort = 8080
     @JvmField var multipartConfig = MultipartConfig()
     @JvmField var threadPool: ThreadPool? = null
+    /** Default HTTP status code when the server had a timeout. */
+    @JvmField var timeoutStatus = 500
+    /** Default HTTP status code when the client closes the connection. */
+    @JvmField var clientAbortStatus = 500
     //@formatter:on
 
     /** Configure the jetty [Server]. This is useful if you want to configure Jetty features that are not exposed by Javalin.

--- a/javalin/src/main/java/io/javalin/config/JettyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/JettyConfig.kt
@@ -24,8 +24,10 @@ class JettyConfig(private val cfg: JavalinConfig) {
     @JvmField var multipartConfig = MultipartConfig()
     @JvmField var threadPool: ThreadPool? = null
     /** Default HTTP status code when the server had a timeout. */
+    //TODO: change to 408 for javalin7
     @JvmField var timeoutStatus = 500
     /** Default HTTP status code when the client closes the connection. */
+    //TODO: change to 499 for javalin7
     @JvmField var clientAbortStatus = 500
     //@formatter:on
 

--- a/javalin/src/main/java/io/javalin/config/PrivateConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/PrivateConfig.kt
@@ -25,7 +25,7 @@ class PrivateConfig(val cfg: JavalinConfig) {
 
     @JvmField val eventManager = EventManager()
     @JvmField val wsRouter = WsRouter(cfg.router)
-    @JvmField var internalRouter = InternalRouter(wsRouter, eventManager, cfg.router)
+    @JvmField var internalRouter = InternalRouter(wsRouter, eventManager, cfg.router, cfg.jetty)
     @JvmField var appDataManager = AppDataManager()
     @JvmField var pluginManager = PluginManager(cfg)
     @JvmField var jsonMapper: Lazy<JsonMapper> = javalinLazy { JavalinJackson(null, cfg.useVirtualThreads) }

--- a/javalin/src/main/java/io/javalin/config/RouterConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RouterConfig.kt
@@ -33,6 +33,10 @@ class RouterConfig(internal val cfg: JavalinConfig) {
     @JvmField var treatMultipleSlashesAsSingleSlash = false
     /** If true, treat '/PATH' and '/path' as the same path (default: false). */
     @JvmField var caseInsensitiveRoutes = false
+    /** Default HTTP status code when the server had a timeout. */
+    @JvmField var timeoutStatus = 408
+    /** Default HTTP status code when the client closes the connection. */
+    @JvmField var clientAbortStatus = 499
     // @formatter:on
 
     internal var javaLangErrorHandler: JavaLangErrorHandler = JavaLangErrorHandler { res, error ->

--- a/javalin/src/main/java/io/javalin/config/RouterConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/RouterConfig.kt
@@ -33,10 +33,6 @@ class RouterConfig(internal val cfg: JavalinConfig) {
     @JvmField var treatMultipleSlashesAsSingleSlash = false
     /** If true, treat '/PATH' and '/path' as the same path (default: false). */
     @JvmField var caseInsensitiveRoutes = false
-    /** Default HTTP status code when the server had a timeout. */
-    @JvmField var timeoutStatus = 408
-    /** Default HTTP status code when the client closes the connection. */
-    @JvmField var clientAbortStatus = 499
     // @formatter:on
 
     internal var javaLangErrorHandler: JavaLangErrorHandler = JavaLangErrorHandler { res, error ->

--- a/javalin/src/main/java/io/javalin/http/HttpResponseException.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpResponseException.kt
@@ -10,6 +10,7 @@ import io.javalin.http.HttpStatus.ACCEPTED
 import io.javalin.http.HttpStatus.ALREADY_REPORTED
 import io.javalin.http.HttpStatus.BAD_GATEWAY
 import io.javalin.http.HttpStatus.BAD_REQUEST
+import io.javalin.http.HttpStatus.CLIENT_CLOSED_REQUEST
 import io.javalin.http.HttpStatus.CONFLICT
 import io.javalin.http.HttpStatus.CONTENT_TOO_LARGE
 import io.javalin.http.HttpStatus.CONTINUE
@@ -345,6 +346,11 @@ open class UnavailableForLegalReasonsResponse @JvmOverloads constructor(
     message: String = UNAVAILABLE_FOR_LEGAL_REASONS.message,
     details: Map<String, String> = mapOf()
 ) : HttpResponseException(UNAVAILABLE_FOR_LEGAL_REASONS, message, details)
+
+open class ClientClosedRequestResponse @JvmOverloads constructor(
+    message: String = CLIENT_CLOSED_REQUEST.message,
+    details: Map<String, String> = mapOf()
+) : HttpResponseException(CLIENT_CLOSED_REQUEST, message, details)
 
 open class InternalServerErrorResponse @JvmOverloads constructor(
     message: String = INTERNAL_SERVER_ERROR.message,

--- a/javalin/src/main/java/io/javalin/http/HttpStatus.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpStatus.kt
@@ -110,6 +110,8 @@ enum class HttpStatus(val code: Int, val message: String) {
     REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
     /** The user agent requested a resource that cannot legally be provided, such as a web page censored by a government. */
     UNAVAILABLE_FOR_LEGAL_REASONS(451, "Unavailable for Legal Reason"),
+    /** The client has closed the connection prematurely, before the server could deliver a response. */
+    CLIENT_CLOSED_REQUEST(499, "Client Closed Request"),
 
     /** The server has encountered a situation it does not know how to handle. */
     INTERNAL_SERVER_ERROR(500, "Server Error"),

--- a/javalin/src/main/java/io/javalin/router/InternalRouter.kt
+++ b/javalin/src/main/java/io/javalin/router/InternalRouter.kt
@@ -1,5 +1,6 @@
 package io.javalin.router
 
+import io.javalin.config.JettyConfig
 import io.javalin.config.RouterConfig
 import io.javalin.event.EventManager
 import io.javalin.event.HandlerMetaInfo
@@ -26,12 +27,13 @@ import java.util.stream.Stream
 open class InternalRouter(
     private val wsRouter: WsRouter,
     private val eventManager: EventManager,
-    private val routerConfig: RouterConfig
+    private val routerConfig: RouterConfig,
+    jettyConfig: JettyConfig
 ) {
 
     protected open val httpPathMatcher = PathMatcher()
     protected open val httpErrorMapper = ErrorMapper()
-    protected open val httpExceptionMapper = ExceptionMapper(routerConfig)
+    protected open val httpExceptionMapper = ExceptionMapper(routerConfig, jettyConfig)
 
     /**
      * Adds a request handler for the specified handlerType and path to the instance.

--- a/javalin/src/main/java/io/javalin/router/exception/ExceptionMapper.kt
+++ b/javalin/src/main/java/io/javalin/router/exception/ExceptionMapper.kt
@@ -35,8 +35,8 @@ class ExceptionMapper(private val routerConfig: RouterConfig) {
             return handle(ctx, t.cause as Exception)
         }
         when {
-            isClientAbortException(t) -> logDebugAndSetError(t, ctx.res(), HttpStatus.CLIENT_CLOSED_REQUEST)
-            isJettyTimeoutException(t) -> logDebugAndSetError(t, ctx.res(), HttpStatus.REQUEST_TIMEOUT)
+            isClientAbortException(t) -> logDebugAndSetError(t, ctx.res(), HttpStatus.forStatus(routerConfig.clientAbortStatus))
+            isJettyTimeoutException(t) -> logDebugAndSetError(t, ctx.res(), HttpStatus.forStatus(routerConfig.timeoutStatus))
             t is Exception -> Util.findByClass(handlers, t.javaClass)?.handle(t, ctx) ?: uncaughtException(ctx, t)
             else -> handleUnexpectedThrowable(ctx.res(), t)
         }
@@ -51,8 +51,8 @@ class ExceptionMapper(private val routerConfig: RouterConfig) {
         res.status = INTERNAL_SERVER_ERROR.code
         when {
             throwable is Error -> routerConfig.javaLangErrorHandler.handle(res, throwable)
-            isClientAbortException(throwable) -> logDebugAndSetError(throwable, res, HttpStatus.CLIENT_CLOSED_REQUEST)
-            isJettyTimeoutException(throwable) -> logDebugAndSetError(throwable, res, HttpStatus.REQUEST_TIMEOUT)
+            isClientAbortException(throwable) -> logDebugAndSetError(throwable, res, HttpStatus.forStatus(routerConfig.clientAbortStatus))
+            isJettyTimeoutException(throwable) -> logDebugAndSetError(throwable, res, HttpStatus.forStatus(routerConfig.timeoutStatus))
             else -> JavalinLogger.error("Exception occurred while servicing http-request", throwable)
         }
         return null

--- a/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
+++ b/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
@@ -109,7 +109,7 @@ class TestExceptionMapper {
 
     @Test
     fun `jetty eof exceptions are caught and handled as errors`() = TestUtil.test(Javalin.create {
-        it.router.clientAbortStatus = 499
+        it.jetty.clientAbortStatus = 499
     }) { app, http ->
         app.get("/") { throw EofException() }
         assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.forStatus(499))
@@ -117,7 +117,7 @@ class TestExceptionMapper {
 
     @Test
     fun `jetty timeout exceptions are caught and handled as errors`() = TestUtil.test(Javalin.create {
-        it.router.timeoutStatus = 408
+        it.jetty.timeoutStatus = 408
     }) { app, http ->
         app.get("/") { throw IOException("timeout", TimeoutException()) }
         assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.forStatus(408))

--- a/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
+++ b/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
@@ -9,6 +9,7 @@ package io.javalin
 
 import io.javalin.http.BadRequestResponse
 import io.javalin.http.HttpResponseException
+import io.javalin.http.HttpStatus
 import io.javalin.http.HttpStatus.BAD_REQUEST
 import io.javalin.http.HttpStatus.INTERNAL_SERVER_ERROR
 import io.javalin.http.HttpStatus.NOT_FOUND
@@ -20,6 +21,8 @@ import io.javalin.testing.httpCode
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.io.EofException
 import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.util.concurrent.TimeoutException
 import kotlin.reflect.full.allSuperclasses
 
 class TestExceptionMapper {
@@ -107,7 +110,13 @@ class TestExceptionMapper {
     @Test
     fun `jetty eof exceptions are caught and handled as errors`() = TestUtil.test { app, http ->
         app.get("/") { throw EofException() }
-        assertThat(http.get("/").httpCode()).isEqualTo(INTERNAL_SERVER_ERROR)
+        assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST)
+    }
+
+    @Test
+    fun `jetty timeout exceptions are caught and handled as errors`() = TestUtil.test { app, http ->
+        app.get("/") { throw IOException("timeout", TimeoutException()) }
+        assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.REQUEST_TIMEOUT)
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
+++ b/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
@@ -108,15 +108,19 @@ class TestExceptionMapper {
     }
 
     @Test
-    fun `jetty eof exceptions are caught and handled as errors`() = TestUtil.test { app, http ->
+    fun `jetty eof exceptions are caught and handled as errors`() = TestUtil.test(Javalin.create {
+        it.router.clientAbortStatus = 499
+    }) { app, http ->
         app.get("/") { throw EofException() }
-        assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.CLIENT_CLOSED_REQUEST)
+        assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.forStatus(499))
     }
 
     @Test
-    fun `jetty timeout exceptions are caught and handled as errors`() = TestUtil.test { app, http ->
+    fun `jetty timeout exceptions are caught and handled as errors`() = TestUtil.test(Javalin.create {
+        it.router.timeoutStatus = 408
+    }) { app, http ->
         app.get("/") { throw IOException("timeout", TimeoutException()) }
-        assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.REQUEST_TIMEOUT)
+        assertThat(http.get("/").httpCode()).isEqualTo(HttpStatus.forStatus(408))
     }
 
     @Test


### PR DESCRIPTION
## 🧠 Motivation

Map client aborts to 499 and timeouts to 408.

Previously, both were returned as 500, mixing them with genuine server errors. Now, client disconnects are tracked as 499 (Client Closed Request), and request timeouts produce 408 (Request Timeout) to better categorize errors in logs and monitoring tools.

- **Author:** @martinsk82 [martin.kozlowski@mercadolibre.com]
- **Affiliation:** MercadoLibre
- **OSPO Contact:** ospo@mercadolibre.com
- **Context:** Strategic collaboration from Mercadolibre's internal Open Source Program Office (OSPO)