### PR TITLE
[compression] Add preferred compressors list

### DIFF
--- a/javalin/src/main/java/io/javalin/compression/CompressedStream.kt
+++ b/javalin/src/main/java/io/javalin/compression/CompressedStream.kt
@@ -5,6 +5,7 @@ import io.javalin.http.Header
 import jakarta.servlet.ServletOutputStream
 import jakarta.servlet.WriteListener
 import java.io.OutputStream
+import java.util.Locale.getDefault
 
 internal class CompressedOutputStream(
     val minSizeForCompression: Int,
@@ -22,7 +23,7 @@ internal class CompressedOutputStream(
                 compression.allowsForCompression(ctx.res().contentType)
             val isCompressionDesired = length >= minSizeForCompression
             if (isCompressionAllowed && isCompressionDesired) {
-                findMatchingCompressor(compression, ctx)?.also {
+                compression.findMatchingCompressor(ctx.header(Header.ACCEPT_ENCODING) ?: "")?.also {
                     this.compressedStream = it.compress(originStream)
                     ctx.header(Header.CONTENT_ENCODING, it.encoding())
                 }
@@ -48,14 +49,6 @@ internal class CompressedOutputStream(
     }
 
 }
-
-private fun findMatchingCompressor(
-    compression: CompressionStrategy,
-    ctx: Context,
-): Compressor? =
-    ctx.header(Header.ACCEPT_ENCODING)?.let { acceptedEncoding ->
-        compression.compressors.firstOrNull { acceptedEncoding.contains(it.encoding(), ignoreCase = true) }
-    }
 
 
 private fun CompressionStrategy.allowsForCompression(contentType: String?): Boolean =

--- a/javalin/src/main/java/io/javalin/compression/CompressionStrategy.kt
+++ b/javalin/src/main/java/io/javalin/compression/CompressionStrategy.kt
@@ -5,6 +5,7 @@ import io.javalin.util.CoreDependency
 import io.javalin.util.DependencyUtil
 import io.javalin.util.JavalinLogger
 import io.javalin.util.Util
+import java.util.Locale.getDefault
 
 /**
  * This class is a settings container for Javalin's content compression.
@@ -74,6 +75,8 @@ class CompressionStrategy(brotli: Brotli? = null, gzip: Gzip? = null) {
         "application/x-rar-compressed"
     )
 
+    var preferredCompressors: List<CompressionType> = listOf()
+
     /**
      * When enabling Brotli, we try loading the jvm-brotli native libraries first.
      * If this fails, we keep Brotli disabled and warn the user.
@@ -99,6 +102,37 @@ class CompressionStrategy(brotli: Brotli? = null, gzip: Gzip? = null) {
                 null
             }
         }
+    }
+
+    private fun getPreferredCompressorForSupportedCompressors(supportedCompressors: List<String>): Compressor?
+    {
+        for (preferredCompressor in preferredCompressors) {
+            if(supportedCompressors.contains(preferredCompressor.typeName)) {
+                val compressor = compressors.forType(preferredCompressor.typeName)
+
+                if(compressor != null) {
+                    return compressor
+                }
+            }
+        }
+
+        return null;
+    }
+
+    fun findMatchingCompressor(encodingHeaderValue: String): Compressor?
+    {
+        val supportedCompressors = encodingHeaderValue
+            .split(",")
+            .map { it.trim() }
+            .map { it.lowercase(getDefault()) }
+
+        val compressor = getPreferredCompressorForSupportedCompressors(supportedCompressors)
+
+        if (compressor != null) {
+            return compressor
+        }
+
+        return supportedCompressors.firstNotNullOfOrNull { compressors.forType(it) }
     }
 
 }

--- a/javalin/src/test/java/io/javalin/TestCompression.kt
+++ b/javalin/src/test/java/io/javalin/TestCompression.kt
@@ -9,6 +9,7 @@ package io.javalin
 
 import io.javalin.compression.Brotli
 import io.javalin.compression.CompressionStrategy
+import io.javalin.compression.CompressionType
 import io.javalin.compression.Compressor
 import io.javalin.compression.Gzip
 import io.javalin.http.ContentType
@@ -68,6 +69,11 @@ class TestCompression {
         get("/huge") { it.result(getSomeObjects(1000).toString()) }
         get("/tiny") { it.result(getSomeObjects(10).toString()) }
     }
+
+    private fun preferredCompressors(prefCompressors : List<CompressionType>) = Javalin.create {
+        it.http.customCompression(CompressionStrategy(Brotli(), Gzip()).apply { preferredCompressors = prefCompressors })
+        it.staticFiles.add("/public", Location.CLASSPATH)
+    }.addTestEndpoints()
 
     @Test
     fun `Compresssor interface works`() {
@@ -447,6 +453,60 @@ class TestCompression {
             ctx.writeJsonStream(createLargeJsonStream())
         }
         // no test for uncompressed since writing a Stream<T> forces compression
+    }
+
+    @Test
+    @EnabledIf("brotliAvailable")
+    fun `assure preferred compressor is respected (br)`() = TestUtil.test(preferredCompressors(listOf(
+        CompressionType.BR, CompressionType.GZIP
+    ))) { app, http ->
+        getResponse(http.origin, "/huge", "gzip, br").let { response -> // dynamic
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("br")
+        }
+        getResponse(http.origin, "/svg.svg", "gzip, br").let { response -> // static
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("br")
+        }
+
+        getResponse(http.origin, "/huge", "br, gzip").let { response -> // dynamic
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("br")
+        }
+        getResponse(http.origin, "/svg.svg", "br, gzip").let { response -> // static
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("br")
+        }
+
+        getResponse(http.origin, "/huge", "").let { response -> // dynamic
+            assertThat(response.header(Header.CONTENT_ENCODING)).isNull()
+        }
+        getResponse(http.origin, "/svg.svg", "").let { response -> // static
+            assertThat(response.header(Header.CONTENT_ENCODING)).isNull()
+        }
+    }
+
+    @Test
+    @EnabledIf("brotliAvailable")
+    fun `assure preferred compressor is respected (gzip)`() = TestUtil.test(preferredCompressors(listOf(
+        CompressionType.GZIP, CompressionType.BR
+    ))) { app, http ->
+        getResponse(http.origin, "/huge", "gzip, br").let { response -> // dynamic
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("gzip")
+        }
+        getResponse(http.origin, "/svg.svg", "gzip, br").let { response -> // static
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("gzip")
+        }
+
+        getResponse(http.origin, "/huge", "br, gzip").let { response -> // dynamic
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("gzip")
+        }
+        getResponse(http.origin, "/svg.svg", "br, gzip").let { response -> // static
+            assertThat(response.header(Header.CONTENT_ENCODING)).isEqualTo("gzip")
+        }
+
+        getResponse(http.origin, "/huge", "").let { response -> // dynamic
+            assertThat(response.header(Header.CONTENT_ENCODING)).isNull()
+        }
+        getResponse(http.origin, "/svg.svg", "").let { response -> // static
+            assertThat(response.header(Header.CONTENT_ENCODING)).isNull()
+        }
     }
 
     private fun assertUncompressedResponse(origin: String, url: String) {


### PR DESCRIPTION
I was missing a way to select a preferred compression type server side. Currently the first compression type supported by both the client and the server is selected, usually browsers send brotli as last, which resulted in gzip to always be favored over it.

I added a new List that allows us to specify our preference on the server side by priority (according to the order of the elements in the list).

I never programmed in Kotlin and it's my first contribution to this project, so please guide me how to get the pull request ready to merge.