### PR TITLE
Draft for demonstrating reflection reduction via `NoClassDefFoundError`

### DIFF
--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -242,6 +242,22 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>compile-java21</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>21</release>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <compileSourceRoots>
+                                <root>${project.basedir}/src/main/java21</root>
+                            </compileSourceRoots>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -77,16 +77,18 @@ class JavalinJackson(
     companion object {
         @JvmStatic
         fun defaultMapper(): ObjectMapper = ObjectMapper()
-            .registerOptionalModule(CoreDependency.JACKSON_KT.testClass)
-            .registerOptionalModule(CoreDependency.JACKSON_JSR_310.testClass)
-            .registerOptionalModule(CoreDependency.JACKSON_ECLIPSE_COLLECTIONS.testClass)
-            .registerOptionalModule(CoreDependency.JACKSON_KTORM.testClass) // very optional module for ktorm (a kotlin orm)
+            .registerOptionalModule(CoreDependency.JACKSON_KT.testClass) { com.fasterxml.jackson.module.kotlin.KotlinModule.Builder().build() }
+            .registerOptionalModule(CoreDependency.JACKSON_JSR_310.testClass) { com.fasterxml.jackson.datatype.jsr310.JavaTimeModule.Builder().build() }
+            .registerOptionalModule(CoreDependency.JACKSON_ECLIPSE_COLLECTIONS.testClass) { com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule.Builder().build() }
+
+            // very optional module for ktorm (a kotlin orm)
+            .registerOptionalModule(CoreDependency.JACKSON_KTORM.testClass) { org.ktorm.jackson.KtormModule.Builder().build() }
     }
 }
 
