### PR TITLE
Dev server - Hot reload for Maven and Gradle builds

### DIFF
--- a/javalin-build/javalin-build-common/pom.xml
+++ b/javalin-build/javalin-build-common/pom.xml
@@ -22,7 +22,7 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>${asm.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/javalin-build/javalin-build-common/pom.xml
+++ b/javalin-build/javalin-build-common/pom.xml
@@ -22,7 +22,7 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>${asm.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/javalin-build/javalin-build-common/pom.xml
+++ b/javalin-build/javalin-build-common/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.javalin</groupId>
+        <artifactId>javalin-build</artifactId>
+        <version>7.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>javalin-build-common</artifactId>
+    <name>Javalin Build Common</name>
+    <description>Common module providing javalin:dev goal for development mode with automatic recompilation and restart</description>
+
+    <properties>
+        <asm.version>9.9.1</asm.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/classloader/BaseClassLoader.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/classloader/BaseClassLoader.java
@@ -1,0 +1,10 @@
+package io.javalin.dev.classloader;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class BaseClassLoader extends URLClassLoader {
+    public BaseClassLoader(URL[] urls) {
+        super(urls, ClassLoader.getPlatformClassLoader());
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/classloader/RuntimeClassLoader.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/classloader/RuntimeClassLoader.java
@@ -1,0 +1,50 @@
+package io.javalin.dev.classloader;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class RuntimeClassLoader extends URLClassLoader {
+    public RuntimeClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            // Already loaded?
+            Class<?> c = findLoadedClass(name);
+            if (c != null) {
+                if (resolve) {
+                    resolveClass(c);
+                }
+                return c;
+            }
+
+            // JDK classes must be delegated
+            if (isJdkClassName(name)) {
+                return super.loadClass(name, resolve);
+            }
+
+            // Child-first: try own URLs before parent
+            try {
+                c = findClass(name);
+                if (resolve) {
+                    resolveClass(c);
+                }
+                return c;
+            } catch (ClassNotFoundException e) {
+                // Fall through to parent
+            }
+
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static boolean isJdkClassName(String name) {
+        return name.startsWith("java.")
+               || name.startsWith("javax.")
+               || name.startsWith("jdk.")
+               || name.startsWith("sun.")
+               || name.startsWith("com.sun.");
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationInvoker.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationInvoker.java
@@ -1,0 +1,5 @@
+package io.javalin.dev.compilation;
+
+public interface CompilationInvoker {
+    CompilationResult invoke();
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationResult.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationResult.java
@@ -1,0 +1,7 @@
+package io.javalin.dev.compilation;
+
+public enum CompilationResult {
+    NO_CHANGES,
+    SUCCESS,
+    ERROR
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationSourcesList.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationSourcesList.java
@@ -1,0 +1,27 @@
+package io.javalin.dev.compilation;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+
+public record CompilationSourcesList(List<Path> added, List<Path> modified, List<Path> deleted) {
+    @Override
+    public List<Path> added() {
+        return Collections.unmodifiableList(added);
+    }
+
+    @Override
+    public List<Path> modified() {
+        return Collections.unmodifiableList(modified);
+    }
+
+    @Override
+    public List<Path> deleted() {
+        return Collections.unmodifiableList(deleted);
+    }
+
+    public boolean isEmpty() {
+        return added.isEmpty() && modified.isEmpty() && deleted.isEmpty();
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationSourcesTracker.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/compilation/CompilationSourcesTracker.java
@@ -1,0 +1,246 @@
+package io.javalin.dev.compilation;
+
+import io.javalin.dev.log.JavalinDevLogger;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+
+public class CompilationSourcesTracker implements AutoCloseable {
+    private final JavalinDevLogger logger;
+    private final WatchService watchService;
+    private final Map<WatchKey, Path> keyToDir;
+    private final Set<Path> fileOnlyDirs;
+    private final Set<Path> watchedFiles;
+
+    private final Object lock;
+    private final Set<Path> added;
+    private final Set<Path> modified;
+    private final Set<Path> deleted;
+
+    private volatile Thread watchThread;
+    private volatile boolean closed;
+
+    public CompilationSourcesTracker(JavalinDevLogger logger) throws IOException {
+        this.logger = logger;
+        this.watchService = FileSystems.getDefault().newWatchService();
+        this.keyToDir = new HashMap<>();
+        this.fileOnlyDirs = new HashSet<>();
+        this.watchedFiles = new HashSet<>();
+        this.lock = new Object();
+        this.added = new HashSet<>();
+        this.modified = new HashSet<>();
+        this.deleted = new HashSet<>();
+        this.watchThread = null;
+        this.closed = false;
+        logger.debug("CompilationSourcesTracker initialized with WatchService");
+    }
+
+    public void watchDirectory(Path dir) throws IOException {
+        if (dir == null || Files.notExists(dir)) {
+            logger.debug("Skipping watch for non-existent directory: " + dir);
+            return;
+        }
+        Path normalized = dir.toAbsolutePath().normalize();
+        if (Files.isDirectory(normalized)) {
+            logger.info("Watching directory recursively: " + normalized);
+            registerRecursive(normalized);
+        }
+    }
+
+    public void watchFile(Path file) throws IOException {
+        if (file == null || Files.notExists(file)) {
+            logger.debug("Skipping watch for non-existent file: " + file);
+            return;
+        }
+        Path normalized = file.toAbsolutePath().normalize();
+        Path parent = normalized.getParent();
+        if (parent != null && Files.isDirectory(parent)) {
+            watchedFiles.add(normalized);
+            registerSingle(parent);
+            logger.info("Watching file: " + normalized);
+        }
+    }
+
+    public synchronized void recordBaseline() {
+        // Discard any events generated during registration
+        synchronized (lock) {
+            added.clear();
+            modified.clear();
+            deleted.clear();
+        }
+        logger.debug("Baseline recorded, clearing initial events");
+        startWatchThread();
+    }
+
+    public CompilationSourcesList getAndClearChanges() {
+        synchronized (lock) {
+            CompilationSourcesList result = new CompilationSourcesList(
+                List.copyOf(added),
+                List.copyOf(modified),
+                List.copyOf(deleted)
+            );
+
+            added.clear();
+            modified.clear();
+            deleted.clear();
+
+            if (!result.isEmpty()) {
+                logger.info("Detected source changes: added: " + result.added().size()
+                    + ", modified: " + result.modified().size()
+                    + ", deleted: " + result.deleted().size());
+                for (Path p : result.added()) {
+                    logger.debug("  + " + p);
+                }
+                for (Path p : result.modified()) {
+                    logger.debug("  ~ " + p);
+                }
+                for (Path p : result.deleted()) {
+                    logger.debug("  - " + p);
+                }
+            } else {
+                logger.debug("No source changes detected since last check");
+            }
+
+            return result;
+        }
+    }
+
+    private void registerRecursive(Path root) throws IOException {
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                WatchKey key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+                keyToDir.put(key, dir);
+                fileOnlyDirs.remove(dir);
+                logger.debug("Registered watch on directory: " + dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private void registerSingle(Path dir) throws IOException {
+        if (keyToDir.containsValue(dir)) {
+            return;
+        }
+        WatchKey key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+        keyToDir.put(key, dir);
+        fileOnlyDirs.add(dir);
+        logger.debug("Registered single-directory watch on: " + dir);
+    }
+
+    private void startWatchThread() {
+        if (watchThread != null) {
+            return;
+        }
+
+        watchThread = new Thread(new WatchEventProcessor());
+        watchThread.setDaemon(true);
+        watchThread.setName("compilation-source-watcher");
+        watchThread.start();
+        logger.info("File watcher thread started");
+    }
+
+    @Override
+    public void close() throws IOException {
+        logger.info("Closing CompilationSourcesTracker");
+        closed = true;
+        watchService.close();
+        if (watchThread != null) {
+            watchThread.interrupt();
+        }
+        logger.debug("CompilationSourcesTracker closed, watch thread interrupted");
+    }
+
+    private class WatchEventProcessor implements Runnable {
+
+        @Override
+        public void run() {
+            logger.debug("WatchEventProcessor started, waiting for file system events");
+            while (!closed) {
+                try {
+                    WatchKey key = watchService.take();
+
+                    logger.debug("WatchEventProcessor processing key: " + key);
+
+                    Path dir = keyToDir.get(key);
+                    if (dir == null) {
+                        key.cancel();
+                        logger.debug("Received watch key for unknown directory, cancelling");
+                        continue;
+                    }
+
+                    processEvents(key, dir);
+
+                    boolean valid = key.reset();
+                    if (!valid) {
+                        keyToDir.remove(key);
+                        logger.warn("Watch key invalidated for directory: " + dir);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.debug("WatchEventProcessor interrupted, shutting down");
+                    break;
+                } catch (ClosedWatchServiceException e) {
+                    logger.debug("WatchService closed, stopping event processor");
+                    break;
+                }
+            }
+        }
+
+        private void processEvents(WatchKey key, Path dir) {
+            boolean isFileOnly = fileOnlyDirs.contains(dir);
+
+            for (WatchEvent<?> event : key.pollEvents()) {
+                WatchEvent.Kind<?> kind = event.kind();
+                if (kind == OVERFLOW) {
+                    logger.warn("File system event overflow detected in: " + dir);
+                    continue;
+                }
+
+                @SuppressWarnings("unchecked")
+                WatchEvent<Path> pathEvent = (WatchEvent<Path>) event;
+                Path resolved = dir.resolve(pathEvent.context());
+
+                if (isFileOnly && !watchedFiles.contains(resolved)) {
+                    logger.debug("Skipping non-watched file: " + resolved);
+                    continue;
+                }
+
+                if (kind == ENTRY_CREATE && Files.isDirectory(resolved, LinkOption.NOFOLLOW_LINKS)) {
+                    try {
+                        logger.debug("New directory detected, registering recursively: " + resolved);
+                        registerRecursive(resolved);
+                    } catch (IOException e) {
+                        logger.warn("Failed to register new directory: " + resolved + " (" + e.getMessage() + ")");
+                    }
+                }
+
+                logger.debug("File event: " + kind.name() + " -> " + resolved);
+                categorize(kind, resolved);
+            }
+        }
+
+        private void categorize(WatchEvent.Kind<?> kind, Path path) {
+            synchronized (lock) {
+                if (kind == ENTRY_CREATE) {
+                    deleted.remove(path);
+                    modified.remove(path);
+                    added.add(path);
+                } else if (kind == ENTRY_MODIFY) {
+                    if (!added.contains(path)) {
+                        modified.add(path);
+                    }
+                } else if (kind == ENTRY_DELETE) {
+                    if (!added.remove(path)) {
+                        modified.remove(path);
+                        deleted.add(path);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/log/JavalinDevLogger.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/log/JavalinDevLogger.java
@@ -1,0 +1,8 @@
+package io.javalin.dev.log;
+
+public interface JavalinDevLogger {
+    void info(String message);
+    void warn(String message);
+    void error(String message);
+    void debug(String message);
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/ApplicationMainClassCandidate.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/ApplicationMainClassCandidate.java
@@ -1,0 +1,6 @@
+package io.javalin.dev.main;
+
+
+public record ApplicationMainClassCandidate(String className, ApplicationMainClassType type) {
+
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/ApplicationMainClassScanner.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/ApplicationMainClassScanner.java
@@ -1,0 +1,83 @@
+package io.javalin.dev.main;
+
+import io.javalin.dev.log.JavalinDevLogger;
+import org.objectweb.asm.ClassReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+
+public final class ApplicationMainClassScanner {
+    private final JavalinDevLogger logger;
+
+    public ApplicationMainClassScanner(JavalinDevLogger logger) {
+        this.logger = logger;
+    }
+
+    public Map<ApplicationMainClassType, List<ApplicationMainClassCandidate>> scanDirectory(Path classesDir) throws IOException {
+        if (!Files.isDirectory(classesDir)) {
+            logger.warn("Classes directory does not exist: " + classesDir);
+            return Map.of();
+        }
+
+        logger.info("Scanning for main class candidates in: " + classesDir);
+
+        Map<ApplicationMainClassType, List<ApplicationMainClassCandidate>> candidates = new HashMap<>();
+        Files.walkFileTree(classesDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Optional<ApplicationMainClassCandidate> candidate = scanFile(file);
+                if (candidate.isEmpty()) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                candidates.compute(candidate.get().type(), (ignored, candidates) -> {
+                    if (candidates == null) {
+                        candidates = new ArrayList<>();
+                    }
+                    candidates.add(candidate.get());
+                    return candidates;
+                });
+
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        int totalCandidates = candidates.values().stream().mapToInt(List::size).sum();
+        logger.info("Main class scan complete: found " + totalCandidates + " candidate(s) across " + candidates.size() + " type(s)");
+        for (var entry : candidates.entrySet()) {
+            for (var candidate : entry.getValue()) {
+                logger.debug("  Candidate: " + candidate.className() + " [" + candidate.type() + "]");
+            }
+        }
+        return Collections.unmodifiableMap(candidates);
+    }
+
+    public Optional<ApplicationMainClassCandidate> scanFile(Path file) throws IOException {
+        if (!Files.isRegularFile(file)) {
+            return Optional.empty();
+        }
+
+        // Using a PathMatcher is not worth the cost
+        if (!file.toString().endsWith(".class")) {
+            return Optional.empty();
+        }
+
+        try (InputStream in = Files.newInputStream(file)) {
+            ClassReader cr = new ClassReader(in);
+            MainMethodAsmVisitor detector = new MainMethodAsmVisitor();
+            cr.accept(detector, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+
+            return detector.result().map(type -> {
+                String className = cr.getClassName().replace('/', '.');
+                logger.debug("Found main method in: " + className + " [" + type + "]");
+                return new ApplicationMainClassCandidate(className, type);
+            });
+        }
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/ApplicationMainClassType.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/ApplicationMainClassType.java
@@ -1,0 +1,8 @@
+package io.javalin.dev.main;
+
+public enum ApplicationMainClassType {
+    STATIC_MAIN_WITH_ARGS,
+    STATIC_MAIN_WITHOUT_ARGS,
+    INSTANCE_MAIN_WITH_ARGS,
+    INSTANCE_MAIN_WITHOUT_ARGS
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/MainMethodAsmVisitor.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/main/MainMethodAsmVisitor.java
@@ -1,0 +1,68 @@
+package io.javalin.dev.main;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.util.Optional;
+
+class MainMethodAsmVisitor extends ClassVisitor {
+    private ApplicationMainClassType result;
+
+    private boolean hasStaticMainWithArgs;
+    private boolean hasStaticMainNoArgs;
+    private boolean hasInstanceMainWithArgs;
+    private boolean hasInstanceMainNoArgs;
+    private boolean hasValidConstructor;
+
+    MainMethodAsmVisitor() {
+        super(Opcodes.ASM9);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                     String signature, String[] exceptions) {
+        // Check for non-private zero-arg constructor
+        if ("<init>".equals(name) && "()V".equals(descriptor)
+            && (access & Opcodes.ACC_PRIVATE) == 0) {
+            hasValidConstructor = true;
+        }
+
+        // Check for main methods (non-private, void return)
+        if ("main".equals(name) && (access & Opcodes.ACC_PRIVATE) == 0) {
+            boolean isStatic = (access & Opcodes.ACC_STATIC) != 0;
+            if ("([Ljava/lang/String;)V".equals(descriptor)) {
+                if (isStatic) {
+                    hasStaticMainWithArgs = true;
+                } else {
+                    hasInstanceMainWithArgs = true;
+                }
+            } else if ("()V".equals(descriptor)) {
+                if (isStatic) {
+                    hasStaticMainNoArgs = true;
+                } else {
+                    hasInstanceMainNoArgs = true;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void visitEnd() {
+        if (hasStaticMainWithArgs) {
+            result = ApplicationMainClassType.STATIC_MAIN_WITH_ARGS;
+        } else if (hasStaticMainNoArgs) {
+            result = ApplicationMainClassType.STATIC_MAIN_WITHOUT_ARGS;
+        } else if (hasInstanceMainWithArgs && hasValidConstructor) {
+            result = ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS;
+        } else if (hasInstanceMainNoArgs && hasValidConstructor) {
+            result = ApplicationMainClassType.INSTANCE_MAIN_WITHOUT_ARGS;
+        }
+    }
+
+    public Optional<ApplicationMainClassType> result() {
+        return Optional.ofNullable(result);
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/proxy/ApplicationProxy.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/proxy/ApplicationProxy.java
@@ -1,0 +1,455 @@
+package io.javalin.dev.proxy;
+
+import io.javalin.dev.compilation.CompilationInvoker;
+import io.javalin.dev.compilation.CompilationResult;
+import io.javalin.dev.compilation.CompilationSourcesList;
+import io.javalin.dev.compilation.CompilationSourcesTracker;
+import io.javalin.dev.log.JavalinDevLogger;
+import io.javalin.dev.runner.ApplicationInstance;
+import io.javalin.dev.runner.ApplicationRunner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ApplicationProxy {
+    private static final Duration MAX_BACKEND_READY_DURATION = Duration.ofSeconds(5);
+    private static final Duration MAX_DRAIN_DURATION = Duration.ofSeconds(30);
+    private static final long SCAN_COOLDOWN_MS = 2000;
+    private static final int BUFFER_SIZE = 65536;
+    private static final String ERROR_HTML_TEMPLATE;
+
+    static {
+        try (InputStream is = ApplicationProxy.class.getResourceAsStream("/compilation-error.html")) {
+            if (is == null) {
+                throw new IllegalStateException("Missing resource: compilation-error.html");
+            }
+            ERROR_HTML_TEMPLATE = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final CompilationSourcesTracker tracker;
+    private final CompilationInvoker compiler;
+    private final ApplicationRunner runner;
+    private final JavalinDevLogger logger;
+
+    private volatile ServerSocketChannel serverChannel;
+    private volatile long lastScanTime;
+    private volatile CompilationResult lastScanResult;
+    private final Object scanLock = new Object();
+
+    private ExecutorService executor;
+    private ScheduledExecutorService reaper;
+
+    private final AtomicLong generationSeq = new AtomicLong(0);
+    private final AtomicReference<ApplicationProxyHandle> currentBackend = new AtomicReference<>();
+    private final ConcurrentHashMap<Long, ApplicationProxyState> backends = new ConcurrentHashMap<>();
+
+    public ApplicationProxy(CompilationSourcesTracker tracker, CompilationInvoker compiler, ApplicationRunner runner, ApplicationInstance initialInstance, JavalinDevLogger logger) {
+        this.tracker = tracker;
+        this.compiler = compiler;
+        this.runner = runner;
+        this.logger = logger;
+        this.lastScanResult = CompilationResult.NO_CHANGES;
+
+        ApplicationProxyHandle initial = new ApplicationProxyHandle(nextGen(), initialInstance);
+        currentBackend.set(initial);
+        backends.put(initial.generation(), new ApplicationProxyState(initial));
+        logger.debug("ApplicationProxy initialized with initial backend generation " + initial.generation()
+            + " on port " + initialInstance.port());
+    }
+
+    private long nextGen() {
+        return generationSeq.incrementAndGet();
+    }
+
+    public boolean start(int port) throws IOException {
+        logger.info("Starting proxy server on port " + port);
+        serverChannel = ServerSocketChannel.open();
+        serverChannel.setOption(StandardSocketOptions.SO_REUSEADDR, true);
+        serverChannel.bind(new InetSocketAddress(port));
+        serverChannel.configureBlocking(true);
+
+        executor = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "javalin-dev-proxy");
+            t.setDaemon(true);
+            return t;
+        });
+
+        reaper = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "javalin-dev-reaper");
+            t.setDaemon(true);
+            return t;
+        });
+
+        logger.info("Proxy server listening on port " + port + ", ready to accept connections");
+
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    SocketChannel client = serverChannel.accept();
+                    client.setOption(StandardSocketOptions.TCP_NODELAY, true);
+                    logger.debug("Accepted incoming connection from " + client.getRemoteAddress());
+                    executor.submit(() -> handleConnection(client));
+                } catch (IOException e) {
+                    if (serverChannel == null || !serverChannel.isOpen()) {
+                        logger.info("Server channel closed, exiting accept loop");
+                        break;
+                    }
+                    logger.warn("IOException during accept: " + e.getMessage());
+                }
+            }
+        } finally {
+            stop();
+        }
+
+        return true;
+    }
+
+    public void stop() {
+        logger.info("Stopping proxy server");
+        try {
+            if (serverChannel != null && serverChannel.isOpen()) {
+                serverChannel.close();
+                logger.debug("Server channel closed");
+            }
+        } catch (IOException e) {
+            logger.warn("Error closing server channel: " + e.getMessage());
+        }
+
+        if (executor != null) {
+            executor.shutdownNow();
+            logger.debug("Proxy executor shut down");
+        }
+        if (reaper != null) {
+            reaper.shutdownNow();
+            logger.debug("Reaper executor shut down");
+        }
+
+        logger.debug("Stopping " + backends.size() + " backend(s)");
+        for (ApplicationProxyState state : backends.values()) {
+            stopBackend(state);
+        }
+        backends.clear();
+        logger.info("Proxy server stopped");
+    }
+
+    private void handleConnection(SocketChannel client) {
+        try (client) {
+            CompilationResult result = scanIfNeeded();
+
+            if (result == CompilationResult.ERROR) {
+                logger.warn("Returning compilation error response to client");
+                writeErrorResponse(client, "Compilation failed");
+                return;
+            }
+
+            if (result == CompilationResult.SUCCESS) {
+                logger.info("Source changes compiled successfully, swapping backend");
+                if (!startAndSwapBackend()) {
+                    logger.error("Failed to start and swap to new backend after successful compilation");
+                    writeErrorResponse(client, "Failed to restart application");
+                    return;
+                }
+            }
+
+            ApplicationProxyHandle backend = currentBackend.get();
+            ApplicationProxyState state = backends.get(backend.generation());
+            if (state == null) {
+                logger.error("No backend state found for generation " + backend.generation());
+                writeErrorResponse(client, "No backend available");
+                return;
+            }
+
+            long activeCount = state.incrementActiveConnections();
+            logger.debug("Proxying request to backend generation " + backend.generation()
+                + " on port " + backend.address().getPort()
+                + " (active connections: " + activeCount + ")");
+            try {
+                Optional<SocketChannel> target = connectToBackend(backend.address());
+                if (target.isEmpty()) {
+                    logger.error("Cannot connect to backend at " + backend.address());
+                    writeErrorResponse(client, "Cannot connect to internal service");
+                    return;
+                }
+
+                try (SocketChannel delegate = target.get()) {
+                    bridge(client, delegate);
+                }
+            } finally {
+                long remaining = state.decrementActiveConnections();
+                logger.debug("Connection to generation " + backend.generation() + " completed (remaining: " + remaining + ")");
+                if (state.isRetired() && remaining == 0) {
+                    logger.info("Retired backend generation " + state.handle().generation() + " has no more connections, stopping");
+                    stopBackend(state);
+                    backends.remove(state.handle().generation(), state);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Unhandled exception in connection handler: " + e.getMessage());
+            try {
+                writeErrorResponse(client, e.getMessage());
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    private CompilationResult scanIfNeeded() {
+        synchronized (scanLock) {
+            if (System.currentTimeMillis() - lastScanTime < SCAN_COOLDOWN_MS) {
+                logger.debug("Scan cooldown active, returning cached result: " + lastScanResult);
+                return lastScanResult == CompilationResult.ERROR
+                    ? lastScanResult
+                    : CompilationResult.NO_CHANGES;
+            }
+
+            try {
+                CompilationSourcesList changes = tracker.getAndClearChanges();
+                if (changes.isEmpty()) {
+                    lastScanResult = CompilationResult.NO_CHANGES;
+                    return CompilationResult.NO_CHANGES;
+                }
+
+                logger.info("Source changes detected, closing RuntimeClassLoaders before compilation");
+                // Close ALL RuntimeClassLoaders before compilation (Windows file locking).
+                // Backends keep running, but they won't be able to lazily load new classes after close.
+                for (ApplicationProxyState s : backends.values()) {
+                    try {
+                        s.handle().instance().closeRuntimeClassLoader();
+                    } catch (Throwable e) {
+                        logger.warn("Failed to close RuntimeClassLoader for generation " + s.handle().generation() + " (" + e.getMessage() + ")");
+                    }
+                }
+
+                logger.info("Invoking compiler...");
+                CompilationResult result = compiler.invoke();
+                lastScanResult = result;
+                logger.info("Compilation result: " + result);
+                return result;
+            } catch (Exception e) {
+                logger.error("Exception during scan/compile: " + e.getMessage());
+                lastScanResult = CompilationResult.ERROR;
+                return CompilationResult.ERROR;
+            } finally {
+                lastScanTime = System.currentTimeMillis();
+            }
+        }
+    }
+
+    private boolean startAndSwapBackend() {
+        ApplicationInstance nextInstance;
+        try {
+            logger.info("Starting new backend instance...");
+            nextInstance = runner.start();
+        } catch (Exception e) {
+            logger.error("Failed to start new backend instance: " + e.getMessage());
+            return false;
+        }
+
+        logger.debug("Waiting for new backend to become ready at " + nextInstance.address());
+        if (!awaitBackendReady(nextInstance.address())) {
+            logger.error("New backend did not become ready within " + MAX_BACKEND_READY_DURATION.toSeconds() + "s at " + nextInstance.address());
+            safeStop(nextInstance);
+            return false;
+        }
+
+        ApplicationProxyHandle next = new ApplicationProxyHandle(nextGen(), nextInstance);
+        backends.put(next.generation(), new ApplicationProxyState(next));
+        logger.info("New backend ready: generation " + next.generation() + " on port " + nextInstance.port());
+
+        ApplicationProxyHandle old = currentBackend.getAndSet(next);
+        logger.info("Swapped backend: generation " + old.generation() + " -> " + next.generation());
+
+        retireBackend(old);
+        return true;
+    }
+
+    private void retireBackend(ApplicationProxyHandle old) {
+        ApplicationProxyState state = backends.get(old.generation());
+        if (state == null) {
+            return;
+        }
+
+        state.setRetired(true);
+        long activeConns = state.activeConnections();
+        logger.debug("Retiring backend generation " + old.generation() + " (active connections: " + activeConns + ")");
+
+        if (activeConns == 0) {
+            logger.info("Retired backend generation " + old.generation() + " has no active connections, stopping immediately");
+            stopBackend(state);
+            backends.remove(state.handle().generation(), state);
+            return;
+        }
+
+        logger.info("Retired backend generation " + old.generation() + " still has " + activeConns
+            + " active connection(s), scheduling force-stop in " + MAX_DRAIN_DURATION.toSeconds() + "s");
+        if (reaper != null) {
+            var task = reaper.schedule(() -> {
+                logger.warn("Force-stopping retired backend generation " + old.generation() + " after drain timeout");
+                stopBackend(state);
+                backends.remove(state.handle().generation(), state);
+            }, MAX_DRAIN_DURATION.toMillis(), TimeUnit.MILLISECONDS);
+            state.setStopTask(task);
+        }
+    }
+
+    private void stopBackend(ApplicationProxyState state) {
+        logger.debug("Stopping backend generation " + state.handle().generation());
+        state.stopTask()
+            .ifPresent(task -> task.cancel(false));
+
+        safeStop(state.handle().instance());
+    }
+
+    private void safeStop(ApplicationInstance instance) {
+        try {
+            instance.stop();
+        } catch (Throwable e) {
+            logger.warn("Error stopping application instance on port " + instance.port() + " (" + e.getMessage() + ")");
+        }
+    }
+
+    private boolean awaitBackendReady(InetSocketAddress address) {
+        var start = Instant.now();
+        while (Duration.between(start, Instant.now()).compareTo(MAX_BACKEND_READY_DURATION) < 0) {
+            try (SocketChannel ch = SocketChannel.open(address)) {
+                ch.setOption(StandardSocketOptions.TCP_NODELAY, true);
+                logger.debug("Backend at " + address + " is ready (connected successfully)");
+                return true;
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    logger.warn("Interrupted while waiting for backend readiness at " + address);
+                    return false;
+                }
+            }
+        }
+        logger.warn("Backend at " + address + " did not become ready within " + MAX_BACKEND_READY_DURATION.toSeconds() + "s");
+        return false;
+    }
+
+    private void bridge(SocketChannel client, SocketChannel target) {
+        Thread clientToTarget = new Thread(() -> {
+            try {
+                transfer(client, target);
+            } finally {
+                silentShutdown(target);
+            }
+        }, "javalin-dev-c2t");
+
+        Thread targetToClient = new Thread(() -> {
+            try {
+                transfer(target, client);
+            } finally {
+                silentShutdown(client);
+            }
+        }, "javalin-dev-t2c");
+
+        clientToTarget.setDaemon(true);
+        targetToClient.setDaemon(true);
+        clientToTarget.start();
+        targetToClient.start();
+
+        try {
+            clientToTarget.join();
+            targetToClient.join();
+        } catch (InterruptedException e) {
+            clientToTarget.interrupt();
+            targetToClient.interrupt();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void transfer(SocketChannel src, SocketChannel dst) {
+        ByteBuffer buf = ByteBuffer.allocateDirect(BUFFER_SIZE);
+        try {
+            while (src.read(buf) != -1) {
+                buf.flip();
+                while (buf.hasRemaining()) {
+                    dst.write(buf);
+                }
+                buf.clear();
+            }
+        } catch (IOException ignored) {
+        }
+    }
+
+    private void writeErrorResponse(SocketChannel client, String errorMessage) throws IOException {
+        String escaped = errorMessage != null
+            ? errorMessage.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            : "Unknown error";
+        String html = ERROR_HTML_TEMPLATE.formatted(escaped);
+        byte[] body = html.getBytes(StandardCharsets.UTF_8);
+        String header = "HTTP/1.1 500 Compilation Error\r\n"
+                        + "Content-Type: text/html; charset=utf-8\r\n"
+                        + "Content-Length: " + body.length + "\r\n"
+                        + "Connection: close\r\n"
+                        + "\r\n";
+
+        byte[] headerBytes = header.getBytes(StandardCharsets.US_ASCII);
+        ByteBuffer buf = ByteBuffer.allocate(headerBytes.length + body.length);
+        buf.put(headerBytes);
+        buf.put(body);
+        buf.flip();
+        while (buf.hasRemaining()) {
+            client.write(buf);
+        }
+    }
+
+    private Optional<SocketChannel> connectToBackend(InetSocketAddress address) {
+        var start = Instant.now();
+        while (Duration.between(start, Instant.now()).compareTo(MAX_BACKEND_READY_DURATION) < 0) {
+            SocketChannel ch = null;
+            try {
+                ch = SocketChannel.open(address);
+                ch.setOption(StandardSocketOptions.TCP_NODELAY, true);
+                return Optional.of(ch);
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    logger.warn("Interrupted while connecting to backend at " + address);
+                    return Optional.empty();
+                } finally {
+                    silentClose(ch);
+                }
+            }
+        }
+        logger.warn("Could not connect to backend at " + address + " within " + MAX_BACKEND_READY_DURATION.toSeconds() + "s");
+        return Optional.empty();
+    }
+
+    private void silentShutdown(SocketChannel ch) {
+        try {
+            if (ch != null && ch.isOpen()) {
+                ch.shutdownOutput();
+            }
+        } catch (IOException ignored) {
+        }
+    }
+
+    private void silentClose(SocketChannel ch) {
+        try {
+            if (ch != null) {
+                ch.close();
+            }
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/proxy/ApplicationProxyHandle.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/proxy/ApplicationProxyHandle.java
@@ -1,0 +1,27 @@
+package io.javalin.dev.proxy;
+
+import io.javalin.dev.runner.ApplicationInstance;
+
+import java.net.InetSocketAddress;
+
+final class ApplicationProxyHandle {
+    private final long generation;
+    private final ApplicationInstance instance;
+
+    ApplicationProxyHandle(long generation, ApplicationInstance instance) {
+        this.generation = generation;
+        this.instance = instance;
+    }
+
+    long generation() {
+        return generation;
+    }
+
+    ApplicationInstance instance() {
+        return instance;
+    }
+
+    InetSocketAddress address() {
+        return instance.address();
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/proxy/ApplicationProxyState.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/proxy/ApplicationProxyState.java
@@ -1,0 +1,51 @@
+package io.javalin.dev.proxy;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+final class ApplicationProxyState {
+    private final ApplicationProxyHandle handle;
+    private final AtomicLong activeConnections;
+    private volatile boolean retired;
+    private volatile ScheduledFuture<?> stopTask;
+
+    ApplicationProxyState(ApplicationProxyHandle handle) {
+        this.handle = handle;
+        this.activeConnections = new AtomicLong(0);
+    }
+
+    ApplicationProxyHandle handle() {
+        return handle;
+    }
+
+    long activeConnections() {
+        return activeConnections.get();
+    }
+
+    long incrementActiveConnections() {
+        return activeConnections.incrementAndGet();
+    }
+
+    long decrementActiveConnections() {
+        return activeConnections.decrementAndGet();
+    }
+
+    boolean isRetired() {
+        return retired;
+    }
+
+    ApplicationProxyState setRetired(boolean retired) {
+        this.retired = retired;
+        return this;
+    }
+
+    Optional<ScheduledFuture<?>> stopTask() {
+        return Optional.ofNullable(stopTask);
+    }
+
+    ApplicationProxyState setStopTask(ScheduledFuture<?> forceStop) {
+        this.stopTask = forceStop;
+        return this;
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/runner/ApplicationInstance.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/runner/ApplicationInstance.java
@@ -1,0 +1,69 @@
+package io.javalin.dev.runner;
+
+import io.javalin.dev.classloader.RuntimeClassLoader;
+import io.javalin.dev.log.JavalinDevLogger;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class ApplicationInstance {
+    private final int port;
+    private final AtomicBoolean stopped;
+    private final JavalinDevLogger logger;
+
+    private volatile RuntimeClassLoader runtimeClassLoader;
+    private volatile Thread appThread;
+
+    public ApplicationInstance(int port, RuntimeClassLoader runtimeClassLoader, Thread appThread, JavalinDevLogger logger) {
+        this.port = port;
+        this.runtimeClassLoader = runtimeClassLoader;
+        this.appThread = appThread;
+        this.stopped = new AtomicBoolean(false);
+        this.logger = logger;
+        logger.debug("ApplicationInstance created on port " + port);
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public InetSocketAddress address() {
+        return new InetSocketAddress("localhost", port);
+    }
+
+    public void closeRuntimeClassLoader() {
+        RuntimeClassLoader cl = runtimeClassLoader;
+        if (cl != null) {
+            try {
+                cl.close();
+                logger.debug("RuntimeClassLoader closed for instance on port " + port);
+            } catch (Exception e) {
+                logger.warn("Failed to close RuntimeClassLoader for instance on port " + port + " (" + e.getMessage() + ")");
+            }
+        }
+    }
+
+    public void stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            logger.debug("ApplicationInstance on port " + port + " already stopped, skipping");
+            return;
+        }
+
+        logger.info("Stopping ApplicationInstance on port " + port);
+
+        // Also interrupt the launching thread (in case it didn't inherit, or as a fallback)
+        Thread t = appThread;
+        if (t != null && t.isAlive()) {
+            logger.debug("Interrupting application thread: " + t.getName());
+            t.interrupt();
+        }
+
+        // Release file locks
+        closeRuntimeClassLoader();
+
+        // Allow GC after stop
+        runtimeClassLoader = null;
+        appThread = null;
+        logger.debug("ApplicationInstance on port " + port + " stopped and cleaned up");
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/runner/ApplicationRunner.java
+++ b/javalin-build/javalin-build-common/src/main/java/io/javalin/dev/runner/ApplicationRunner.java
@@ -1,0 +1,120 @@
+package io.javalin.dev.runner;
+
+import io.javalin.dev.classloader.BaseClassLoader;
+import io.javalin.dev.classloader.RuntimeClassLoader;
+import io.javalin.dev.log.JavalinDevLogger;
+import io.javalin.dev.main.ApplicationMainClassCandidate;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+
+public class ApplicationRunner {
+    private final URL[] dependencyUrls;
+    private final URL[] classesUrls;
+    private final ApplicationMainClassCandidate mainClass;
+    private final JavalinDevLogger logger;
+    private final Object startLock;
+    private volatile BaseClassLoader baseClassLoader;
+
+    public ApplicationRunner(URL[] dependencyUrls, URL[] classesUrls, ApplicationMainClassCandidate mainClass, JavalinDevLogger logger) {
+        this.dependencyUrls = dependencyUrls;
+        this.classesUrls = classesUrls;
+        this.mainClass = mainClass;
+        this.logger = logger;
+        this.startLock = new Object();
+        logger.debug("ApplicationRunner created for main class: " + mainClass.className() + " [" + mainClass.type() + "]");
+        logger.debug("Dependency URLs: " + Arrays.toString(dependencyUrls));
+        logger.debug("Classes URLs: " + Arrays.toString(classesUrls));
+    }
+
+    public ApplicationInstance start() throws Exception {
+        synchronized (startLock) {
+            logger.info("Starting new application instance...");
+
+            var internalPort = findFreePort();
+            if (internalPort.isEmpty()) {
+                logger.error("Could not find any available port");
+                throw new IllegalStateException("Could not find any available port");
+            }
+            logger.info("Allocated internal port: " + internalPort.getAsInt());
+            System.setProperty("javalin.dev.internalPort", String.valueOf(internalPort.getAsInt()));
+
+            if (baseClassLoader == null) {
+                logger.debug("Creating BaseClassLoader with " + dependencyUrls.length + " dependency URL(s)");
+                baseClassLoader = new BaseClassLoader(dependencyUrls);
+            }
+
+            logger.debug("Creating RuntimeClassLoader with " + classesUrls.length + " classes URL(s)");
+            RuntimeClassLoader runtimeCl = new RuntimeClassLoader(classesUrls, baseClassLoader);
+
+            logger.debug("Loading main class: " + mainClass.className());
+            Class<?> mainClass = runtimeCl.loadClass(this.mainClass.className());
+            logger.debug("Main class loaded successfully: " + mainClass.getName());
+
+            CountDownLatch started = new CountDownLatch(1);
+            Thread appThread = new Thread(() -> {
+                Thread.currentThread().setContextClassLoader(runtimeCl);
+                started.countDown();
+                try {
+                    logger.debug("Invoking main method on thread: " + Thread.currentThread().getName());
+                    invokeMain(mainClass);
+                } catch (Exception e) {
+                    logger.error("Application main method threw an exception: " + e.getMessage());
+                    e.printStackTrace();
+                }
+            });
+            appThread.setDaemon(true);
+            appThread.start();
+            logger.debug("Application thread started: " + appThread.getName() + ", waiting for latch...");
+
+            started.await();
+            logger.info("Application instance started on port " + internalPort.getAsInt());
+
+            return new ApplicationInstance(internalPort.getAsInt(), runtimeCl, appThread, logger);
+        }
+    }
+
+    private static OptionalInt findFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            var result = socket.getLocalPort();
+            return OptionalInt.of(result);
+        } catch (IOException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+    private void invokeMain(Class<?> mainClazz) throws Exception {
+        logger.debug("Invoking main method via reflection for type: " + mainClass.type());
+        switch (mainClass.type()) {
+            case STATIC_MAIN_WITH_ARGS -> {
+                Method m = mainClazz.getDeclaredMethod("main", String[].class);
+                m.setAccessible(true);
+                m.invoke(null, (Object) new String[0]);
+            }
+            case STATIC_MAIN_WITHOUT_ARGS -> {
+                Method m = mainClazz.getDeclaredMethod("main");
+                m.setAccessible(true);
+                m.invoke(null);
+            }
+            case INSTANCE_MAIN_WITH_ARGS -> {
+                Method m = mainClazz.getDeclaredMethod("main", String[].class);
+                m.setAccessible(true);
+                logger.debug("Creating instance of " + mainClazz.getName() + " via zero-arg constructor");
+                Object obj = mainClazz.getDeclaredConstructor().newInstance();
+                m.invoke(obj, (Object) new String[0]);
+            }
+            case INSTANCE_MAIN_WITHOUT_ARGS -> {
+                Method m = mainClazz.getDeclaredMethod("main");
+                logger.debug("Creating instance of " + mainClazz.getName() + " via zero-arg constructor");
+                Object obj = mainClazz.getDeclaredConstructor().newInstance();
+                m.invoke(obj);
+            }
+        }
+    }
+}

--- a/javalin-build/javalin-build-common/src/main/resources/compilation-error.html
+++ b/javalin-build/javalin-build-common/src/main/resources/compilation-error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Compilation Error</title>
+    <style>
+        body { font-family: monospace; background: #1e1e1e; color: #d4d4d4; padding: 2em; }
+        h1 { color: #f44747; }
+        pre { background: #2d2d2d; padding: 1em; border-radius: 4px; overflow-x: auto;
+            white-space: pre-wrap; word-wrap: break-word; }
+    </style>
+</head>
+<body>
+<h1>Compilation Error</h1>
+<pre>%s</pre>
+<p>Fix the error and refresh to retry.</p>
+</body>
+</html>

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/classloader/BaseClassLoaderTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/classloader/BaseClassLoaderTest.java
@@ -1,0 +1,62 @@
+package io.javalin.dev.classloader;
+
+import io.javalin.dev.testutil.ClassFileCompiler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URL;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BaseClassLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void parent_isPlatformClassLoader() throws Exception {
+        try (var cl = new BaseClassLoader(new URL[0])) {
+            assertThat(cl.getParent()).isSameAs(ClassLoader.getPlatformClassLoader());
+        }
+    }
+
+    @Test
+    void loadsClassFromProvidedUrl() throws Exception {
+        ClassFileCompiler.compile(tempDir, "BaseTest", """
+            public class BaseTest {
+                public static String marker() { return "from-base"; }
+            }
+            """);
+
+        try (var cl = new BaseClassLoader(new URL[]{tempDir.toUri().toURL()})) {
+            Class<?> clazz = cl.loadClass("BaseTest");
+            assertThat(clazz.getClassLoader()).isSameAs(cl);
+        }
+    }
+
+    @Test
+    void cannotLoadAppClasspath() throws Exception {
+        try (var cl = new BaseClassLoader(new URL[0])) {
+            // org.junit.jupiter.api.Test is on the test classpath but NOT provided to BaseClassLoader.
+            // BaseClassLoader's parent is PlatformClassLoader which doesn't have JUnit.
+            assertThatThrownBy(() -> cl.loadClass("org.junit.jupiter.api.Test"))
+                .isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test
+    void loadsJdkClasses() throws Exception {
+        try (var cl = new BaseClassLoader(new URL[0])) {
+            Class<?> clazz = cl.loadClass("java.util.ArrayList");
+            assertThat(clazz).isEqualTo(java.util.ArrayList.class);
+        }
+    }
+
+    @Test
+    void close_releasesResources() throws Exception {
+        var cl = new BaseClassLoader(new URL[0]);
+        cl.close(); // Should not throw
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/classloader/RuntimeClassLoaderTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/classloader/RuntimeClassLoaderTest.java
@@ -1,0 +1,142 @@
+package io.javalin.dev.classloader;
+
+import io.javalin.dev.testutil.ClassFileCompiler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URL;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RuntimeClassLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void childFirst_loadsFromOwnUrlsBeforeParent() throws Exception {
+        // Compile same class name in two different directories with different markers
+        Path parentDir = tempDir.resolve("parent");
+        Path childDir = tempDir.resolve("child");
+
+        ClassFileCompiler.compile(parentDir, "Marker", """
+            public class Marker {
+                public static String value() { return "parent"; }
+            }
+            """);
+        ClassFileCompiler.compile(childDir, "Marker", """
+            public class Marker {
+                public static String value() { return "child"; }
+            }
+            """);
+
+        try (var parent = new BaseClassLoader(new URL[]{parentDir.toUri().toURL()});
+             var child = new RuntimeClassLoader(new URL[]{childDir.toUri().toURL()}, parent)) {
+            Class<?> clazz = child.loadClass("Marker");
+            String value = (String) clazz.getMethod("value").invoke(null);
+            assertThat(value).isEqualTo("child");
+            assertThat(clazz.getClassLoader()).isSameAs(child);
+        }
+    }
+
+    @Test
+    void jdkClasses_delegatedToParent() throws Exception {
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            Class<?> clazz = child.loadClass("java.lang.String");
+            assertThat(clazz).isSameAs(String.class);
+        }
+    }
+
+    @Test
+    void javaxClasses_delegatedToParent() throws Exception {
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            Class<?> clazz = child.loadClass("javax.net.ssl.SSLContext");
+            assertThat(clazz).isEqualTo(javax.net.ssl.SSLContext.class);
+        }
+    }
+
+    @Test
+    void jdkPrefixClasses_delegated() throws Exception {
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            // jdk.internal classes are typically not accessible, but the delegation path should be exercised.
+            // Use a well-known jdk.* class if available or just test delegation doesn't NPE.
+            // jdk.jfr.Event is available in standard JDK distributions
+            Class<?> clazz = child.loadClass("jdk.jfr.Event");
+            assertThat(clazz).isNotNull();
+        }
+    }
+
+    @Test
+    void sunClasses_delegated() throws Exception {
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            // sun.misc.Unsafe is commonly available
+            Class<?> clazz = child.loadClass("sun.nio.ch.IOUtil");
+            assertThat(clazz).isNotNull();
+        }
+    }
+
+    @Test
+    void comSunClasses_delegated() throws Exception {
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            // com.sun classes should be delegated
+            Class<?> clazz = child.loadClass("com.sun.net.httpserver.HttpServer");
+            assertThat(clazz).isNotNull();
+        }
+    }
+
+    @Test
+    void classNotFound_throwsCNFE() throws Exception {
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            assertThatThrownBy(() -> child.loadClass("com.nonexistent.FakeClass"))
+                .isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test
+    void fallsBackToParent() throws Exception {
+        Path parentDir = tempDir.resolve("parent-only");
+        ClassFileCompiler.compile(parentDir, "ParentOnly", """
+            public class ParentOnly {
+                public static String value() { return "from-parent"; }
+            }
+            """);
+
+        try (var parent = new BaseClassLoader(new URL[]{parentDir.toUri().toURL()});
+             var child = new RuntimeClassLoader(new URL[0], parent)) {
+            Class<?> clazz = child.loadClass("ParentOnly");
+            String value = (String) clazz.getMethod("value").invoke(null);
+            assertThat(value).isEqualTo("from-parent");
+        }
+    }
+
+    @Test
+    void alreadyLoaded_returnsCached() throws Exception {
+        Path childDir = tempDir.resolve("cached");
+        ClassFileCompiler.compile(childDir, "CachedClass", """
+            public class CachedClass {}
+            """);
+
+        try (var parent = new BaseClassLoader(new URL[0]);
+             var child = new RuntimeClassLoader(new URL[]{childDir.toUri().toURL()}, parent)) {
+            Class<?> first = child.loadClass("CachedClass");
+            Class<?> second = child.loadClass("CachedClass");
+            assertThat(first).isSameAs(second);
+        }
+    }
+
+    @Test
+    void close_releasesResources() throws Exception {
+        var parent = new BaseClassLoader(new URL[0]);
+        var child = new RuntimeClassLoader(new URL[0], parent);
+        child.close(); // Should not throw
+        parent.close();
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/compilation/CompilationSourcesListTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/compilation/CompilationSourcesListTest.java
@@ -1,0 +1,77 @@
+package io.javalin.dev.compilation;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CompilationSourcesListTest {
+
+    @Test
+    void isEmpty_trueWhenAllEmpty() {
+        var list = new CompilationSourcesList(List.of(), List.of(), List.of());
+        assertThat(list.isEmpty()).isTrue();
+    }
+
+    @Test
+    void isEmpty_falseWhenAddedNonEmpty() {
+        var list = new CompilationSourcesList(List.of(Path.of("a.java")), List.of(), List.of());
+        assertThat(list.isEmpty()).isFalse();
+    }
+
+    @Test
+    void isEmpty_falseWhenModifiedNonEmpty() {
+        var list = new CompilationSourcesList(List.of(), List.of(Path.of("b.java")), List.of());
+        assertThat(list.isEmpty()).isFalse();
+    }
+
+    @Test
+    void isEmpty_falseWhenDeletedNonEmpty() {
+        var list = new CompilationSourcesList(List.of(), List.of(), List.of(Path.of("c.java")));
+        assertThat(list.isEmpty()).isFalse();
+    }
+
+    @Test
+    void added_returnsUnmodifiableList() {
+        var list = new CompilationSourcesList(new ArrayList<>(List.of(Path.of("a.java"))), List.of(), List.of());
+        assertThatThrownBy(() -> list.added().add(Path.of("x.java")))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void modified_returnsUnmodifiableList() {
+        var list = new CompilationSourcesList(List.of(), new ArrayList<>(List.of(Path.of("b.java"))), List.of());
+        assertThatThrownBy(() -> list.modified().add(Path.of("x.java")))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void deleted_returnsUnmodifiableList() {
+        var list = new CompilationSourcesList(List.of(), List.of(), new ArrayList<>(List.of(Path.of("c.java"))));
+        assertThatThrownBy(() -> list.deleted().add(Path.of("x.java")))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void accessors_returnCorrectContent() {
+        var a = Path.of("added.java");
+        var m = Path.of("modified.java");
+        var d = Path.of("deleted.java");
+        var list = new CompilationSourcesList(List.of(a), List.of(m), List.of(d));
+        assertThat(list.added()).containsExactly(a);
+        assertThat(list.modified()).containsExactly(m);
+        assertThat(list.deleted()).containsExactly(d);
+    }
+
+    @Test
+    void equalsAndHashCode() {
+        var a = new CompilationSourcesList(List.of(Path.of("x")), List.of(), List.of());
+        var b = new CompilationSourcesList(List.of(Path.of("x")), List.of(), List.of());
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/compilation/CompilationSourcesTrackerTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/compilation/CompilationSourcesTrackerTest.java
@@ -1,0 +1,344 @@
+package io.javalin.dev.compilation;
+
+import io.javalin.dev.testutil.TestLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class CompilationSourcesTrackerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final TestLogger logger = new TestLogger();
+    private CompilationSourcesTracker tracker;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (tracker != null) {
+            tracker.close();
+        }
+    }
+
+    private CompilationSourcesTracker createTracker() throws IOException {
+        tracker = new CompilationSourcesTracker(logger);
+        return tracker;
+    }
+
+    @Test
+    void constructor_initializes() throws Exception {
+        createTracker();
+        assertThat(logger.hasMessage("debug", "CompilationSourcesTracker initialized")).isTrue();
+    }
+
+    @Test
+    void watchDirectory_null_skips() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(null);
+        assertThat(logger.hasMessage("debug", "Skipping watch for non-existent directory: null")).isTrue();
+    }
+
+    @Test
+    void watchDirectory_nonExistent_skips() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir.resolve("nonexistent"));
+        assertThat(logger.hasMessage("debug", "Skipping watch for non-existent directory")).isTrue();
+    }
+
+    @Test
+    void watchFile_null_skips() throws Exception {
+        var t = createTracker();
+        t.watchFile(null);
+        assertThat(logger.hasMessage("debug", "Skipping watch for non-existent file: null")).isTrue();
+    }
+
+    @Test
+    void watchFile_nonExistent_skips() throws Exception {
+        var t = createTracker();
+        t.watchFile(tempDir.resolve("nofile.txt"));
+        assertThat(logger.hasMessage("debug", "Skipping watch for non-existent file")).isTrue();
+    }
+
+    @Test
+    void watchDirectory_registersRecursively() throws Exception {
+        Path nested = Files.createDirectories(tempDir.resolve("a/b/c"));
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.writeString(nested.resolve("test.java"), "content");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.added()).anyMatch(p -> p.toString().contains("test.java"));
+        });
+    }
+
+    @Test
+    void watchFile_onlyTracksSpecificFile() throws Exception {
+        Path watched = Files.createFile(tempDir.resolve("watched.txt"));
+        var t = createTracker();
+        t.watchFile(watched);
+        t.recordBaseline();
+
+        // Create a sibling file that should NOT be tracked
+        Files.writeString(tempDir.resolve("sibling.txt"), "ignore me");
+        // Modify the watched file
+        Files.writeString(watched, "modified");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.added().stream().anyMatch(p -> p.toString().contains("sibling.txt"))).isFalse();
+            assertThat(changes.modified().stream().anyMatch(p -> p.toString().contains("sibling.txt"))).isFalse();
+        });
+    }
+
+    @Test
+    void recordBaseline_clearsAccumulatedEvents() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+
+        // Create a file before baseline
+        Files.writeString(tempDir.resolve("before.txt"), "content");
+        Thread.sleep(500);
+
+        t.recordBaseline();
+
+        // Initial read should be empty (events cleared by baseline)
+        var changes = t.getAndClearChanges();
+        assertThat(changes.added().stream().anyMatch(p -> p.toString().contains("before.txt"))).isFalse();
+    }
+
+    @Test
+    void recordBaseline_startsWatchThread() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        assertThat(logger.hasMessage("info", "File watcher thread started")).isTrue();
+    }
+
+    @Test
+    void recordBaseline_calledTwice_noSecondThread() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+        t.recordBaseline();
+
+        long count = logger.messages("info").stream()
+            .filter(e -> e.message().contains("File watcher thread started"))
+            .count();
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void getAndClearChanges_fileCreated_inAdded() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.writeString(tempDir.resolve("new.java"), "content");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.added()).anyMatch(p -> p.toString().contains("new.java"));
+        });
+    }
+
+    @Test
+    void getAndClearChanges_fileModified_inModified() throws Exception {
+        Path file = Files.writeString(tempDir.resolve("existing.java"), "original");
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.writeString(file, "modified-content");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.modified()).anyMatch(p -> p.toString().contains("existing.java"));
+        });
+    }
+
+    @Test
+    void getAndClearChanges_fileDeleted_inDeleted() throws Exception {
+        Path file = Files.writeString(tempDir.resolve("toDelete.java"), "content");
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.delete(file);
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.deleted()).anyMatch(p -> p.toString().contains("toDelete.java"));
+        });
+    }
+
+    @Test
+    void getAndClearChanges_clearsAfterRead() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.writeString(tempDir.resolve("clearTest.java"), "content");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.added()).isNotEmpty();
+        });
+
+        // Second read should be empty
+        var changes2 = t.getAndClearChanges();
+        assertThat(changes2.isEmpty()).isTrue();
+    }
+
+    @Test
+    void categorize_createThenModify_onlyInAdded() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Path file = tempDir.resolve("createModify.java");
+        Files.writeString(file, "initial");
+        Thread.sleep(200);
+        Files.writeString(file, "modified");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            boolean inAdded = changes.added().stream().anyMatch(p -> p.toString().contains("createModify.java"));
+            boolean inModified = changes.modified().stream().anyMatch(p -> p.toString().contains("createModify.java"));
+            assertThat(inAdded).isTrue();
+            assertThat(inModified).isFalse();
+        });
+    }
+
+    @Test
+    void categorize_createThenDelete_empty() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Path file = tempDir.resolve("createDelete.java");
+        Files.writeString(file, "content");
+        Thread.sleep(500);
+        Files.delete(file);
+
+        // Wait for events to be processed
+        Thread.sleep(2000);
+        var changes = t.getAndClearChanges();
+        // File was created then deleted - should cancel out
+        boolean inAdded = changes.added().stream().anyMatch(p -> p.toString().contains("createDelete.java"));
+        boolean inDeleted = changes.deleted().stream().anyMatch(p -> p.toString().contains("createDelete.java"));
+        assertThat(inAdded).isFalse();
+        assertThat(inDeleted).isFalse();
+    }
+
+    @Test
+    void categorize_modifyThenDelete_inDeleted() throws Exception {
+        Path file = Files.writeString(tempDir.resolve("modDel.java"), "original");
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.writeString(file, "modified");
+        Thread.sleep(500);
+        Files.delete(file);
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.deleted()).anyMatch(p -> p.toString().contains("modDel.java"));
+            assertThat(changes.modified()).noneMatch(p -> p.toString().contains("modDel.java"));
+        });
+    }
+
+    @Test
+    void categorize_deleteThenCreate_inAdded() throws Exception {
+        Path file = Files.writeString(tempDir.resolve("delCreate.java"), "original");
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.delete(file);
+        Thread.sleep(500);
+        Files.writeString(file, "recreated");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.added()).anyMatch(p -> p.toString().contains("delCreate.java"));
+            assertThat(changes.deleted()).noneMatch(p -> p.toString().contains("delCreate.java"));
+        });
+    }
+
+    @Test
+    void close_shutsDownWatchServiceAndThread() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        t.close();
+        tracker = null; // prevent double-close in tearDown
+
+        assertThat(logger.hasMessage("info", "Closing CompilationSourcesTracker")).isTrue();
+    }
+
+    @Test
+    void close_isIdempotent() throws Exception {
+        var t = createTracker();
+        t.close();
+        t.close(); // should not throw
+        tracker = null;
+    }
+
+    @Test
+    void newSubdirectory_autoRegistered() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Path newDir = tempDir.resolve("newsubdir");
+        Files.createDirectory(newDir);
+        Thread.sleep(500);
+        Files.writeString(newDir.resolve("file.java"), "content");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            assertThat(changes.added()).anyMatch(p -> p.toString().contains("file.java"));
+        });
+    }
+
+    @Test
+    void logsChangeSummary() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Files.writeString(tempDir.resolve("summary.java"), "content");
+
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            var changes = t.getAndClearChanges();
+            if (!changes.isEmpty()) {
+                assertThat(logger.hasMessage("info", "Detected source changes")).isTrue();
+            }
+        });
+    }
+
+    @Test
+    void logsNoChanges() throws Exception {
+        var t = createTracker();
+        t.watchDirectory(tempDir);
+        t.recordBaseline();
+
+        Thread.sleep(500);
+        t.getAndClearChanges();
+        assertThat(logger.hasMessage("debug", "No source changes detected")).isTrue();
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/main/ApplicationMainClassCandidateTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/main/ApplicationMainClassCandidateTest.java
@@ -1,0 +1,37 @@
+package io.javalin.dev.main;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationMainClassCandidateTest {
+
+    @Test
+    void accessors() {
+        var candidate = new ApplicationMainClassCandidate("com.example.App", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        assertThat(candidate.className()).isEqualTo("com.example.App");
+        assertThat(candidate.type()).isEqualTo(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void equalsAndHashCode() {
+        var a = new ApplicationMainClassCandidate("com.example.App", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var b = new ApplicationMainClassCandidate("com.example.App", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void notEqual_differentClassName() {
+        var a = new ApplicationMainClassCandidate("com.example.A", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var b = new ApplicationMainClassCandidate("com.example.B", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void notEqual_differentType() {
+        var a = new ApplicationMainClassCandidate("com.example.App", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var b = new ApplicationMainClassCandidate("com.example.App", ApplicationMainClassType.STATIC_MAIN_WITHOUT_ARGS);
+        assertThat(a).isNotEqualTo(b);
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/main/ApplicationMainClassScannerTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/main/ApplicationMainClassScannerTest.java
@@ -1,0 +1,190 @@
+package io.javalin.dev.main;
+
+import io.javalin.dev.testutil.ClassFileCompiler;
+import io.javalin.dev.testutil.TestLogger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApplicationMainClassScannerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final TestLogger logger = new TestLogger();
+    private final ApplicationMainClassScanner scanner = new ApplicationMainClassScanner(logger);
+
+    @Test
+    void scanDirectory_findsStaticMainWithArgs() throws Exception {
+        ClassFileCompiler.compile(tempDir, "App", """
+            public class App {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThat(result).containsKey(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        assertThat(result.get(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS))
+            .extracting(ApplicationMainClassCandidate::className)
+            .contains("App");
+    }
+
+    @Test
+    void scanDirectory_findsMultipleCandidates() throws Exception {
+        ClassFileCompiler.compile(tempDir, "StaticApp", """
+            public class StaticApp {
+                public static void main(String[] args) {}
+            }
+            """);
+        ClassFileCompiler.compile(tempDir, "InstanceApp", """
+            public class InstanceApp {
+                public InstanceApp() {}
+                public void main(String[] args) {}
+            }
+            """);
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThat(result).containsKey(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        assertThat(result).containsKey(ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void scanDirectory_groupsByType() throws Exception {
+        ClassFileCompiler.compile(tempDir, "App1", """
+            public class App1 {
+                public static void main(String[] args) {}
+            }
+            """);
+        ClassFileCompiler.compile(tempDir, "App2", """
+            public class App2 {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThat(result.get(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS)).hasSize(2);
+    }
+
+    @Test
+    void scanDirectory_nonExistentDir_emptyMap() throws Exception {
+        var result = scanner.scanDirectory(tempDir.resolve("nonexistent"));
+        assertThat(result).isEmpty();
+        assertThat(logger.hasMessage("warn", "does not exist")).isTrue();
+    }
+
+    @Test
+    void scanDirectory_emptyDir_emptyMap() throws Exception {
+        var emptyDir = Files.createDirectory(tempDir.resolve("empty"));
+        var result = scanner.scanDirectory(emptyDir);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void scanDirectory_nonClassFiles_ignored() throws Exception {
+        Files.writeString(tempDir.resolve("readme.txt"), "hello");
+        Files.writeString(tempDir.resolve("App.java"), "public class App {}");
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void scanDirectory_classWithoutMain_excluded() throws Exception {
+        ClassFileCompiler.compile(tempDir, "NoMain", """
+            public class NoMain {
+                public void doStuff() {}
+            }
+            """);
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void scanDirectory_returnsUnmodifiableMap() throws Exception {
+        ClassFileCompiler.compile(tempDir, "App", """
+            public class App {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThatThrownBy(() -> result.put(ApplicationMainClassType.STATIC_MAIN_WITHOUT_ARGS, List.of()))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void scanFile_classFile_returnsCandidate() throws Exception {
+        ClassFileCompiler.compile(tempDir, "FileApp", """
+            public class FileApp {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var result = scanner.scanFile(tempDir.resolve("FileApp.class"));
+        assertThat(result).isPresent();
+        assertThat(result.get().className()).isEqualTo("FileApp");
+        assertThat(result.get().type()).isEqualTo(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void scanFile_nonClassFile_returnsEmpty() throws Exception {
+        Files.writeString(tempDir.resolve("readme.txt"), "hello");
+        var result = scanner.scanFile(tempDir.resolve("readme.txt"));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void scanFile_directory_returnsEmpty() throws Exception {
+        var subdir = Files.createDirectory(tempDir.resolve("subdir"));
+        var result = scanner.scanFile(subdir);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void scanFile_classWithoutMain_returnsEmpty() throws Exception {
+        ClassFileCompiler.compile(tempDir, "NoMainFile", """
+            public class NoMainFile {
+                public void doStuff() {}
+            }
+            """);
+
+        var result = scanner.scanFile(tempDir.resolve("NoMainFile.class"));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void scanDirectory_nestedPackages_correctClassNames() throws Exception {
+        ClassFileCompiler.compile(tempDir, "com.example.App", """
+            package com.example;
+            public class App {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var result = scanner.scanDirectory(tempDir);
+        assertThat(result.get(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS))
+            .extracting(ApplicationMainClassCandidate::className)
+            .contains("com.example.App");
+    }
+
+    @Test
+    void scanDirectory_logsCorrectCounts() throws Exception {
+        ClassFileCompiler.compile(tempDir, "LogApp", """
+            public class LogApp {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        scanner.scanDirectory(tempDir);
+        assertThat(logger.hasMessage("info", "1 candidate(s)")).isTrue();
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/main/MainMethodAsmVisitorTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/main/MainMethodAsmVisitorTest.java
@@ -1,0 +1,222 @@
+package io.javalin.dev.main;
+
+import io.javalin.dev.testutil.ClassFileCompiler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.objectweb.asm.ClassReader;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainMethodAsmVisitorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Optional<ApplicationMainClassType> scan(String className, String source) throws Exception {
+        ClassFileCompiler.compile(tempDir, className, source);
+        Path classFile = tempDir.resolve(className.replace('.', '/') + ".class");
+        try (InputStream in = Files.newInputStream(classFile)) {
+            ClassReader cr = new ClassReader(in);
+            MainMethodAsmVisitor visitor = new MainMethodAsmVisitor();
+            cr.accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+            return visitor.result();
+        }
+    }
+
+    @Test
+    void detectsStaticMainWithArgs() throws Exception {
+        var result = scan("StaticMainArgs", """
+            public class StaticMainArgs {
+                public static void main(String[] args) {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void detectsStaticMainWithoutArgs() throws Exception {
+        var result = scan("StaticMainNoArgs", """
+            public class StaticMainNoArgs {
+                public static void main() {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.STATIC_MAIN_WITHOUT_ARGS);
+    }
+
+    @Test
+    void detectsInstanceMainWithArgs() throws Exception {
+        var result = scan("InstanceMainArgs", """
+            public class InstanceMainArgs {
+                public InstanceMainArgs() {}
+                public void main(String[] args) {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void detectsInstanceMainWithoutArgs() throws Exception {
+        var result = scan("InstanceMainNoArgs", """
+            public class InstanceMainNoArgs {
+                public InstanceMainNoArgs() {}
+                public void main() {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.INSTANCE_MAIN_WITHOUT_ARGS);
+    }
+
+    @Test
+    void instanceMainWithArgs_privateCtor_notDetected() throws Exception {
+        var result = scan("PrivateCtorArgs", """
+            public class PrivateCtorArgs {
+                private PrivateCtorArgs() {}
+                public void main(String[] args) {}
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void instanceMainNoArgs_privateCtor_notDetected() throws Exception {
+        var result = scan("PrivateCtorNoArgs", """
+            public class PrivateCtorNoArgs {
+                private PrivateCtorNoArgs() {}
+                public void main() {}
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void instanceMainWithArgs_protectedCtor_detected() throws Exception {
+        var result = scan("ProtectedCtor", """
+            public class ProtectedCtor {
+                protected ProtectedCtor() {}
+                public void main(String[] args) {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void instanceMainWithArgs_packagePrivateCtor_detected() throws Exception {
+        var result = scan("PkgPrivateCtor", """
+            public class PkgPrivateCtor {
+                PkgPrivateCtor() {}
+                public void main(String[] args) {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void staticWithArgs_priorityOverStaticNoArgs() throws Exception {
+        var result = scan("BothStatic", """
+            public class BothStatic {
+                public static void main(String[] args) {}
+                public static void main() {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void staticWithArgs_priorityOverInstanceWithArgs() throws Exception {
+        var result = scan("StaticVsInstance", """
+            public class StaticVsInstance {
+                public StaticVsInstance() {}
+                public static void main(String[] args) {}
+                public void main(String[] args) { /* won't compile with same sig */ }
+            }
+            """.replace("public void main(String[] args) { /* won't compile with same sig */ }",
+                "// instance main with args not compilable with same signature as static"));
+        // Since we can't have both static and instance with same signature, test with different combos
+        var result2 = scan("StaticArgsVsInstanceNoArgs", """
+            public class StaticArgsVsInstanceNoArgs {
+                public StaticArgsVsInstanceNoArgs() {}
+                public static void main(String[] args) {}
+                public void main() {}
+            }
+            """);
+        assertThat(result2).contains(ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void staticNoArgs_priorityOverInstanceWithArgs() throws Exception {
+        var result = scan("StaticNoArgsVsInstanceArgs", """
+            public class StaticNoArgsVsInstanceArgs {
+                public StaticNoArgsVsInstanceArgs() {}
+                public static void main() {}
+                public void main(String[] args) {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.STATIC_MAIN_WITHOUT_ARGS);
+    }
+
+    @Test
+    void instanceWithArgs_priorityOverInstanceNoArgs() throws Exception {
+        var result = scan("InstanceArgsPriority", """
+            public class InstanceArgsPriority {
+                public InstanceArgsPriority() {}
+                public void main(String[] args) {}
+                public void main() {}
+            }
+            """);
+        assertThat(result).contains(ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS);
+    }
+
+    @Test
+    void noMainMethod_returnsEmpty() throws Exception {
+        var result = scan("NoMain", """
+            public class NoMain {
+                public void notMain() {}
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void privateMainMethod_notDetected() throws Exception {
+        var result = scan("PrivateMain", """
+            public class PrivateMain {
+                private static void main(String[] args) {}
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void mainWithWrongReturnType_notDetected() throws Exception {
+        var result = scan("WrongReturn", """
+            public class WrongReturn {
+                public static int main(String[] args) { return 0; }
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void mainWithExtraParams_notDetected() throws Exception {
+        var result = scan("ExtraParams", """
+            public class ExtraParams {
+                public static void main(String[] args, int extra) {}
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void classWithOnlyConstructor_returnsEmpty() throws Exception {
+        var result = scan("OnlyCtor", """
+            public class OnlyCtor {
+                public OnlyCtor() {}
+            }
+            """);
+        assertThat(result).isEmpty();
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/proxy/ApplicationProxyHandleTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/proxy/ApplicationProxyHandleTest.java
@@ -1,0 +1,43 @@
+package io.javalin.dev.proxy;
+
+import io.javalin.dev.classloader.RuntimeClassLoader;
+import io.javalin.dev.runner.ApplicationInstance;
+import io.javalin.dev.testutil.TestLogger;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationProxyHandleTest {
+
+    private final TestLogger logger = new TestLogger();
+
+    private ApplicationInstance createInstance(int port) {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var thread = new Thread(() -> {});
+        return new ApplicationInstance(port, cl, thread, logger);
+    }
+
+    @Test
+    void generation_returnsValue() {
+        var instance = createInstance(8080);
+        var handle = new ApplicationProxyHandle(42L, instance);
+        assertThat(handle.generation()).isEqualTo(42L);
+    }
+
+    @Test
+    void instance_returnsValue() {
+        var instance = createInstance(8080);
+        var handle = new ApplicationProxyHandle(1L, instance);
+        assertThat(handle.instance()).isSameAs(instance);
+    }
+
+    @Test
+    void address_delegatesToInstance() {
+        var instance = createInstance(9090);
+        var handle = new ApplicationProxyHandle(1L, instance);
+        assertThat(handle.address()).isEqualTo(new InetSocketAddress("localhost", 9090));
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/proxy/ApplicationProxyStateTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/proxy/ApplicationProxyStateTest.java
@@ -1,0 +1,138 @@
+package io.javalin.dev.proxy;
+
+import io.javalin.dev.runner.ApplicationInstance;
+import io.javalin.dev.testutil.TestLogger;
+import io.javalin.dev.classloader.RuntimeClassLoader;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationProxyStateTest {
+
+    private final TestLogger logger = new TestLogger();
+
+    private ApplicationProxyHandle createHandle(long generation) {
+        var instance = createInstanceReflectively(8080);
+        return new ApplicationProxyHandle(generation, instance);
+    }
+
+    private ApplicationInstance createInstanceReflectively(int port) {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var thread = new Thread(() -> {});
+        return new ApplicationInstance(port, cl, thread, logger);
+    }
+
+    @Test
+    void handle_returnsValue() {
+        var handle = createHandle(1L);
+        var state = new ApplicationProxyState(handle);
+        assertThat(state.handle()).isSameAs(handle);
+    }
+
+    @Test
+    void activeConnections_initiallyZero() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        assertThat(state.activeConnections()).isZero();
+    }
+
+    @Test
+    void incrementActiveConnections() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        state.incrementActiveConnections();
+        state.incrementActiveConnections();
+        state.incrementActiveConnections();
+        assertThat(state.activeConnections()).isEqualTo(3);
+    }
+
+    @Test
+    void decrementActiveConnections() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        state.incrementActiveConnections();
+        state.incrementActiveConnections();
+        state.decrementActiveConnections();
+        assertThat(state.activeConnections()).isEqualTo(1);
+    }
+
+    @Test
+    void isRetired_initiallyFalse() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        assertThat(state.isRetired()).isFalse();
+    }
+
+    @Test
+    void setRetired_setsFlag() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        state.setRetired(true);
+        assertThat(state.isRetired()).isTrue();
+    }
+
+    @Test
+    void setRetired_returnsSelf() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        assertThat(state.setRetired(true)).isSameAs(state);
+    }
+
+    @Test
+    void stopTask_initiallyEmpty() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        assertThat(state.stopTask()).isEmpty();
+    }
+
+    @Test
+    void setStopTask_setsTask() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            ScheduledFuture<?> future = scheduler.schedule(() -> {}, 1, TimeUnit.HOURS);
+            state.setStopTask(future);
+            assertThat(state.stopTask()).isPresent().containsSame(future);
+            future.cancel(false);
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void setStopTask_returnsSelf() {
+        var state = new ApplicationProxyState(createHandle(1L));
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            ScheduledFuture<?> future = scheduler.schedule(() -> {}, 1, TimeUnit.HOURS);
+            assertThat(state.setStopTask(future)).isSameAs(state);
+            future.cancel(false);
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void concurrentIncrementDecrement_threadSafe() throws Exception {
+        var state = new ApplicationProxyState(createHandle(1L));
+        int threadCount = 100;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            pool.submit(() -> {
+                try {
+                    state.incrementActiveConnections();
+                    state.decrementActiveConnections();
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        pool.shutdown();
+        assertThat(errors.get()).isZero();
+        assertThat(state.activeConnections()).isZero();
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/proxy/ApplicationProxyTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/proxy/ApplicationProxyTest.java
@@ -1,0 +1,512 @@
+package io.javalin.dev.proxy;
+
+import io.javalin.dev.classloader.RuntimeClassLoader;
+import io.javalin.dev.compilation.CompilationInvoker;
+import io.javalin.dev.compilation.CompilationResult;
+import io.javalin.dev.compilation.CompilationSourcesList;
+import io.javalin.dev.compilation.CompilationSourcesTracker;
+import io.javalin.dev.runner.ApplicationInstance;
+import io.javalin.dev.runner.ApplicationRunner;
+import io.javalin.dev.testutil.TestLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class ApplicationProxyTest {
+
+    private TestLogger logger;
+    private CompilationSourcesTracker tracker;
+    private CompilationInvoker compiler;
+    private ApplicationRunner runner;
+
+    private ServerSocket echoServer;
+    private Thread echoServerThread;
+    private ExecutorService echoPool;
+
+    private ApplicationProxy proxy;
+    private Thread proxyThread;
+    private int proxyPort;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        logger = new TestLogger();
+        tracker = mock(CompilationSourcesTracker.class);
+        compiler = mock(CompilationInvoker.class);
+        runner = mock(ApplicationRunner.class);
+
+        // Default: no changes
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(), List.of(), List.of()));
+
+        // Start a real TCP echo server
+        echoServer = new ServerSocket(0);
+        echoServer.setReuseAddress(true);
+        echoPool = Executors.newCachedThreadPool();
+        echoServerThread = new Thread(() -> {
+            while (!echoServer.isClosed()) {
+                try {
+                    Socket client = echoServer.accept();
+                    echoPool.submit(() -> {
+                        try (client) {
+                            InputStream in = client.getInputStream();
+                            OutputStream out = client.getOutputStream();
+                            byte[] buf = new byte[8192];
+                            int read;
+                            while ((read = in.read(buf)) != -1) {
+                                out.write(buf, 0, read);
+                                out.flush();
+                            }
+                        } catch (IOException ignored) {
+                        }
+                    });
+                } catch (IOException e) {
+                    if (!echoServer.isClosed()) {
+                        // unexpected
+                    }
+                    break;
+                }
+            }
+        });
+        echoServerThread.setDaemon(true);
+        echoServerThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (proxy != null) {
+            proxy.stop();
+        }
+        if (proxyThread != null) {
+            proxyThread.interrupt();
+            proxyThread.join(5000);
+        }
+        if (!echoServer.isClosed()) {
+            echoServer.close();
+        }
+        echoPool.shutdownNow();
+    }
+
+    private ApplicationInstance createRealInstance(int port) {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var thread = new Thread(() -> {});
+        return new ApplicationInstance(port, cl, thread, logger);
+    }
+
+    private void startProxy(ApplicationInstance initialInstance) throws Exception {
+        proxy = new ApplicationProxy(tracker, compiler, runner, initialInstance, logger);
+        ServerSocket tmpSocket = new ServerSocket(0);
+        proxyPort = tmpSocket.getLocalPort();
+        tmpSocket.close();
+
+        proxyThread = new Thread(() -> {
+            try {
+                proxy.start(proxyPort);
+            } catch (IOException ignored) {
+            }
+        });
+        proxyThread.setDaemon(true);
+        proxyThread.start();
+
+        // Wait for proxy to start accepting
+        waitForPort(proxyPort, 5000);
+    }
+
+    private void startProxyWithEchoBackend() throws Exception {
+        startProxy(createRealInstance(echoServer.getLocalPort()));
+    }
+
+    private void waitForPort(int port, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            try (Socket s = new Socket("localhost", port)) {
+                return;
+            } catch (IOException e) {
+                Thread.sleep(50);
+            }
+        }
+        throw new RuntimeException("Port " + port + " not available within " + timeoutMs + "ms");
+    }
+
+    private String sendAndReceive(String data) throws IOException {
+        try (Socket s = new Socket("localhost", proxyPort)) {
+            s.setSoTimeout(5000);
+            s.getOutputStream().write(data.getBytes(StandardCharsets.UTF_8));
+            s.shutdownOutput();
+            var baos = new ByteArrayOutputStream(); // Not efficient but who cares here
+            var in = s.getInputStream();
+            byte[] buf = new byte[8192];
+            try {
+                int n;
+                while ((n = in.read(buf)) != -1) {
+                    baos.write(buf, 0, n);
+                }
+            } catch (SocketException e) {
+                // Connection reset — return whatever we have so far
+            }
+            return baos.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    void constructor_registersInitialBackend() throws Exception {
+        var instance = createRealInstance(echoServer.getLocalPort());
+        proxy = new ApplicationProxy(tracker, compiler, runner, instance, logger);
+        // Should not throw - backend registered
+        proxy.stop();
+        proxy = null;
+    }
+
+    @Test
+    void start_bindsToPort() throws Exception {
+        startProxyWithEchoBackend();
+        try (Socket s = new Socket("localhost", proxyPort)) {
+            assertThat(s.isConnected()).isTrue();
+        }
+    }
+
+    @Test
+    void start_setsReuseAddress() throws Exception {
+        startProxyWithEchoBackend();
+        int port = proxyPort;
+        proxy.stop();
+        proxyThread.interrupt();
+        proxyThread.join(5000);
+
+        // Start again on the same port - should not throw BindException
+        proxy = new ApplicationProxy(tracker, compiler, runner,
+            createRealInstance(echoServer.getLocalPort()), logger);
+        proxyThread = new Thread(() -> {
+            try {
+                proxy.start(port);
+            } catch (IOException ignored) {
+            }
+        });
+        proxyThread.setDaemon(true);
+        proxyThread.start();
+        waitForPort(port, 5000);
+    }
+
+    @Test
+    void stop_closesServerChannel() throws Exception {
+        startProxyWithEchoBackend();
+        proxy.stop();
+        // After stop, new connections should fail
+        Thread.sleep(200);
+        assertThat(connectSucceeds(proxyPort)).isFalse();
+    }
+
+    @Test
+    void stop_shutsDownExecutors() throws Exception {
+        startProxyWithEchoBackend();
+        proxy.stop();
+        proxyThread.interrupt();
+        proxyThread.join(5000);
+        Thread.sleep(500);
+
+        // Check no lingering proxy/reaper threads
+        boolean hasProxyThread = Thread.getAllStackTraces().keySet().stream()
+            .anyMatch(t -> t.getName().equals("javalin-dev-proxy") && t.isAlive() && !t.isDaemon());
+        // Daemon threads may linger briefly, but executors should be shut down
+        assertThat(logger.hasMessage("debug", "Proxy executor shut down")).isTrue();
+        assertThat(logger.hasMessage("debug", "Reaper executor shut down")).isTrue();
+    }
+
+    @Test
+    void stop_stopsAllBackends() throws Exception {
+        startProxyWithEchoBackend();
+        proxy.stop();
+        assertThat(logger.hasMessage("info", "Proxy server stopped")).isTrue();
+    }
+
+    @Test
+    void handleConnection_noChanges_proxiesToBackend() throws Exception {
+        startProxyWithEchoBackend();
+        String response = sendAndReceive("hello");
+        assertThat(response).isEqualTo("hello");
+    }
+
+    @Test
+    void handleConnection_noChanges_echoesData() throws Exception {
+        startProxyWithEchoBackend();
+        String payload = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        String response = sendAndReceive(payload);
+        assertThat(response).isEqualTo(payload);
+    }
+
+    @Test
+    void handleConnection_compilationError_returnsHttp500() throws Exception {
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.ERROR);
+
+        startProxyWithEchoBackend();
+        String response = sendAndReceive("GET / HTTP/1.1\r\n\r\n");
+        assertThat(response).contains("HTTP/1.1 500");
+    }
+
+    @Test
+    void handleConnection_compilationError_containsErrorHtml() throws Exception {
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.ERROR);
+
+        startProxyWithEchoBackend();
+        String response = sendAndReceive("GET / HTTP/1.1\r\n\r\n");
+        assertThat(response).contains("<title>Compilation Error</title>");
+    }
+
+    @Test
+    void handleConnection_errorMessage_htmlEscaped() throws Exception {
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.ERROR);
+
+        startProxyWithEchoBackend();
+        // The error message "Compilation failed" is hardcoded in handleConnection
+        // The HTML escaping is applied to the error string passed to writeErrorResponse
+        String response = sendAndReceive("GET / HTTP/1.1\r\n\r\n");
+        assertThat(response).contains("Compilation failed");
+    }
+
+    @Test
+    void handleConnection_compilationSuccess_swapsBackend() throws Exception {
+        // First call returns changes, second returns no changes
+        when(tracker.getAndClearChanges())
+            .thenReturn(new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()))
+            .thenReturn(new CompilationSourcesList(List.of(), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.SUCCESS);
+
+        // Create a second echo server for the new backend
+        ServerSocket echo2 = new ServerSocket(0);
+        echo2.setReuseAddress(true);
+        Thread echo2Thread = new Thread(() -> {
+            try {
+                while (!echo2.isClosed()) {
+                    Socket client = echo2.accept();
+                    echoPool.submit(() -> {
+                        try (client) {
+                            InputStream in = client.getInputStream();
+                            OutputStream out = client.getOutputStream();
+                            byte[] buf = new byte[8192];
+                            int read;
+                            while ((read = in.read(buf)) != -1) {
+                                out.write(buf, 0, read);
+                                out.flush();
+                            }
+                        } catch (IOException ignored) {
+                        }
+                    });
+                }
+            } catch (IOException ignored) {
+            }
+        });
+        echo2Thread.setDaemon(true);
+        echo2Thread.start();
+
+        var newInstance = createRealInstance(echo2.getLocalPort());
+        when(runner.start()).thenReturn(newInstance);
+
+        startProxyWithEchoBackend();
+
+        String response = sendAndReceive("swap-test");
+        // Either the original or new backend should echo (both are echo servers)
+        assertThat(response).isEqualTo("swap-test");
+
+        echo2.close();
+    }
+
+    @Test
+    void handleConnection_swapFails_returnsError() throws Exception {
+        startProxyWithEchoBackend();
+
+        // Wait for cooldown to expire so next request triggers a fresh scan
+        Thread.sleep(2500);
+
+        // Now set up mocks for the test request
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.SUCCESS);
+        when(runner.start()).thenThrow(new RuntimeException("start failed"));
+
+        String response = sendAndReceive("GET / HTTP/1.1\r\n\r\n");
+        assertThat(response).contains("HTTP/1.1 500");
+        assertThat(response).contains("Failed to restart application");
+    }
+
+    @Test
+    void scanIfNeeded_cooldownPreventsDuplicateScan() throws Exception {
+        startProxyWithEchoBackend();
+
+        sendAndReceive("first");
+        sendAndReceive("second");
+
+        // Tracker should only be queried once within the cooldown window
+        verify(tracker, atMost(1)).getAndClearChanges();
+    }
+
+    @Test
+    void scanIfNeeded_errorCacheDuringCooldown() throws Exception {
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.ERROR);
+
+        startProxyWithEchoBackend();
+
+        String response1 = sendAndReceive("first");
+        assertThat(response1).contains("HTTP/1.1 500");
+
+        // Second request within cooldown should also return error (cached)
+        String response2 = sendAndReceive("second");
+        assertThat(response2).contains("HTTP/1.1 500");
+
+        // Compiler should only be invoked once
+        verify(compiler, times(1)).invoke();
+    }
+
+    @Test
+    void scanIfNeeded_afterCooldownExpires_rescans() throws Exception {
+        startProxyWithEchoBackend();
+
+        sendAndReceive("first");
+        // Wait for cooldown to expire
+        Thread.sleep(2500);
+        sendAndReceive("second");
+
+        verify(tracker, times(2)).getAndClearChanges();
+    }
+
+    @Test
+    void scanIfNeeded_closesAllRuntimeClassLoadersBeforeCompile() throws Exception {
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.ERROR);
+
+        startProxyWithEchoBackend();
+        sendAndReceive("trigger");
+
+        assertThat(logger.hasMessage("info", "closing RuntimeClassLoaders before compilation")).isTrue();
+    }
+
+    @Test
+    void retireBackend_noConnections_stopsImmediately() throws Exception {
+        startProxyWithEchoBackend();
+
+        // Wait for cooldown to expire
+        Thread.sleep(2500);
+
+        ServerSocket echo2 = new ServerSocket(0);
+        echo2.setReuseAddress(true);
+        Thread echo2Thread = new Thread(() -> {
+            try {
+                while (!echo2.isClosed()) {
+                    Socket c = echo2.accept();
+                    echoPool.submit(() -> {
+                        try (c) {
+                            c.getInputStream().transferTo(c.getOutputStream());
+                        } catch (IOException ignored) {}
+                    });
+                }
+            } catch (IOException ignored) {}
+        });
+        echo2Thread.setDaemon(true);
+        echo2Thread.start();
+
+        // Setup: changes detected, compile succeeds, new backend ready
+        when(tracker.getAndClearChanges())
+            .thenReturn(new CompilationSourcesList(List.of(Path.of("a.java")), List.of(), List.of()))
+            .thenReturn(new CompilationSourcesList(List.of(), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.SUCCESS);
+        when(runner.start()).thenReturn(createRealInstance(echo2.getLocalPort()));
+
+        sendAndReceive("trigger-swap");
+
+        // Give time for retirement logic to complete
+        Thread.sleep(500);
+
+        // Old backend with 0 connections should be stopped immediately
+        assertThat(logger.hasMessage("info", "has no active connections, stopping immediately") ||
+                   logger.hasMessage("info", "has no more connections, stopping")).isTrue();
+
+        echo2.close();
+    }
+
+    @Test
+    void bridge_forwardsBidirectionally() throws Exception {
+        startProxyWithEchoBackend();
+        String data = "bidirectional-test-data";
+        String response = sendAndReceive(data);
+        assertThat(response).isEqualTo(data);
+    }
+
+    @Test
+    void bridge_handlesLargePayload() throws Exception {
+        startProxyWithEchoBackend();
+        byte[] payload = new byte[1024 * 1024]; // 1MB
+        java.util.Arrays.fill(payload, (byte) 'X');
+
+        try (Socket s = new Socket("localhost", proxyPort)) {
+            s.setSoTimeout(10000);
+            s.getOutputStream().write(payload);
+            s.shutdownOutput();
+            byte[] response = s.getInputStream().readAllBytes();
+            assertThat(response).hasSize(payload.length);
+            assertThat(response).isEqualTo(payload);
+        }
+    }
+
+    @Test
+    void concurrentConnections_allServed() throws Exception {
+        startProxyWithEchoBackend();
+        int count = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(count);
+        List<Future<String>> futures = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            final String msg = "msg-" + i;
+            futures.add(pool.submit(() -> sendAndReceive(msg)));
+        }
+
+        List<String> results = new ArrayList<>();
+        for (Future<String> f : futures) {
+            results.add(f.get(10, TimeUnit.SECONDS));
+        }
+        pool.shutdown();
+
+        for (int i = 0; i < count; i++) {
+            assertThat(results).contains("msg-" + i);
+        }
+    }
+
+    @Test
+    void errorHtmlTemplate_loadedFromClasspath() throws Exception {
+        when(tracker.getAndClearChanges()).thenReturn(
+            new CompilationSourcesList(List.of(Path.of("changed.java")), List.of(), List.of()));
+        when(compiler.invoke()).thenReturn(CompilationResult.ERROR);
+
+        startProxyWithEchoBackend();
+        String response = sendAndReceive("GET / HTTP/1.1\r\n\r\n");
+        assertThat(response).contains("<title>Compilation Error</title>");
+    }
+
+    private boolean connectSucceeds(int port) {
+        try (Socket s = new Socket("localhost", port)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/runner/ApplicationInstanceTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/runner/ApplicationInstanceTest.java
@@ -1,0 +1,149 @@
+package io.javalin.dev.runner;
+
+import io.javalin.dev.classloader.RuntimeClassLoader;
+import io.javalin.dev.testutil.TestLogger;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationInstanceTest {
+
+    private final TestLogger logger = new TestLogger();
+
+    private ApplicationInstance create(int port, RuntimeClassLoader cl, Thread thread) {
+        return new ApplicationInstance(port, cl, thread, logger);
+    }
+
+    @Test
+    void port_returnsConstructorPort() {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var instance = create(8080, cl, new Thread(() -> {}));
+        assertThat(instance.port()).isEqualTo(8080);
+        instance.stop();
+    }
+
+    @Test
+    void address_returnsLocalhostWithPort() {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var instance = create(9090, cl, new Thread(() -> {}));
+        assertThat(instance.address()).isEqualTo(new InetSocketAddress("localhost", 9090));
+        instance.stop();
+    }
+
+    @Test
+    void stop_interruptsAppThread() throws Exception {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        AtomicBoolean interrupted = new AtomicBoolean(false);
+        Thread thread = new Thread(() -> {
+            try {
+                Thread.sleep(60_000);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
+
+        var instance = create(8080, cl, thread);
+        instance.stop();
+
+        thread.join(5000);
+        assertThat(interrupted.get()).isTrue();
+    }
+
+    @Test
+    void stop_closesRuntimeClassLoader() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader()) {
+            @Override
+            public void close() throws java.io.IOException {
+                closed.set(true);
+                super.close();
+            }
+        };
+        var instance = create(8080, cl, new Thread(() -> {}));
+        instance.stop();
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void stop_isIdempotent() throws Exception {
+        AtomicBoolean closeCalled = new AtomicBoolean(false);
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader()) {
+            @Override
+            public void close() throws java.io.IOException {
+                if (!closeCalled.compareAndSet(false, true)) {
+                    throw new RuntimeException("close called twice");
+                }
+                super.close();
+            }
+        };
+        var instance = create(8080, cl, new Thread(() -> {}));
+        instance.stop();
+        instance.stop(); // second stop should be a no-op, no exception
+        assertThat(closeCalled.get()).isTrue();
+    }
+
+    @Test
+    void stop_nullsReferences() throws Exception {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var instance = create(8080, cl, new Thread(() -> {}));
+        instance.stop();
+        // After stop, closeRuntimeClassLoader should be a no-op (cl is null internally)
+        instance.closeRuntimeClassLoader(); // should not throw
+    }
+
+    @Test
+    void closeRuntimeClassLoader_closesClassLoader() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader()) {
+            @Override
+            public void close() throws java.io.IOException {
+                closed.set(true);
+                super.close();
+            }
+        };
+        var instance = create(8080, cl, new Thread(() -> {}));
+        instance.closeRuntimeClassLoader();
+        assertThat(closed.get()).isTrue();
+        instance.stop();
+    }
+
+    @Test
+    void closeRuntimeClassLoader_logsWarningOnException() throws Exception {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader()) {
+            @Override
+            public void close() throws java.io.IOException {
+                throw new java.io.IOException("test error");
+            }
+        };
+        var instance = create(8080, cl, new Thread(() -> {}));
+        instance.closeRuntimeClassLoader();
+        assertThat(logger.hasMessage("warn", "Failed to close RuntimeClassLoader")).isTrue();
+        // Need to stop without re-closing the broken classloader
+        // stop() will try to close again but that's fine since it handles errors
+    }
+
+    @Test
+    void stop_withFinishedThread_noException() throws Exception {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        Thread thread = new Thread(() -> {}); // finishes immediately
+        thread.start();
+        thread.join();
+
+        var instance = create(8080, cl, thread);
+        instance.stop(); // should not throw even though thread already finished
+    }
+
+    @Test
+    void stop_logsMessages() throws Exception {
+        var cl = new RuntimeClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        var instance = create(8080, cl, new Thread(() -> {}));
+        instance.stop();
+        assertThat(logger.hasMessage("info", "Stopping ApplicationInstance on port 8080")).isTrue();
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/runner/ApplicationRunnerTest.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/runner/ApplicationRunnerTest.java
@@ -1,0 +1,241 @@
+package io.javalin.dev.runner;
+
+import io.javalin.dev.main.ApplicationMainClassCandidate;
+import io.javalin.dev.main.ApplicationMainClassType;
+import io.javalin.dev.testutil.ClassFileCompiler;
+import io.javalin.dev.testutil.TestLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URL;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationRunnerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final TestLogger logger = new TestLogger();
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty("javalin.dev.internalPort");
+        System.clearProperty("test.marker.staticArgs");
+        System.clearProperty("test.marker.staticNoArgs");
+        System.clearProperty("test.marker.instanceArgs");
+        System.clearProperty("test.marker.instanceNoArgs");
+    }
+
+    private ApplicationRunner createRunner(String className, ApplicationMainClassType type) throws Exception {
+        var candidate = new ApplicationMainClassCandidate(className, type);
+        URL classesUrl = tempDir.toUri().toURL();
+        return new ApplicationRunner(new URL[0], new URL[]{classesUrl}, candidate, logger);
+    }
+
+    @Test
+    void start_returnsValidInstance() throws Exception {
+        ClassFileCompiler.compile(tempDir, "ValidApp", """
+            public class ValidApp {
+                public static void main(String[] args) {
+                    System.setProperty("test.marker.staticArgs", "ok");
+                }
+            }
+            """);
+
+        var runner = createRunner("ValidApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var instance = runner.start();
+        try {
+            assertThat(instance).isNotNull();
+            assertThat(instance.port()).isGreaterThan(0);
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_setsInternalPortSystemProperty() throws Exception {
+        ClassFileCompiler.compile(tempDir, "PortApp", """
+            public class PortApp {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var runner = createRunner("PortApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var instance = runner.start();
+        try {
+            assertThat(System.getProperty("javalin.dev.internalPort"))
+                .isEqualTo(String.valueOf(instance.port()));
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_lazyCreatesBaseClassLoader() throws Exception {
+        ClassFileCompiler.compile(tempDir, "LazyApp", """
+            public class LazyApp {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var runner = createRunner("LazyApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var instance1 = runner.start();
+        instance1.stop();
+
+        // Second start should reuse base classloader
+        var instance2 = runner.start();
+        instance2.stop();
+        // Both should succeed (no exception means base CL was reused)
+    }
+
+    @Test
+    void start_spawnsAppThreadAsDaemon() throws Exception {
+        ClassFileCompiler.compile(tempDir, "DaemonApp", """
+            public class DaemonApp {
+                public static void main(String[] args) {
+                    try { Thread.sleep(60000); } catch (InterruptedException e) {}
+                }
+            }
+            """);
+
+        var runner = createRunner("DaemonApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var instance = runner.start();
+        try {
+            // The app thread should be a daemon so it won't prevent JVM shutdown
+            // We verify it started and the instance was created
+            assertThat(instance.port()).isGreaterThan(0);
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_invokesStaticMainWithArgs() throws Exception {
+        ClassFileCompiler.compile(tempDir, "StaticArgsApp", """
+            public class StaticArgsApp {
+                public static void main(String[] args) {
+                    System.setProperty("test.marker.staticArgs", "invoked");
+                }
+            }
+            """);
+
+        var runner = createRunner("StaticArgsApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var instance = runner.start();
+        try {
+            Thread.sleep(200); // give app thread time to run
+            assertThat(System.getProperty("test.marker.staticArgs")).isEqualTo("invoked");
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_invokesStaticMainWithoutArgs() throws Exception {
+        ClassFileCompiler.compile(tempDir, "StaticNoArgsApp", """
+            public class StaticNoArgsApp {
+                public static void main() {
+                    System.setProperty("test.marker.staticNoArgs", "invoked");
+                }
+            }
+            """);
+
+        var runner = createRunner("StaticNoArgsApp", ApplicationMainClassType.STATIC_MAIN_WITHOUT_ARGS);
+        var instance = runner.start();
+        try {
+            Thread.sleep(200);
+            assertThat(System.getProperty("test.marker.staticNoArgs")).isEqualTo("invoked");
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_invokesInstanceMainWithArgs() throws Exception {
+        ClassFileCompiler.compile(tempDir, "InstanceArgsApp", """
+            public class InstanceArgsApp {
+                public InstanceArgsApp() {}
+                public void main(String[] args) {
+                    System.setProperty("test.marker.instanceArgs", "invoked");
+                }
+            }
+            """);
+
+        var runner = createRunner("InstanceArgsApp", ApplicationMainClassType.INSTANCE_MAIN_WITH_ARGS);
+        var instance = runner.start();
+        try {
+            Thread.sleep(200);
+            assertThat(System.getProperty("test.marker.instanceArgs")).isEqualTo("invoked");
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_invokesInstanceMainWithoutArgs() throws Exception {
+        ClassFileCompiler.compile(tempDir, "InstanceNoArgsApp", """
+            public class InstanceNoArgsApp {
+                public InstanceNoArgsApp() {}
+                public void main() {
+                    System.setProperty("test.marker.instanceNoArgs", "invoked");
+                }
+            }
+            """);
+
+        var runner = createRunner("InstanceNoArgsApp", ApplicationMainClassType.INSTANCE_MAIN_WITHOUT_ARGS);
+        var instance = runner.start();
+        try {
+            Thread.sleep(200);
+            assertThat(System.getProperty("test.marker.instanceNoArgs")).isEqualTo("invoked");
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_setsContextClassLoader() throws Exception {
+        ClassFileCompiler.compile(tempDir, "CtxClApp", """
+            public class CtxClApp {
+                public static void main(String[] args) {
+                    System.setProperty("test.marker.staticArgs",
+                        Thread.currentThread().getContextClassLoader().getClass().getName());
+                }
+            }
+            """);
+
+        var runner = createRunner("CtxClApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+        var instance = runner.start();
+        try {
+            Thread.sleep(200);
+            assertThat(System.getProperty("test.marker.staticArgs"))
+                .isEqualTo("io.javalin.dev.classloader.RuntimeClassLoader");
+        } finally {
+            instance.stop();
+        }
+    }
+
+    @Test
+    void start_isSerialized() throws Exception {
+        ClassFileCompiler.compile(tempDir, "SerialApp", """
+            public class SerialApp {
+                public static void main(String[] args) {}
+            }
+            """);
+
+        var runner = createRunner("SerialApp", ApplicationMainClassType.STATIC_MAIN_WITH_ARGS);
+
+        // Start two instances in sequence (concurrent starts are serialized via startLock)
+        var instance1 = runner.start();
+        var instance2 = runner.start();
+        try {
+            assertThat(instance1.port()).isNotEqualTo(instance2.port());
+            assertThat(instance1.port()).isGreaterThan(0);
+            assertThat(instance2.port()).isGreaterThan(0);
+        } finally {
+            instance1.stop();
+            instance2.stop();
+        }
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/testutil/ClassFileCompiler.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/testutil/ClassFileCompiler.java
@@ -1,0 +1,49 @@
+package io.javalin.dev.testutil;
+
+import javax.tools.*;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public final class ClassFileCompiler {
+
+    private ClassFileCompiler() {}
+
+    public static Path compile(Path outputDir, String className, String sourceCode) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("No JavaCompiler available - run tests with a JDK, not a JRE");
+        }
+
+        Files.createDirectories(outputDir);
+
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(outputDir.toFile()));
+
+            JavaFileObject source = new SimpleJavaFileObject(
+                URI.create("string:///" + className.replace('.', '/') + ".java"),
+                JavaFileObject.Kind.SOURCE
+            ) {
+                @Override
+                public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                    return sourceCode;
+                }
+            };
+
+            DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+            JavaCompiler.CompilationTask task = compiler.getTask(null, fm, diagnostics, null, null, List.of(source));
+
+            if (!task.call()) {
+                StringBuilder sb = new StringBuilder("Compilation failed:\n");
+                for (Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                    sb.append(d.toString()).append('\n');
+                }
+                throw new RuntimeException(sb.toString());
+            }
+        }
+
+        return outputDir;
+    }
+}

--- a/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/testutil/TestLogger.java
+++ b/javalin-build/javalin-build-common/src/test/java/io/javalin/dev/testutil/TestLogger.java
@@ -1,0 +1,52 @@
+package io.javalin.dev.testutil;
+
+import io.javalin.dev.log.JavalinDevLogger;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public final class TestLogger implements JavalinDevLogger {
+
+    public record LogEntry(String level, String message) {}
+
+    private final CopyOnWriteArrayList<LogEntry> entries = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void info(String message) {
+        entries.add(new LogEntry("info", message));
+    }
+
+    @Override
+    public void warn(String message) {
+        entries.add(new LogEntry("warn", message));
+    }
+
+    @Override
+    public void error(String message) {
+        entries.add(new LogEntry("error", message));
+    }
+
+    @Override
+    public void debug(String message) {
+        entries.add(new LogEntry("debug", message));
+    }
+
+    public List<LogEntry> all() {
+        return List.copyOf(entries);
+    }
+
+    public List<LogEntry> messages(String level) {
+        return entries.stream()
+            .filter(e -> e.level().equals(level))
+            .toList();
+    }
+
+    public boolean hasMessage(String level, String substring) {
+        return entries.stream()
+            .anyMatch(e -> e.level().equals(level) && e.message().contains(substring));
+    }
+
+    public void clear() {
+        entries.clear();
+    }
+}

--- a/javalin-build/javalin-build-gradle-plugin/pom.xml
+++ b/javalin-build/javalin-build-gradle-plugin/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.javalin</groupId>
+        <artifactId>javalin-build</artifactId>
+        <version>7.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>javalin-build-gradle-plugin</artifactId>
+    <name>Javalin Gradle Plugin</name>
+    <description>Gradle plugin providing javalinDev task for development mode with automatic recompilation and restart</description>
+
+    <properties>
+        <gradle.version>8.11.1</gradle.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>gradle-releases</id>
+            <url>https://repo.gradle.org/gradle/libs-releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin-build-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.gradleplugins</groupId>
+            <artifactId>gradle-api</artifactId>
+            <version>${gradle.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/GradleCompilationInvoker.kt
+++ b/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/GradleCompilationInvoker.kt
@@ -1,0 +1,39 @@
+package io.javalin.dev.gradle
+
+import io.javalin.dev.compilation.CompilationInvoker
+import io.javalin.dev.compilation.CompilationResult
+import io.javalin.dev.log.JavalinDevLogger
+import org.gradle.tooling.GradleConnector
+import java.io.File
+
+class GradleCompilationInvoker(
+    private val rootDir: File,
+    private val taskPath: String,
+    private val logger: JavalinDevLogger
+) : CompilationInvoker {
+
+    init {
+        logger.debug("GradleCompilationInvoker created for root directory: ${rootDir.absolutePath}, task: $taskPath")
+    }
+
+    override fun invoke(): CompilationResult {
+        logger.info("Running Gradle task: $taskPath in ${rootDir.absolutePath}")
+        val connector = GradleConnector.newConnector()
+            .forProjectDirectory(rootDir)
+        val connection = connector.connect()
+        return try {
+            connection.newBuild()
+                .forTasks(taskPath)
+                .setStandardOutput(System.out)
+                .setStandardError(System.err)
+                .run()
+            logger.info("Gradle compilation succeeded")
+            CompilationResult.SUCCESS
+        } catch (e: Exception) {
+            logger.error("Gradle compilation failed: ${e.message}")
+            CompilationResult.ERROR
+        } finally {
+            connection.close()
+        }
+    }
+}

--- a/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/GradleDevLogger.kt
+++ b/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/GradleDevLogger.kt
@@ -1,0 +1,11 @@
+package io.javalin.dev.gradle
+
+import io.javalin.dev.log.JavalinDevLogger
+import org.gradle.api.logging.Logger
+
+class GradleDevLogger(private val logger: Logger) : JavalinDevLogger {
+    override fun info(message: String) = logger.lifecycle(message)
+    override fun warn(message: String) = logger.warn(message)
+    override fun error(message: String) = logger.error(message)
+    override fun debug(message: String) = logger.debug(message)
+}

--- a/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/JavalinDevPlugin.kt
+++ b/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/JavalinDevPlugin.kt
@@ -1,0 +1,20 @@
+package io.javalin.dev.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+open class JavalinDevExtension {
+    var mainClass: String? = null
+}
+
+class JavalinDevPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.extensions.create("javalinDev", JavalinDevExtension::class.java)
+        project.pluginManager.withPlugin("java-base") {
+            project.tasks.register("javalinDev", JavalinDevTask::class.java) { task ->
+                task.group = "application"
+                task.description = "Starts Javalin in dev mode with automatic recompilation and restart"
+            }
+        }
+    }
+}

--- a/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/JavalinDevTask.kt
+++ b/javalin-build/javalin-build-gradle-plugin/src/main/kotlin/io/javalin/dev/gradle/JavalinDevTask.kt
@@ -1,0 +1,192 @@
+package io.javalin.dev.gradle
+
+import io.javalin.dev.compilation.CompilationInvoker
+import io.javalin.dev.compilation.CompilationResult
+import io.javalin.dev.compilation.CompilationSourcesTracker
+import io.javalin.dev.log.JavalinDevLogger
+import io.javalin.dev.main.ApplicationMainClassCandidate
+import io.javalin.dev.main.ApplicationMainClassScanner
+import io.javalin.dev.main.ApplicationMainClassType
+import io.javalin.dev.proxy.ApplicationProxy
+import io.javalin.dev.runner.ApplicationRunner
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.net.URL
+
+abstract class JavalinDevTask : DefaultTask() {
+
+    init {
+        outputs.upToDateWhen { false }
+    }
+
+    @TaskAction
+    fun execute() {
+        logger.lifecycle("Starting dev mode...")
+        val devLogger: JavalinDevLogger = GradleDevLogger(logger)
+
+        val mainClassOverride = project.extensions.findByType(JavalinDevExtension::class.java)?.mainClass
+            ?: project.findProperty("mainClass") as? String
+
+        val taskPath = if (project == project.rootProject) "classes" else "${project.path}:classes"
+        val compiler = GradleCompilationInvoker(project.rootProject.projectDir, taskPath, devLogger)
+
+        compileApplication(compiler, devLogger)
+
+        val runner = createApplicationRunner(mainClassOverride, devLogger)
+        val instance = runner.start()
+
+        CompilationSourcesTracker(devLogger).use { tracker ->
+            registerWatchedSources(tracker, devLogger)
+            tracker.recordBaseline()
+
+            val proxyPort = waitForAppInit(devLogger)
+            val proxy = ApplicationProxy(tracker, compiler, runner, instance, devLogger)
+            proxy.start(proxyPort)
+        }
+    }
+
+    private fun compileApplication(compiler: CompilationInvoker, devLogger: JavalinDevLogger) {
+        devLogger.info("Compiling...")
+        val result = compiler.invoke()
+        if (result == CompilationResult.ERROR) {
+            throw GradleException("Initial compilation failed")
+        }
+        devLogger.info("Compilation successful")
+    }
+
+    private fun createApplicationRunner(mainClassOverride: String?, devLogger: JavalinDevLogger): ApplicationRunner {
+        val dependencyUrls = resolveDependencyUrls()
+        val classesUrls = resolveClassesUrls()
+        val mainClass = resolveMainClass(mainClassOverride, devLogger)
+        return ApplicationRunner(dependencyUrls, classesUrls, mainClass, devLogger)
+    }
+
+    private fun resolveDependencyUrls(): Array<URL> {
+        val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+        val mainSourceSet = sourceSets.getByName("main")
+        val outputFiles = mainSourceSet.output.files
+
+        return project.configurations.getByName("runtimeClasspath")
+            .resolve()
+            .filter { it !in outputFiles }
+            .map { it.toURI().toURL() }
+            .toTypedArray()
+    }
+
+    private fun resolveClassesUrls(): Array<URL> {
+        val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+        val mainSourceSet = sourceSets.getByName("main")
+        val urls = mutableListOf<URL>()
+        mainSourceSet.output.classesDirs.forEach { urls.add(it.toURI().toURL()) }
+        mainSourceSet.output.resourcesDir?.let { urls.add(it.toURI().toURL()) }
+        return urls.toTypedArray()
+    }
+
+    private fun resolveMainClass(mainClassOverride: String?, devLogger: JavalinDevLogger): ApplicationMainClassCandidate {
+        val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+        val mainSourceSet = sourceSets.getByName("main")
+        val scanner = ApplicationMainClassScanner(devLogger)
+
+        if (!mainClassOverride.isNullOrBlank()) {
+            for (classesDir in mainSourceSet.output.classesDirs) {
+                if (!classesDir.exists()) continue
+                val classFile = classesDir.toPath().resolve(
+                    mainClassOverride.replace(".", File.separator) + ".class"
+                )
+                val result = scanner.scanFile(classFile)
+                if (result.isPresent) {
+                    return result.get()
+                }
+            }
+            throw GradleException("Cannot find main class: $mainClassOverride")
+        }
+
+        // Auto-detect by scanning all classes directories
+        for (classesDir in mainSourceSet.output.classesDirs) {
+            if (!classesDir.exists()) continue
+            val candidates = scanner.scanDirectory(classesDir.toPath())
+            for (type in ApplicationMainClassType.values()) {
+                val byType: List<ApplicationMainClassCandidate> = candidates[type] ?: continue
+                if (byType.isEmpty()) continue
+                if (byType.size == 1) return byType[0]
+
+                val names = byType.joinToString(", ") { it.className() }
+                throw GradleException(
+                    "Multiple main classes found: $names" +
+                    ". Specify with -PmainClass=com.example.App"
+                )
+            }
+        }
+
+        throw GradleException(
+            "No main classes found" +
+            ". Create one or specify with -PmainClass=com.example.App"
+        )
+    }
+
+    private fun registerWatchedSources(tracker: CompilationSourcesTracker, devLogger: JavalinDevLogger) {
+        devLogger.info("Registering watched sources...")
+
+        // Watch settings file
+        for (name in listOf("settings.gradle.kts", "settings.gradle")) {
+            val file = project.rootProject.file(name)
+            if (file.exists()) tracker.watchFile(file.toPath())
+        }
+
+        // Watch current project
+        watchProjectSources(project, tracker, devLogger)
+
+        // Watch project dependencies (equivalent to Maven reactor dependencies)
+        val projectDeps = project.configurations.getByName("runtimeClasspath")
+            .allDependencies
+            .filterIsInstance<ProjectDependency>()
+            .map { project.project(it.path) }
+
+        for (dep in projectDeps) {
+            devLogger.info("Watching project dependency: ${dep.path}")
+            watchProjectSources(dep, tracker, devLogger)
+        }
+        devLogger.info("Watched sources registration complete")
+    }
+
+    private fun watchProjectSources(proj: Project, tracker: CompilationSourcesTracker, devLogger: JavalinDevLogger) {
+        devLogger.debug("Watching project: ${proj.group}:${proj.name}")
+
+        // Build file (build.gradle.kts or build.gradle)
+        if (proj.buildFile.exists()) {
+            tracker.watchFile(proj.buildFile.toPath())
+        }
+
+        // Source and resource directories
+        val sourceSets = proj.extensions.findByType(SourceSetContainer::class.java) ?: return
+        val mainSourceSet = sourceSets.findByName("main") ?: return
+
+        for (srcDir in mainSourceSet.allSource.srcDirs) {
+            tracker.watchDirectory(srcDir.toPath())
+        }
+    }
+
+    private fun waitForAppInit(devLogger: JavalinDevLogger): Int {
+        devLogger.debug("Waiting for application to set javalin.dev.requestedPort...")
+        while (!Thread.interrupted()) {
+            val value = System.getProperty("javalin.dev.requestedPort")
+            if (value != null) {
+                val port = value.toInt()
+                devLogger.info("Application requested proxy port: $port")
+                return port
+            }
+            try {
+                Thread.sleep(100)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                break
+            }
+        }
+        throw GradleException("Could not detect requested port")
+    }
+}

--- a/javalin-build/javalin-build-gradle-plugin/src/main/resources/META-INF/gradle-plugins/io.javalin.dev.properties
+++ b/javalin-build/javalin-build-gradle-plugin/src/main/resources/META-INF/gradle-plugins/io.javalin.dev.properties
@@ -1,0 +1,1 @@
+implementation-class=io.javalin.dev.gradle.JavalinDevPlugin

--- a/javalin-build/javalin-build-maven-plugin/pom.xml
+++ b/javalin-build/javalin-build-maven-plugin/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.javalin</groupId>
+        <artifactId>javalin-build</artifactId>
+        <version>7.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>javalin-build-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Javalin Maven Plugin</name>
+    <description>Maven plugin providing javalin:dev goal for development mode with automatic recompilation and restart</description>
+
+    <properties>
+        <maven.api.version>3.9.9</maven.api.version>
+        <maven.resolver.version>1.9.22</maven.resolver.version>
+        <maven.plugin-annotations.version>3.15.1</maven.plugin-annotations.version>
+        <maven.plugin-plugin.version>3.15.1</maven.plugin-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin-build-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven.plugin-annotations.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-embedder</artifactId>
+            <version>${maven.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-connector-basic</artifactId>
+            <version>${maven.resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-http</artifactId>
+            <version>${maven.resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Generate Maven plugin descriptor -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven.plugin-plugin.version}</version>
+                <configuration>
+                    <goalPrefix>javalin</goalPrefix>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/javalin-build/javalin-build-maven-plugin/src/main/java/io/javalin/dev/maven/JavalinDevMojo.java
+++ b/javalin-build/javalin-build-maven-plugin/src/main/java/io/javalin/dev/maven/JavalinDevMojo.java
@@ -1,0 +1,270 @@
+package io.javalin.dev.maven;
+
+import io.javalin.dev.compilation.CompilationInvoker;
+import io.javalin.dev.compilation.CompilationResult;
+import io.javalin.dev.compilation.CompilationSourcesTracker;
+import io.javalin.dev.log.JavalinDevLogger;
+import io.javalin.dev.main.ApplicationMainClassCandidate;
+import io.javalin.dev.main.ApplicationMainClassScanner;
+import io.javalin.dev.main.ApplicationMainClassType;
+import io.javalin.dev.proxy.ApplicationProxy;
+import io.javalin.dev.runner.ApplicationInstance;
+import io.javalin.dev.runner.ApplicationRunner;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Mojo(name = "dev", requiresDependencyResolution = ResolutionScope.RUNTIME, requiresProject = true)
+public final class JavalinDevMojo extends AbstractMojo {
+    /**
+     * The current Maven project.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * All projects in the reactor (populated automatically by Maven).
+     * Respects {@code -pl} filtering: only modules selected by the user are included.
+     */
+    @Parameter(defaultValue = "${reactorProjects}", readonly = true, required = true)
+    private List<MavenProject> reactorProjects;
+
+    /**
+     * The fully qualified main class name.
+     * If not specified, it is auto-detected by scanning for main method candidates.
+     */
+    @Parameter(property = "main.class")
+    private String mainClassName;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        JavalinDevLogger logger = new MavenDevLogger(getLog());
+
+        logger.info("Starting dev mode...");
+
+        try {
+            CompilationInvoker compiler = new MavenCompilationInvoker(project.getBasedir(), logger);
+
+            compileApplication(compiler, logger);
+
+            ApplicationRunner runner = createApplicationRunner(logger);
+
+            ApplicationInstance instance = runner.start();
+
+            try (CompilationSourcesTracker tracker = new CompilationSourcesTracker(logger)) {
+                registerWatchedSources(tracker, logger);
+                tracker.recordBaseline();
+
+                var proxyPort = waitForAppInit(logger);
+                ApplicationProxy proxy = createApplicationProxy(tracker, compiler, runner, instance, logger);
+                proxy.start(proxyPort);
+            }
+        } catch (MojoExecutionException | MojoFailureException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MojoExecutionException("Dev mode failed", e);
+        }
+    }
+
+    private void compileApplication(CompilationInvoker compiler, JavalinDevLogger logger) throws MojoExecutionException {
+        logger.info("Compiling...");
+        CompilationResult initialCompile = compiler.invoke();
+        if (initialCompile == CompilationResult.ERROR) {
+            throw new MojoExecutionException("Initial compilation failed");
+        }
+        logger.info("Compilation successful");
+    }
+
+
+    private @NotNull ApplicationRunner createApplicationRunner(JavalinDevLogger logger) throws MojoExecutionException {
+        URL[] dependencyUrls = resolveDependencyUrls(logger);
+        URL[] classesUrls = resolveClassesUrls(logger);
+        ApplicationMainClassCandidate resolvedMainClass = resolveMainClass(logger);
+        return new ApplicationRunner(dependencyUrls, classesUrls, resolvedMainClass, logger);
+    }
+
+    private URL[] resolveDependencyUrls(JavalinDevLogger logger) throws MojoExecutionException {
+        try {
+            List<URL> urls = new ArrayList<>();
+            for (String element : project.getRuntimeClasspathElements()) {
+                // Skip the output directory (those go in RuntimeClassLoader)
+                if (element.equals(project.getBuild().getOutputDirectory())) {
+                    continue;
+                }
+                urls.add(new File(element).toURI().toURL());
+            }
+            logger.debug("Resolved " + urls.size() + " dependency URL(s)");
+            return urls.toArray(URL[]::new);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to resolve classpath", e);
+        }
+    }
+
+    private URL[] resolveClassesUrls(JavalinDevLogger logger) throws MojoExecutionException {
+        try {
+            File outputDir = new File(project.getBuild().getOutputDirectory());
+            logger.debug("Classes output directory: " + outputDir.getAbsolutePath());
+            return new URL[]{outputDir.toURI().toURL()};
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to resolve classes directory", e);
+        }
+    }
+
+    private ApplicationMainClassCandidate resolveMainClass(JavalinDevLogger logger) throws MojoExecutionException {
+        try {
+            Path classesDir = Path.of(project.getBuild().getOutputDirectory());
+            ApplicationMainClassScanner scanner = new ApplicationMainClassScanner(logger);
+            if (mainClassName != null && !mainClassName.isBlank()) {
+                logger.info("Using configured main class: " + mainClassName);
+                Path mainClass = classesDir.resolve(mainClassName.replaceAll("\\.", File.separator) + ".class");
+                var result = scanner.scanFile(mainClass);
+                if (result.isEmpty()) {
+                    throw new MojoExecutionException("Cannot find main class: " + mainClassName);
+                }
+                return result.get();
+            } else {
+                logger.info("No main class configured, auto-detecting...");
+                Map<ApplicationMainClassType, List<ApplicationMainClassCandidate>> candidates = scanner.scanDirectory(classesDir);
+                for (var mainClassType : ApplicationMainClassType.values()) {
+                    var candidatesByType = candidates.get(mainClassType);
+                    if (candidatesByType == null || candidatesByType.isEmpty()) {
+                        continue;
+                    }
+
+                    if (candidatesByType.size() == 1) {
+                        logger.info("Auto-detected main class: " + candidatesByType.get(0).className() + " [" + candidatesByType.get(0).type() + "]");
+                        return candidatesByType.get(0);
+                    }
+
+                    var candidatesByTypeClassNames = candidatesByType.stream()
+                        .map(ApplicationMainClassCandidate::className)
+                        .collect(Collectors.joining(", "));
+                    throw new MojoExecutionException(
+                        "Multiple main classes found: " + candidatesByTypeClassNames
+                        + ". Specify with -Dmain.class=com.example.App");
+                }
+                throw new MojoExecutionException(
+                    "No main classes found"
+                    + ". Create one or specify with -Dmain.class=com.example.App");
+            }
+        }
+        catch (IOException e) {
+            throw new MojoExecutionException("Failed to scan for main class", e);
+        }
+    }
+
+    private void registerWatchedSources(CompilationSourcesTracker tracker, JavalinDevLogger logger) throws IOException {
+        logger.info("Registering watched sources...");
+        // Watch the current project and its parent chain
+        var current = project;
+        while (current != null) {
+            watchProjectSources(current, tracker, logger);
+            current = current.getParent();
+        }
+
+        // Watch reactor dependencies (sibling modules in the same build)
+        Map<String, MavenProject> reactorsByIdentifier = reactorProjects.stream().collect(Collectors.toMap(
+            p -> p.getGroupId() + ":" + p.getArtifactId(),
+            Function.identity(),
+            (ignored, last) -> last
+        ));
+
+       if (project != null) {
+           for (Artifact artifact : project.getArtifacts()) {
+               String artifactIdentifier = artifact.getGroupId() + ":" + artifact.getArtifactId();
+               MavenProject reactorDep = reactorsByIdentifier.get(artifactIdentifier);
+               if (reactorDep != null) {
+                   logger.info("Watching reactor dependency: " + reactorDep.getGroupId() + ":" + reactorDep.getArtifactId());
+                   watchProjectSources(reactorDep, tracker, logger);
+               }
+
+               // Watch system-scoped dependencies (those with a systemPath)
+               if (Artifact.SCOPE_SYSTEM.equals(artifact.getScope()) && artifact.getFile() != null) {
+                   logger.info("Watching system dependency: " + artifact.getFile().getAbsolutePath());
+                   tracker.watchFile(artifact.getFile().toPath());
+               }
+           }
+       }
+       logger.info("Watched sources registration complete");
+    }
+
+    private void watchProjectSources(MavenProject p, CompilationSourcesTracker tracker, JavalinDevLogger logger) throws IOException {
+        if (p == null) {
+            return;
+        }
+
+        List<MavenProject> collectedProjects = p.getCollectedProjects();
+        if (collectedProjects != null) {
+            for (MavenProject collected : collectedProjects) {
+                watchProjectSources(collected, tracker, logger);
+            }
+        }
+
+        logger.debug("Watching project: " + p.getGroupId() + ":" + p.getArtifactId());
+
+        // Project POM
+        File pom = p.getFile();
+        if (pom != null) {
+            tracker.watchFile(pom.toPath());
+        }
+
+        // Source directories
+        for (String sourceRoot : p.getCompileSourceRoots()) {
+            tracker.watchDirectory(Path.of(sourceRoot));
+        }
+
+        // Resource directories
+        for (Resource resource : p.getResources()) {
+            if (resource != null) {
+                String directory = resource.getDirectory();
+                if (directory != null) {
+                    File dir = new File(directory);
+                    if (!dir.isAbsolute() && p.getBasedir() != null) {
+                        dir = new File(p.getBasedir(), directory);
+                    }
+                    tracker.watchDirectory(dir.toPath());
+                }
+            }
+        }
+    }
+
+    private @NotNull ApplicationProxy createApplicationProxy(CompilationSourcesTracker tracker, CompilationInvoker compiler, ApplicationRunner runner, ApplicationInstance instance, JavalinDevLogger logger) {
+        return new ApplicationProxy(tracker, compiler, runner, instance, logger);
+    }
+
+    private int waitForAppInit(JavalinDevLogger logger) throws MojoExecutionException {
+        logger.debug("Waiting for application to set javalin.dev.requestedPort...");
+        while (!Thread.interrupted()) {
+            String value = System.getProperty("javalin.dev.requestedPort");
+            if (value != null) {
+                int port = Integer.parseInt(value);
+                logger.info("Application requested proxy port: " + port);
+                return port;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        throw new MojoExecutionException("Could not detect requested port, defaulting to 8080");
+    }
+}

--- a/javalin-build/javalin-build-maven-plugin/src/main/java/io/javalin/dev/maven/MavenCompilationInvoker.java
+++ b/javalin-build/javalin-build-maven-plugin/src/main/java/io/javalin/dev/maven/MavenCompilationInvoker.java
@@ -1,0 +1,48 @@
+package io.javalin.dev.maven;
+
+import io.javalin.dev.compilation.CompilationInvoker;
+import io.javalin.dev.compilation.CompilationResult;
+import io.javalin.dev.log.JavalinDevLogger;
+import org.apache.maven.cli.MavenCli;
+
+import java.io.File;
+
+public final class MavenCompilationInvoker implements CompilationInvoker {
+    private final File baseDir;
+    private final MavenCli maven;
+    private final JavalinDevLogger logger;
+
+    public MavenCompilationInvoker(File baseDir, JavalinDevLogger logger) {
+        this.baseDir = baseDir;
+        this.maven = new MavenCli();
+        this.logger = logger;
+        logger.debug("MavenCompilationInvoker created for base directory: " + baseDir.getAbsolutePath());
+    }
+
+    @Override
+    public CompilationResult invoke() {
+        try {
+            logger.debug("Setting maven.multiModuleProjectDirectory to: " + baseDir.getAbsolutePath());
+            System.setProperty("maven.multiModuleProjectDirectory", baseDir.getAbsolutePath());
+
+            logger.info("Running: mvn compile -B in " + baseDir.getAbsolutePath());
+            int exitCode = maven.doMain(
+                new String[]{"compile", "-B"},
+                baseDir.getAbsolutePath(),
+                System.out,
+                System.err
+            );
+
+            if (exitCode != 0) {
+                logger.error("Maven compilation failed with exit code: " + exitCode);
+                return CompilationResult.ERROR;
+            }
+
+            logger.info("Maven compilation succeeded");
+            return CompilationResult.SUCCESS;
+        } catch (Exception e) {
+            logger.error("Maven compilation threw exception: " + e.getMessage());
+            return CompilationResult.ERROR;
+        }
+    }
+}

--- a/javalin-build/javalin-build-maven-plugin/src/main/java/io/javalin/dev/maven/MavenDevLogger.java
+++ b/javalin-build/javalin-build-maven-plugin/src/main/java/io/javalin/dev/maven/MavenDevLogger.java
@@ -1,0 +1,32 @@
+package io.javalin.dev.maven;
+
+import io.javalin.dev.log.JavalinDevLogger;
+import org.apache.maven.plugin.logging.Log;
+
+final class MavenDevLogger implements JavalinDevLogger {
+    private final Log log;
+
+    MavenDevLogger(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    public void info(String message) {
+        log.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        log.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        log.error(message);
+    }
+
+    @Override
+    public void debug(String message) {
+        log.debug(message);
+    }
+}

--- a/javalin-build/pom.xml
+++ b/javalin-build/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>javalin-parent</artifactId>
+        <groupId>io.javalin</groupId>
+        <version>7.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>javalin-build</artifactId>
+    <name>Javalin Build (parent)</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>javalin-build-common</module>
+        <module>javalin-build-maven-plugin</module>
+        <module>javalin-build-gradle-plugin</module>
+    </modules>
+</project>

--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -97,6 +97,7 @@ public class Javalin {
     public Javalin start(String host, int port) {
         state.jetty.host = host;
         state.jetty.port = port;
+        applyDevModePortOverride();
         jettyServer.getValue().start();
         return this;
     }
@@ -112,6 +113,7 @@ public class Javalin {
      */
     public Javalin start(int port) {
         state.jetty.port = port;
+        applyDevModePortOverride();
         jettyServer.getValue().start();
         return this;
     }
@@ -126,8 +128,21 @@ public class Javalin {
      * @see Javalin#create()
      */
     public Javalin start() {
+        applyDevModePortOverride();
         jettyServer.getValue().start();
         return this;
+    }
+
+    /**
+     * If the dev mode plugin is active, captures the user's requested port
+     * and redirects binding to the internal proxy port.
+     */
+    private void applyDevModePortOverride() {
+        String devPort = System.getProperty("javalin.dev.internalPort");
+        if (devPort != null) {
+            System.setProperty("javalin.dev.requestedPort", String.valueOf(state.jetty.port));
+            state.jetty.port = Integer.parseInt(devPort);
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
         <module>javalin-ssl</module>
         <module>javalin-micrometer</module>
         <module>jacoco-coverage-report</module>
+        <module>javalin-build</module>
     </modules>
 
     <groupId>io.javalin</groupId>


### PR DESCRIPTION
We discussed this feature on [Reddit](https://www.reddit.com/r/java/comments/1rdjlhn/comment/o782irp/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)

In short, what we want to implement with this PR is a dev-server that performs hot reload, similar to quarkus mvn quarkus:dev.
I implemented this as Maven/Gradle plugins: the reason is that, as the dev-server needs to compile the project, it should integrate with the user's existing build infrastructure.

What the Maven/Gradle plugins do is:

1. Compile the project
2. Collect all sources/resources that should be watched and start a service that watches them on a separate thread
3. Look for a main method(supports  [JEP 512](https://openjdk.org/jeps/512)) using ASM
4. Set a dev port System property that the application will use instead of the app port
5. Start the application on the dev port with some classloader magic to make sure the application stays isolated
6. Wait for the application to start  and get the app port 
7. Start a TCP socket on the dev port

(This explanation is obviously very high level, there is a lot of complexity involved in doing some of these things, especially arbitrarly compiling the project whenever we want in a multi threaded environment)

When a request arrives on our TCP socket, we check if the file watcher thread has updates: if there are no updates then we simply forward the request to the app server, otherwise we recompile, start the new app and then finally forward the request we got to the new server. This is thread safe and there is a debounce logic in place so we don't have to check too often if code changed, but HTTP 1.1+ and WebSockets support keep alives which makes things slightly more complicated because we can't just kill the old server: the policy I went for is to keep the old backend running until all connections are closed. This means that the old backend won't get the updated code, but i think this is the right behaviour considering the nature of keep alives. It could be a good idea to have a maximum amount of servers we allow to run concurrently so we don't cause resource exhaustion: I haven't implemented that yet. I have already written the E2E test for Maven, not Gradle, but haven't pushed them yet because I wanted to collect some feedback first on the implementation. Keep in mind that there are a lot of edge cases, mostly related to:

1. Multi module setups
2. Annotation processors that do codegen(e.g. immutables) or modify compiler internals(i.g. lombok)
3. Compiler plugins 

I also haven't wrote javadocs yet, I think it's not needed because this is an internal module, but let me know what your policy on this is.

I also understand it's a lot of code for a PR, and that it will need to be reviewed and tested carefully, let me know if you have any questions about why I made some choices/if something is not clear

Btw I'm using a TCP socket for the proxy so we don't have to handle parsing and resending data, we can just forward it. Problem is, it looks like there isn't a no-copy pipe system from a SocketChannel(the proxy's) to another(the app's) so I currently allocate a direct bytebufer: if this is actually the best approach, it would make sense to create some sort of pool as they are expensive to allocate. This is likely a Java NIO limitation though, I'd bet Netty has a way to implement this without allocating additional buffers.

Also I'm not using Virtual Threads because that requires Java 19 :/