### PR TITLE
Set version for maven-deploy-plugin

### DIFF
--- a/javalin-utils/coverage/pom.xml
+++ b/javalin-utils/coverage/pom.xml
@@ -51,6 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
When running `./mvnw test`, the following warnings appear:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.javalin:coverage:pom:6.5.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 51, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

This PR sets the version of this plugin to the latest stable version. 