### PR TITLE
[tests] Add java argument to surefire for mockito as a java agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,9 @@
                                 junit.jupiter.execution.timeout.default = 1m
                             </configurationParameters>
                         </properties>
+                        <argLine>
+                            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                        </argLine>
                         <!--
                         default: **/*$*
                         Source: https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes


### PR DESCRIPTION
This output is showing while running tests:

> Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work
 in future releases of the JDK. Please add Mockito as an agent to your build what is describe
d in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mock
ito/Mockito.html#0.3

Not sure where that documentation is, link doesn't seem right, but following [this Stack Overflow answer](https://stackoverflow.com/a/79213258/1132101) this should be the way, and it does work.