### PR TITLE
Update micrometer to latest patch version

### DIFF
--- a/javalin-micrometer/pom.xml
+++ b/javalin-micrometer/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <copy-build-resources.skip>false</copy-build-resources.skip>
 
-        <micrometer.version>1.13.4</micrometer.version>
+        <micrometer.version>1.13.12</micrometer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
When updating micrometer to the latest version (1.14.5) the tests fail. 

This should be investigated more, but until then we could update the 1.13 dependency to the latest patch version. 
