### PR TITLE
Change `throwContentTooLargeIfContentTooLarge` to throw for unknown body sizes

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -238,9 +238,9 @@ internal object MaxRequestSize {
 
     fun throwContentTooLargeIfContentTooLarge(ctx: Context) {
         val maxRequestSize = ctx.appData(MaxRequestSizeKey)
-
-        if (ctx.req().contentLength > maxRequestSize) {
-            JavalinLogger.warn("Body greater than max size ($maxRequestSize bytes)")
+        val contentLength = ctx.req().contentLengthLong
+        if (contentLength < 0 || contentLength > maxRequestSize) {
+            JavalinLogger.warn("Body size unknown or greater than max size ($maxRequestSize bytes)")
             throw HttpResponseException(CONTENT_TOO_LARGE, CONTENT_TOO_LARGE.message)
         }
     }


### PR DESCRIPTION
A malicious client can use `Transfer-Encoding: chunked` with an arbitrarily large request body, causing [`Context.bodyAsBytes()`](https://github.com/Petersoj/javalin/blob/02f5676b6e6b0c537d3ec0be9f39728dc40791b5/javalin/src/main/java/io/javalin/http/Context.kt#L146) to read the arbitrarily large request body fully into memory, bypassing the `maxRequestSize` config setting and potentially causing OOM errors and the JVM to crash. Perhaps this should be a CVE?