### PR TITLE
[deps] Bump stable deps and sync OptionalDependency.kt

### DIFF
--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -50,16 +50,16 @@ enum class CoreDependency(
 ) : OptionalDependency {
 
     // JSON (Jackson) handling
-    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.20.1"),
-    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.20.1"),
-    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.20.1"),
-    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.20.1"),
+    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.21.2"),
+    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.21.2"),
+    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.21.2"),
+    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.21.2"),
     JACKSON_KTORM("Jackson Ktorm", "org.ktorm.jackson.KtormModule", "org.ktorm", "ktorm-jackson", "3.6.0"),
 
     // JSON (Jackson 3) handling
-    JACKSON3("Jackson3", "tools.jackson.databind.json.JsonMapper", "tools.jackson.core", "jackson-databind", "3.1.0"),
-    JACKSON3_KT("Jackson3Kt", "tools.jackson.module.kotlin.KotlinModule", "tools.jackson.module", "jackson-module-kotlin", "3.1.0"),
-    JACKSON3_ECLIPSE_COLLECTIONS("Jackson3EclipseCollections", "tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "tools.jackson.datatype", "jackson-datatype-eclipse-collections", "3.1.0"),
+    JACKSON3("Jackson3", "tools.jackson.databind.json.JsonMapper", "tools.jackson.core", "jackson-databind", "3.1.2"),
+    JACKSON3_KT("Jackson3Kt", "tools.jackson.module.kotlin.KotlinModule", "tools.jackson.module", "jackson-module-kotlin", "3.1.2"),
+    JACKSON3_ECLIPSE_COLLECTIONS("Jackson3EclipseCollections", "tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "tools.jackson.datatype", "jackson-datatype-eclipse-collections", "3.1.2"),
 
     // JSON (Gson)
     GSON("Gson", "com.google.gson.Gson", "com.google.code.gson", "gson", "2.13.2"),
@@ -68,6 +68,6 @@ enum class CoreDependency(
     SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "2.0.17"),
 
     // Compression
-    BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.20.0"),
-    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-6"),
+    BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.22.0"),
+    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-7"),
 }

--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,12 @@
         <!-- RENDERING ENGINE VERSIONS -->
         <velocity.version>2.4.1</velocity.version>
         <freemarker.version>2.3.34</freemarker.version>
-        <thymeleaf.version>3.1.3.RELEASE</thymeleaf.version>
+        <thymeleaf.version>3.1.4.RELEASE</thymeleaf.version>
         <mustache.version>0.9.14</mustache.version>
         <handlebars.version>4.5.0</handlebars.version>
         <pebble.version>4.1.1</pebble.version>
         <commonmark.version>0.28.0</commonmark.version>
-        <jte.version>3.2.1</jte.version>
+        <jte.version>3.2.3</jte.version>
 
         <!-- ADDITIONAL PLUGIN VERSIONS -->
         <exec.plugin.version>3.6.3</exec.plugin.version>
@@ -106,7 +106,7 @@
         <annotations.version>26.1.0</annotations.version>
         <jetty.jakarta-api>5.0.2</jetty.jakarta-api>
         <jackson.version>2.21.2</jackson.version>
-        <jackson3.version>3.1.1</jackson3.version>
+        <jackson3.version>3.1.2</jackson3.version>
         <jackson.databind.version>2.21.2</jackson.databind.version>
         <brotli4j.version>1.22.0</brotli4j.version>
         <zstd.jni.version>1.5.7-7</zstd.jni.version>
@@ -127,8 +127,8 @@
         <mockito.version>5.23.0</mockito.version>
         <mockk.version>1.14.9</mockk.version>
         <unirest.version>3.14.5</unirest.version>
-        <selenium.chrome.driver.version>4.41.0</selenium.chrome.driver.version>
-        <webdrivermanager.version>6.3.3</webdrivermanager.version>
+        <selenium.chrome.driver.version>4.43.0</selenium.chrome.driver.version>
+        <webdrivermanager.version>6.3.4</webdrivermanager.version>
         <swagger.ui.version>4.10.3</swagger.ui.version> <!-- used for testing webjars -->
     </properties>
 


### PR DESCRIPTION
- jackson3 3.1.1 -> 3.1.2 (tools.jackson.* family)
- thymeleaf 3.1.3.RELEASE -> 3.1.4.RELEASE
- jte 3.2.1 -> 3.2.3
- webdrivermanager 6.3.3 -> 6.3.4 (test)
- selenium-chrome-driver 4.41.0 -> 4.43.0 (test)

Sync OptionalDependency.kt with pom properties so the "missing dep" snippets match what Javalin ships with:
- Jackson 2 family 2.20.1 -> 2.21.2
- Jackson 3 family 3.1.0 -> 3.1.2
- Brotli4j 1.20.0 -> 1.22.0
- Zstd-jni 1.5.7-6 -> 1.5.7-7

Pre-release / major-version bumps (Kotlin 2.4.0-Beta1, JUnit 6.1.0-M1, AssertJ 4, SLF4J 2.1.0-alpha1, Micrometer 1.17.0-RC1, swagger-ui 5, Unirest 4, jackson-annotations 3) deliberately skipped for a minor release.