### PR TITLE
Bump and rename sslcontext-kickstart to ayza

### DIFF
--- a/javalin-ssl/README.md
+++ b/javalin-ssl/README.md
@@ -171,10 +171,10 @@ sslPlugin.reload {
 
 ## Depends on
 
-| Package                                                                 | License                                                                                                              |
-|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| [Javalin](https://github.com/javalin/javalin)                           | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |
-| [SSLContext Kickstart](https://github.com/Hakky54/sslcontext-kickstart) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |
+| Package                                       | License                                                                                                              |
+|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| [Javalin](https://github.com/javalin/javalin) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |
+| [Ayza](https://github.com/Hakky54/ayza)       | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |
 
 ## Contributing
 

--- a/javalin-ssl/pom.xml
+++ b/javalin-ssl/pom.xml
@@ -83,15 +83,15 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart</artifactId>
+            <artifactId>ayza</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-jetty</artifactId>
+            <artifactId>ayza-for-jetty</artifactId>
         </dependency>
         <!-- BEGIN TEST DEPENDENCIES -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <okhttp.version>4.12.0</okhttp.version> <!-- Also used for testing in SSL plugin -->
 
         <!-- SSL DEPENDENCIES -->
-        <sslcontext-kickstart.version>9.1.0</sslcontext-kickstart.version>
+        <ayza.version>10.0.0</ayza.version>
 
         <!-- TEST DEPENDENCIES -->
         <assertj.version>3.27.3</assertj.version>
@@ -181,18 +181,18 @@
             <!-- SSL Plugin -->
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart</artifactId>
-                <version>${sslcontext-kickstart.version}</version>
+                <artifactId>ayza</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-jetty</artifactId>
-                <version>${sslcontext-kickstart.version}</version>
+                <artifactId>ayza-for-jetty</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-pem</artifactId>
-                <version>${sslcontext-kickstart.version}</version>
+                <artifactId>ayza-for-pem</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
 
             <!-- BEGIN Optional dependencies -->


### PR DESCRIPTION
I have renamed the library recently to ayza. This PR bumps the version to the latest and includes also the name change