### PR TITLE
[json] Fix NoClassDefFoundError for ObjectMapper on Kotlin 2.x

### DIFF
--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -27,7 +27,7 @@ class JavalinJackson(
 
     private val pipedStreamExecutor: PipedStreamExecutor by javalinLazy { PipedStreamExecutor(useVirtualThreads) }
 
-    val mapper by javalinLazy {
+    private val mapperDelegate: Lazy<Any> = javalinLazy {
         if (!Util.classExists(CoreDependency.JACKSON.testClass)) {
             val message =
                 """|It looks like you don't have an object mapper configured.
@@ -41,8 +41,10 @@ class JavalinJackson(
             JavalinLogger.warn(DependencyUtil.wrapInSeparators(message))
             throw InternalServerErrorResponse(message)
         }
-        objectMapper ?: defaultMapper()
+        (objectMapper ?: defaultMapper()) as Any
     }
+
+    val mapper: ObjectMapper get() = mapperDelegate.value as ObjectMapper
 
     override fun toJsonString(obj: Any, type: Type): String = when (obj) {
         is String -> obj // the default mapper treats strings as if they are already JSON


### PR DESCRIPTION
Closes #2509

It looks like Kotlin 2.x changed how lambdas are compiled, using `invokedynamic` with specialized method type signatures. The lazy mapper initialization was generating bytecode with `()Lcom/fasterxml/jackson/databind/ObjectMapper;` as the lambda's return type in the BootstrapMethods table.

I think that when `LambdaMetafactory.metafactory` validates this method type during class initialization, the JVM attempts to load `ObjectMapper`, even though the lambda body hasn't executed yet. This causes `NoClassDefFoundError` when Jackson isn't on the classpath, breaking use cases where JSON isn't needed.

This fix casts the lambda return to Any, which generates `()Ljava/lang/Object;` in the bytecode, avoiding early class loading.

From my own testing, this is a fully functional fix, the reason I'm opening this as a draft is because I'm not sure what the best testing strategy is. I validated this by adding another maven module without Jackson - this however feels way too heavyweight as a permanent test to leave around. However, I also couldn't come up with a good way to unit test this in the existing projects (which obviously have Jackson installed) without super awkward class loader patching hacks? I'm happy to take suggestions here. 