### PR TITLE
Add ability to emit plain data messages in SSE 

### DIFF
--- a/javalin/src/main/java/io/javalin/http/sse/Emitter.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/Emitter.kt
@@ -12,12 +12,14 @@ class Emitter(private var response: HttpServletResponse) {
     var closed = false
         private set
 
-    fun emit(event: String, data: InputStream, id: String?) = synchronized(this) {
+    fun emit(event: String?, data: InputStream, id: String?) = synchronized(this) {
         try {
             if (id != null) {
                 write("id: $id$NEW_LINE")
             }
-            write("event: $event$NEW_LINE")
+            if (event != null) {
+                write("event: $event$NEW_LINE")
+            }
 
             data.buffered().reader().useLines {
                 it.forEach { line -> write("data: $line$NEW_LINE") }

--- a/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseClient.kt
@@ -58,7 +58,18 @@ class SseClient internal constructor(
      * the [close] function will be called instead.
      */
     @JvmOverloads
-    fun sendEvent(event: String, data: Any, id: String? = null) {
+    fun sendEvent(event: String, data: Any, id: String? = null) = emitData(event, data, id)
+
+    /**
+     * Attempt to send plain data without an event type.
+     * Browsers will fire the generic "message" event for these.
+     * If the [emitter] fails to emit (remote client has disconnected),
+     * the [close] function will be called instead.
+     */
+    @JvmOverloads
+    fun sendData(data: Any, id: String? = null) = emitData(null, data, id)
+
+    private fun emitData(event: String?, data: Any, id: String?) {
         if (terminated.get()) return logTerminated()
         when (data) {
             is InputStream -> emitter.emit(event, data, id)

--- a/javalin/src/test/java/io/javalin/TestSse.kt
+++ b/javalin/src/test/java/io/javalin/TestSse.kt
@@ -171,6 +171,46 @@ class TestSse {
         assertThat(http.sse("/sse").get().body.trim()).isEqualTo(": Emitted and closed!")
     }
 
+    @Test
+    fun `sending plain data works`() = TestUtil.test { app, http ->
+        app.unsafe.routes.sse("/sse") { it.doAndClose { it.sendData(data) } }
+        val body = http.sse("/sse").get().body
+        assertThat(body).doesNotContain("event:")
+        assertThat(body).contains("data: $data")
+    }
+
+    @Test
+    fun `sending plain data with id works`() = TestUtil.test { app, http ->
+        app.unsafe.routes.sse("/sse") { it.doAndClose { it.sendData(data, id = "ID1") } }
+        val body = http.sse("/sse").get().body
+        assertThat(body).doesNotContain("event:")
+        assertThat(body).contains("id: ID1")
+        assertThat(body).contains("data: $data")
+    }
+
+    @Test
+    fun `sending plain data as json works`() = TestUtil.test { app, http ->
+        app.unsafe.routes.sse("/sse") { it.doAndClose { it.sendData(SerializableObject()) } }
+        val body = http.sse("/sse").get().body
+        assertThat(body).doesNotContain("event:")
+        assertThat(body).contains("""data: {"value1":"FirstValue","value2":"SecondValue"}""")
+    }
+
+    @Test
+    fun `sending plain data as input stream works`() = TestUtil.test { app, http ->
+        app.unsafe.routes.sse("/sse") { it.doAndClose { it.sendData("MY DATA".byteInputStream()) } }
+        val body = http.sse("/sse").get().body
+        assertThat(body).doesNotContain("event:")
+        assertThat(body).contains("data: MY DATA")
+    }
+
+    @Test
+    fun `sending multi line plain data works`() = TestUtil.test { app, http ->
+        app.unsafe.routes.sse("/sse") { it.doAndClose { it.sendData("a\nb") } }
+        val body = http.sse("/sse").get().body
+        assertThat(body).isEqualTo("data: a\ndata: b\n\n")
+    }
+
     private enum class MyRole : RouteRole { ROLE_ONE }
 
     @Test


### PR DESCRIPTION
This PR makes it possible to emit plain data SSE messages:

```java
  client.sendData("Hello World");
```

See <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#examples> for more info on this.

This is useful for libraries like htmx where raw data messages are used to transmit HTML to the client.
    