### PR TITLE
[deps] Some further minor and patch version updates

### DIFF
--- a/javalin-rendering/pom.xml
+++ b/javalin-rendering/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
-            <version>0.23.0</version>
+            <version>0.24.0</version>
             <optional>true</optional>
         </dependency>
         <!-- END OPTIONAL TEMPLATE ENGINES -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <source.plugin.version>3.3.1</source.plugin.version>
         <moditect.plugin.version>1.2.2.Final</moditect.plugin.version>
         <maven.javadoc.skip>true</maven.javadoc.skip> <!-- property used by the javadoc plugin, which is triggered by ... something in the pom -->
-        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.13</jacoco.plugin.version>
 
         <!-- DEPENDENCIES -->
         <annotations.version>26.0.2</annotations.version>
@@ -93,20 +93,20 @@
         <jetty.jakarta-api>5.0.2</jetty.jakarta-api>
         <jackson.version>2.18.3</jackson.version>
         <jackson.databind.version>2.18.3</jackson.databind.version>
-        <brotli4j.version>1.17.0</brotli4j.version>
+        <brotli4j.version>1.18.0</brotli4j.version>
         <logback.version>1.5.18</logback.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <gson.version>2.11.0</gson.version>
+        <gson.version>2.13.0</gson.version>
         <okhttp.version>4.12.0</okhttp.version> <!-- Also used for testing in SSL plugin -->
 
         <!-- SSL DEPENDENCIES -->
-        <sslcontext-kickstart.version>8.3.7</sslcontext-kickstart.version>
+        <sslcontext-kickstart.version>9.1.0</sslcontext-kickstart.version>
 
         <!-- TEST DEPENDENCIES -->
         <assertj.version>3.27.3</assertj.version>
         <moshi.version>1.15.2</moshi.version>
         <java.websocket.version>1.6.0</java.websocket.version>
-        <junit.version>5.12.1</junit.version>
+        <junit.version>5.12.2</junit.version>
         <jmh.version>1.37</jmh.version>
         <mockito.version>5.16.1</mockito.version>
         <mockk.version>1.13.17</mockk.version>


### PR DESCRIPTION
Updates some more dependencies. I believe all dependencies are now updated to their latest released version, except the following:

* Kotlin 2 and JTE 3 (see [here](https://github.com/javalin/javalin/pull/2392))
* Jetty 12 (see [here](https://github.com/javalin/javalin/issues/2067)) 
* Dokka plugin (mentioned [here](https://github.com/javalin/javalin/blob/f7d5fa7068d23c2532cf5a9551b7537e83f5522b/pom.xml#L74), did not investigate further)
* Pebble 3.2 (tests break, did not investigate much, is it perhaps related to [this](https://github.com/javalin/javalin/blob/f7d5fa7068d23c2532cf5a9551b7537e83f5522b/javalin-rendering/src/main/java/io/javalin/rendering/util/RenderingDependency.kt#L26)?)