### PR TITLE
feat: Add route roles for static files

### DIFF
--- a/javalin/src/main/java/io/javalin/config/StaticFilesConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/StaticFilesConfig.kt
@@ -4,6 +4,7 @@ import io.javalin.http.Header
 import io.javalin.http.staticfiles.Location
 import io.javalin.http.staticfiles.StaticFileConfig
 import io.javalin.jetty.JettyResourceHandler
+import io.javalin.security.RouteRole
 import java.util.function.Consumer
 
 /**
@@ -27,11 +28,13 @@ class StaticFilesConfig(private val cfg: JavalinConfig) {
      * Adds the given directory as a static file containers.
      * @param directory the directory where your files are located
      * @param location the location of the static directory (default: CLASSPATH)
+     * @param roles the roles which can access the the static directory (default: emptySet())
      */
     @JvmOverloads
-    fun add(directory: String, location: Location = Location.CLASSPATH) = add { staticFiles ->
+    fun add(directory: String, location: Location = Location.CLASSPATH, roles: Set<RouteRole> = emptySet()) = add { staticFiles ->
         staticFiles.directory = directory
         staticFiles.location = location
+        staticFiles.roles = roles
     }
 
     /**

--- a/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
@@ -27,7 +27,7 @@ object DefaultTasks {
         }
         val willMatch by javalinLazy {
             var routeRoles: Set<RouteRole> = servlet.matchedRoles(ctx, requestUri)
-            if(httpHandlerOrNull == null && ctx.method() == HEAD || ctx.method() == GET) {
+            if(httpHandlerOrNull == null && (ctx.method() == HEAD || ctx.method() == GET)) {
                 routeRoles = servlet.cfg.pvt.resourceHandler?.getResourceRouteRoles(ctx) ?: emptySet()
             }
             ctx.setRouteRoles(routeRoles) // set roles for the matched handler

--- a/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
@@ -27,7 +27,7 @@ object DefaultTasks {
         }
         val willMatch by javalinLazy {
             var routeRoles: Set<RouteRole> = servlet.matchedRoles(ctx, requestUri)
-            if(httpHandlerOrNull == null && (ctx.method() == HEAD || ctx.method() == GET)) {
+            if (httpHandlerOrNull == null && (ctx.method() == HEAD || ctx.method() == GET)) {
                 routeRoles = servlet.cfg.pvt.resourceHandler?.getResourceRouteRoles(ctx) ?: emptySet()
             }
             ctx.setRouteRoles(routeRoles) // set roles for the matched handler

--- a/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.java
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.java
@@ -1,6 +1,8 @@
 package io.javalin.http.staticfiles;
 
 import io.javalin.http.Context;
+import io.javalin.security.RouteRole;
+import java.util.Set;
 
 public interface ResourceHandler {
     boolean canHandle(Context context);
@@ -8,4 +10,6 @@ public interface ResourceHandler {
     boolean handle(Context context);
 
     boolean addStaticFileConfig(StaticFileConfig config);
+
+    Set<RouteRole> getResourceRouteRoles(Context ctx);
 }

--- a/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileConfig.kt
@@ -3,6 +3,7 @@ package io.javalin.http.staticfiles
 import io.javalin.config.StaticFilesConfig
 import io.javalin.http.ContentType
 import io.javalin.http.Header
+import io.javalin.security.RouteRole
 import jakarta.servlet.http.HttpServletRequest
 import org.eclipse.jetty.server.handler.ContextHandler.AliasCheck
 
@@ -37,7 +38,8 @@ data class StaticFileConfig(
     @JvmField var aliasCheck: AliasCheck? = null,
     @JvmField var headers: Map<String, String> = mutableMapOf(Header.CACHE_CONTROL to "max-age=0"),
     @JvmField var skipFileFunction: (HttpServletRequest) -> Boolean = { false },
-    @JvmField val mimeTypes: MimeTypesConfig = MimeTypesConfig()
+    @JvmField val mimeTypes: MimeTypesConfig = MimeTypesConfig(),
+    @JvmField var roles: Set<RouteRole> = emptySet()
 ) {
     internal fun refinedToString(): String {
         return this.toString().replace(", skipFileFunction=(jakarta.servlet.http.HttpServletRequest) -> kotlin.Boolean", "")

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -45,7 +45,8 @@ class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
 
     override fun canHandle(ctx: Context) = nonSkippedHandlers(ctx.jettyReq()).any { handler ->
         try {
-            fileOrWelcomeFile(handler, ctx.target) != null
+            val target = URLDecoder.decode(ctx.target, "UTF-8")
+            fileOrWelcomeFile(handler, target) != null
         } catch (e: Exception) {
             e.message?.contains("Rejected alias reference") == true ||  // we want to say these are un-handleable (404)
                 e.message?.contains("Failed alias check") == true // we want to say these are un-handleable (404)
@@ -89,7 +90,7 @@ class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
 
     override fun getResourceRouteRoles(ctx: Context): Set<RouteRole> {
         nonSkippedHandlers(ctx.jettyReq()).forEach { handler ->
-            val target = ctx.target
+            val target = URLDecoder.decode(ctx.target, "UTF-8")
             val fileOrWelcomeFile = fileOrWelcomeFile(handler, target)
             if (fileOrWelcomeFile != null) {
                 return handler.config.roles;

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -90,7 +90,7 @@ class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
         nonSkippedHandlers(ctx.jettyReq()).forEach { handler ->
             val target = ctx.target
             val fileOrWelcomeFile = fileOrWelcomeFile(handler, target)
-            if(fileOrWelcomeFile != null) {
+            if (fileOrWelcomeFile != null) {
                 return handler.config.roles;
             }
         }

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -10,6 +10,7 @@ import io.javalin.config.PrivateConfig
 import io.javalin.http.Context
 import io.javalin.http.staticfiles.Location
 import io.javalin.http.staticfiles.StaticFileConfig
+import io.javalin.security.RouteRole
 import io.javalin.util.JavalinException
 import io.javalin.util.JavalinLogger
 import io.javalin.util.javalinLazy
@@ -84,6 +85,17 @@ class JettyResourceHandler(val pvt: PrivateConfig) : JavalinResourceHandler {
         handlers.asSequence().filter { !it.config.skipFileFunction(jettyRequest) }
 
     private val Context.target get() = this.req().requestURI.removePrefix(this.req().contextPath)
+
+    override fun getResourceRouteRoles(ctx: Context): Set<RouteRole> {
+        nonSkippedHandlers(ctx.jettyReq()).forEach { handler ->
+            val target = ctx.target
+            val fileOrWelcomeFile = fileOrWelcomeFile(handler, target)
+            if(fileOrWelcomeFile != null) {
+                return handler.config.roles;
+            }
+        }
+        return emptySet();
+    }
 
 }
 

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFileAccess.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFileAccess.kt
@@ -1,0 +1,111 @@
+package io.javalin.staticfiles
+
+import io.javalin.Javalin
+import io.javalin.config.JavalinConfig
+import io.javalin.http.ContentType
+import io.javalin.http.Header
+import io.javalin.http.HttpStatus
+import io.javalin.http.HttpStatus.UNAUTHORIZED
+import io.javalin.http.UnauthorizedResponse
+import io.javalin.http.staticfiles.Location
+import io.javalin.security.RouteRole
+import io.javalin.testing.TestUtil
+import io.javalin.testing.httpCode
+import kong.unirest.Unirest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+
+class TestStaticFileAccess {
+
+    enum class MyRole : RouteRole { ROLE_ONE, ROLE_TWO}
+
+    private fun addAuthentication(config: JavalinConfig) {
+        config.router.mount {
+            it.beforeMatched { ctx ->
+                val role: RouteRole? = ctx.queryParam("role")?.let { role -> MyRole.valueOf(role) }
+                val routeRoles = ctx.routeRoles()
+                if (routeRoles != emptySet<RouteRole>() && role !in routeRoles) {
+                    throw UnauthorizedResponse()
+                }
+            }
+        }
+    }
+
+    private val defaultStaticResourceApp: Javalin by lazy {
+        Javalin.create {
+            it.staticFiles.add("/public", Location.CLASSPATH, roles = setOf(MyRole.ROLE_ONE))
+            addAuthentication(it)
+        }
+    }
+
+    private val passingStaticFileConfigResourceApp: Javalin by lazy {
+        Javalin.create {
+            it.staticFiles.add { staticFileConfig ->
+                staticFileConfig.hostedPath = "/"
+                staticFileConfig.directory = "/public"
+                staticFileConfig.location = Location.CLASSPATH
+                staticFileConfig.roles = setOf(MyRole.ROLE_ONE)
+            }
+            addAuthentication(it)
+        }
+    }
+
+    private val externalStaticResourceApp: Javalin by lazy {
+        Javalin.create {
+            it.staticFiles.add("src/test/external/", Location.EXTERNAL, roles = setOf(MyRole.ROLE_ONE))
+            addAuthentication(it)
+        }
+    }
+    private val multiLocationStaticResourceApp: Javalin by lazy {
+        Javalin.create {
+            it.staticFiles.add("src/test/external/", Location.EXTERNAL, roles = setOf(MyRole.ROLE_ONE))
+            it.staticFiles.add("/public/immutable", Location.CLASSPATH, roles = setOf(MyRole.ROLE_TWO))
+            addAuthentication(it)
+        }
+    }
+
+    @Test
+    fun `Authentication works for overlapping route and file name`() = TestUtil.test(defaultStaticResourceApp) { app, http ->
+        app.get("/file") { it.result("Test Route") }
+        assertThat(callWithRole(http.origin, "/file", role = "ROLE_ONE")).isEqualTo("Test Route")
+    }
+
+    @Test
+    fun `Authentication works for passing static config`() = TestUtil.test(passingStaticFileConfigResourceApp) { _, http ->
+        assertThat(callWithRole(http.origin, "/html.html", "ROLE_TWO")).isEqualTo(UNAUTHORIZED.message)
+        assertThat(http.get("/html.html?role=ROLE_ONE").httpCode()).isEqualTo(HttpStatus.OK)
+        assertThat(http.get("/html.html?role=ROLE_ONE").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
+        assertThat(http.getBody("/html.html?role=ROLE_ONE")).contains("HTML works")
+    }
+
+    @Test
+    fun `Authentication works for classPath location`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
+        assertThat(callWithRole(http.origin, "/html.html", "ROLE_TWO")).isEqualTo(UNAUTHORIZED.message)
+        assertThat(http.get("/html.html?role=ROLE_ONE").httpCode()).isEqualTo(HttpStatus.OK)
+        assertThat(http.get("/html.html?role=ROLE_ONE").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
+        assertThat(http.getBody("/html.html?role=ROLE_ONE")).contains("HTML works")
+    }
+
+    @Test
+    fun `Authentication works for external location`() = TestUtil.test(externalStaticResourceApp) { _, http ->
+        assertThat(callWithRole(http.origin, "/html.html", "ROLE_TWO")).isEqualTo(UNAUTHORIZED.message)
+        assertThat(http.get("/html.html?role=ROLE_ONE").httpCode()).isEqualTo(HttpStatus.OK)
+        assertThat(http.get("/html.html?role=ROLE_ONE").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.HTML)
+        assertThat(http.getBody("/html.html?role=ROLE_ONE")).contains("HTML works")
+    }
+
+    @Test
+    fun `Authentication works for multiple location`() = TestUtil.test(multiLocationStaticResourceApp) { _, http ->
+        assertThat(callWithRole(http.origin, "/txt.txt", "ROLE_TWO")).isEqualTo(UNAUTHORIZED.message)
+        assertThat(callWithRole(http.origin, "/txt.txt", "ROLE_ONE")).isEqualTo("Sample text\n")
+        assertThat(http.get("/txt.txt?role=ROLE_ONE").httpCode()).isEqualTo(HttpStatus.OK)
+
+        assertThat(callWithRole(http.origin, "/library-1.0.0.min.js", "ROLE_ONE")).isEqualTo(UNAUTHORIZED.message)
+        assertThat(callWithRole(http.origin, "/library-1.0.0.min.js", "ROLE_TWO")).isEqualTo("console.log(\"Cached for a year\")\n")
+        assertThat(http.get("/library-1.0.0.min.js?role=ROLE_TWO").httpCode()).isEqualTo(HttpStatus.OK)
+    }
+
+    private fun callWithRole(origin: String, path: String, role: String) =
+        Unirest.get(origin + path).queryString("role", role).asString().body
+}


### PR DESCRIPTION
Provided feature for the issue  https://github.com/javalin/javalin/issues/2364.
Example use case : 
``` Java 
var app = Javalin
            .create(config -> {
                config.staticFiles.add(staticFileConfig -> {
                    staticFileConfig.hostedPath = "/";
                    staticFileConfig.directory = "/public";
                    staticFileConfig.location = Location.CLASSPATH;
                    staticFileConfig.roles = Set.of(Role.USER);
                });
            })
            .start();
```