-private fun ObjectMapper.registerOptionalModule(classString: String): ObjectMapper {
-    if (Util.classExists(classString)) {
-        this.registerModule(Class.forName(classString).getConstructor().newInstance() as Module)
+private fun ObjectMapper.registerOptionalModule(classAccessor: () -> Any?, classInstantiator: () -> Module): ObjectMapper {
+    if (Util.classExists(classAccessor)) {
+        this.registerModule(classInstantiator())
     }
     return this
 }

--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -35,7 +35,7 @@ object DependencyUtil {
 
 interface OptionalDependency {
     val displayName: String
-    val testClass: String
+    val testClass: () -> Any?
     val groupId: String
     val artifactId: String
     val version: String
@@ -43,26 +43,26 @@ interface OptionalDependency {
 
 enum class CoreDependency(
     override val displayName: String,
-    override val testClass: String,
+    override val testClass: () -> Any?,
     override val groupId: String,
     override val artifactId: String,
     override val version: String
 ) : OptionalDependency {
 
     // JSON (Jackson) handling
-    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.17.2"),
-    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.17.2"),
-    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.17.2"),
-    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.17.2"),
-    JACKSON_KTORM("Jackson Ktorm", "org.ktorm.jackson.KtormModule", "org.ktorm", "ktorm-jackson", "3.6.0"),
+    JACKSON("Jackson", { com.fasterxml.jackson.databind.ObjectMapper::class }, "com.fasterxml.jackson.core", "jackson-databind", "2.17.2"),
+    JACKSON_KT("JacksonKt", { com.fasterxml.jackson.module.kotlin.KotlinModule::class }, "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.17.2"),
+    JACKSON_JSR_310("JacksonJsr310", { com.fasterxml.jackson.datatype.jsr310.JavaTimeModule::class }, "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.17.2"),
+    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", { com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule::class }, "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.17.2"),
+    JACKSON_KTORM("Jackson Ktorm", { org.ktorm.jackson.KtormModule::class }, "org.ktorm", "ktorm-jackson", "3.6.0"),
 
     // JSON (Gson)
-    GSON("Gson", "com.google.gson.Gson", "com.google.code.gson", "gson", "2.11.0"),
+    GSON("Gson", { com.google.gson.Gson::class }, "com.google.code.gson", "gson", "2.11.0"),
 
     // Logging
-    SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "2.0.16"),
+    SLF4JSIMPLE("Slf4j simple", { org.slf4j.impl.StaticLoggerBinder::class }, "org.slf4j", "slf4j-simple", "2.0.16"),
 
     // Compression
-    BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.20.0"),
-    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-4"),
+    BROTLI4J("Brotli4j", { com.aayushatharva.brotli4j.Brotli4jLoader::class }, "com.aayushatharva.brotli4j", "brotli4j", "1.20.0"),
+    ZSTD_JNI("Zstd-jni", { com.github.luben.zstd.Zstd::class }, "com.github.luben", "zstd-jni", "1.5.7-4"),
 }

--- a/javalin/src/main/java/io/javalin/util/Util.kt
+++ b/javalin/src/main/java/io/javalin/util/Util.kt
@@ -33,18 +33,16 @@ object Util {
     @JvmStatic
     fun prefixContextPath(contextPath: String, path: String) = if (path == "*") path else ("$contextPath/$path").replace("/{2,}".toRegex(), "/")
 
-    fun classExists(className: String) = try {
-        Class.forName(className)
-        true
-    } catch (e: ClassNotFoundException) {
+    fun classExists(classAccessor: () -> Any?) = try {
+        classAccessor() != null
+    } catch (e: NoClassDefFoundError) {
         false
     }
 
     private fun slf4jServiceImplementationExists() = try {
-        val serviceClass = Class.forName("org.slf4j.spi.SLF4JServiceProvider")
-        val loader = ServiceLoader.load(serviceClass)
+        val loader = ServiceLoader.load(org.slf4j.spi.SLF4JServiceProvider::class.java)
         loader.any()
-    } catch (e: ClassNotFoundException) {
+    } catch (e: NoClassDefFoundError) {
         false
     }
 

--- a/javalin/src/main/java21/io/javalin/util/ConcurrencyUtil.kt
+++ b/javalin/src/main/java21/io/javalin/util/ConcurrencyUtil.kt
@@ -1,0 +1,44 @@
+package io.javalin.util
+
+import org.eclipse.jetty.util.thread.ThreadPool
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors.newThreadPerTaskExecutor
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+internal object LoomUtil {
+
+    @JvmStatic
+    val loomAvailable: Boolean = true
+
+    @JvmStatic
+    fun executorService(name: String): ExecutorService =
+        newThreadPerTaskExecutor(NamedVirtualThreadFactory(name))
+
+    @JvmStatic
+    fun threadPool(name: String): ThreadPool =
+        LoomThreadPool(name)
+
+    @JvmStatic
+    fun isLoomThreadPool(threadPool: ThreadPool): Boolean =
+        threadPool is LoomThreadPool
+
+    private class LoomThreadPool(name: String) : ThreadPool {
+        private val executorService = executorService(name)
+        override fun join() {}
+        override fun getThreads() = 1
+        override fun getIdleThreads() = 1
+        override fun isLowOnThreads() = false
+        override fun execute(command: Runnable) {
+            executorService.submit(command)
+        }
+    }
+}
+
+internal class NamedVirtualThreadFactory(private val prefix: String) : ThreadFactory {
+    private val threadCount = AtomicInteger(0)
+
+    override fun newThread(runnable: Runnable): Thread = Thread.ofVirtual()
+            .name("$prefix-Virtual-${threadCount.getAndIncrement()}")
+            .unstarted(runnable)
+}


### PR DESCRIPTION
This is a hack, but I've done it a lot and personally think it could be a better way of handling optional dependencies over `Class.forName`

The thing is, `Class.forName` was designed for this very use-case of optional dependencies. Javalin claims "no reflection" even in the very readme file, so there are two ways to back this claim

- Remove all non-test usage of reflection entirely, opting for techniques like these (which work and in my opinion have no downsides, except that readers might be annoyed we are catching `Error`s?

  This even works properly in a `native-image` as well)

- Remove the claim of "no reflection"

Please note that I have no clue on writing idiomatic Kotlin.

Related-to: https://github.com/avaje/avaje-http/pull/670#issuecomment-3567115136
Related-to: https://github.com/avaje/avaje-inject/pull/932
Related-to: https://github.com/avaje/avaje-http/pull/675
Signed-off-by: Mahied Maruf <contact@mechite.com>