### PR TITLE
[context] add support for quoted charset in content-type header (#2448)

### DIFF
--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServletContext.kt
@@ -192,7 +192,7 @@ open class JavalinServletContext(
 
 // this header is semicolon separated, like: "text/html; charset=UTF-8"
 fun getRequestCharset(ctx: Context) = ctx.req().getHeader(Header.CONTENT_TYPE)?.let { value ->
-    value.split(";").find { it.trim().startsWith("charset", ignoreCase = true) }?.let { it.split("=")[1].trim() }
+    value.split(";").find { it.trim().startsWith("charset", ignoreCase = true) }?.let { it.split("=")[1].trim().removeSurrounding("\"") }
 }
 
 fun splitKeyValueStringAndGroupByKey(string: String, charset: String): Map<String, List<String>> =

--- a/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
+++ b/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
@@ -6,7 +6,13 @@ import io.javalin.testing.TestUtil
 import io.javalin.testing.httpCode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ContentTypeTest {
 
     @Test
@@ -44,6 +50,30 @@ class ContentTypeTest {
             assertThat(response.httpCode()).isEqualTo(OK)
             assertThat(response.body).contains("# Hello Markdown!")
             assertThat(response.headers.getFirst(Header.CONTENT_TYPE)).isEqualTo("")
+        }
+    }
+
+    fun contentTypes(): Stream<Arguments?> {
+        return Stream.of(
+            Arguments.of("application/json;charset=utf-8"),
+            Arguments.of("application/json;charset=UTF-8"),
+            Arguments.of("application/json;Charset=\"utf-8\" "),
+            Arguments.of("application/json; charset=\"utf-8\""),
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("contentTypes")
+    fun `quoted charset parameter should be handled successfully`(contentType: String) {
+        TestUtil.test { app, http ->
+            app.post("/foo") { ctx ->
+                ctx.result(ctx.body())
+            }
+            val result = http.post("/foo")
+                .header("Content-type", contentType)
+                .body("{}")
+                .asString()
+            assertThat(result.httpCode()).isEqualTo(OK)
         }
     }
 


### PR DESCRIPTION
Small fix regarding quoted charset parameter in content-type header. 
Content-type headers like `application/json;charset="utf-8"` were causing errors.
Changed content-type header parsing to handle both quoted and unquoted values and added a parameterized test for verification.

Fixes #2448