### PR TITLE
feat: add Context.disableCompression() to disable response compression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.3.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           files: "${{ github.workspace }}/javalin-utils/coverage/target/site/jacoco-aggregate/jacoco.xml"
           verbose: true

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -360,6 +360,12 @@ interface Context {
     fun minSizeForCompression(minSizeForCompression: Int): Context
 
     /**
+     * Disables compression for the response output stream.
+     * Equivalent to calling [minSizeForCompression] with [Integer.MAX_VALUE].
+     */
+    fun disableCompression(): Context = minSizeForCompression(Int.MAX_VALUE)
+
+    /**
      * Writes the specified inputStream as a seekable stream.
      * You can change this default in [io.javalin.config.JavalinConfig].
      *

--- a/javalin/src/test/java/io/javalin/TestCompression.kt
+++ b/javalin/src/test/java/io/javalin/TestCompression.kt
@@ -430,13 +430,13 @@ class TestCompression {
     @Test
     fun `disableCompression disables compression even if size is big`() = TestUtil.test(superCompressingApp()) { app, http ->
         app.get("/disabled-compression") { ctx ->
-            ctx.disableCompression() // ✅ 네가 만든 기능
-            ctx.result("a".repeat(10_000)) // 충분히 압축 가능한 길이
+            ctx.disableCompression()
+            ctx.result("a".repeat(10_000))
         }
 
         val response = getResponse(http.origin, "/disabled-compression", "br, gzip")
 
-        assertThat(response.header(Header.CONTENT_ENCODING)).isNull() // ✅ 압축이 비활성화됐는지 검증
+        assertThat(response.header(Header.CONTENT_ENCODING)).isNull()
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestCompression.kt
+++ b/javalin/src/test/java/io/javalin/TestCompression.kt
@@ -428,11 +428,15 @@ class TestCompression {
     }
 
     @Test
-    fun `disables compression using disableCompression`() {
-        testValidUncompressedHandler { ctx ->
-            ctx.disableCompression()
-            ctx.contentType(ContentType.APPLICATION_JSON).result(sampleJson10k)
+    fun `disableCompression disables compression even if size is big`() = TestUtil.test(superCompressingApp()) { app, http ->
+        app.get("/disabled-compression") { ctx ->
+            ctx.disableCompression() // ✅ 네가 만든 기능
+            ctx.result("a".repeat(10_000)) // 충분히 압축 가능한 길이
         }
+
+        val response = getResponse(http.origin, "/disabled-compression", "br, gzip")
+
+        assertThat(response.header(Header.CONTENT_ENCODING)).isNull() // ✅ 압축이 비활성화됐는지 검증
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestCompression.kt
+++ b/javalin/src/test/java/io/javalin/TestCompression.kt
@@ -428,6 +428,14 @@ class TestCompression {
     }
 
     @Test
+    fun `disables compression using disableCompression`() {
+        testValidUncompressedHandler { ctx ->
+            ctx.disableCompression()
+            ctx.contentType(ContentType.APPLICATION_JSON).result(sampleJson10k)
+        }
+    }
+
+    @Test
     fun `compresses a large Stream of JSON`() {
         data class Foo(val value: Long) // will become 19 chars in JSON, 20 with comma separator
         fun createLargeJsonStream() = generateSequence { Foo(123456789) }.take(500).asStream() // > 10,000 chars


### PR DESCRIPTION
This PR adds `Context.disableCompression()` to allow disabling response compression on a per-endpoint basis.

Implements the feature discussed in [#2372](https://github.com/javalin/javalin/issues/2372).

Let me know if there’s anything I should refine before this can be merged.