### PR TITLE
[build] Bump Maven Wrapper to 3.9.15

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar


### PR DESCRIPTION
## Summary
Bumps `.mvn/wrapper/maven-wrapper.properties` to **Maven 3.9.15** (from 3.8.6) and the wrapper jar to **3.3.4** (from 3.1.1).

## Why
Some recent build plugins now require Maven `[3.9.0,)`. Notably, dependabot PR #2589 attempted to bump `git-commit-id-maven-plugin` 9.1.0 → 10.0.0, and CI failed across every matrix cell with:

```
The plugin io.github.git-commit-id:git-commit-id-maven-plugin:10.0.0
requires Maven version [3.9.0,)
```

Bumping the wrapper unblocks #2589 (and any future plugin majors that move the floor to 3.9+).

## Test plan
- [x] `./mvnw -v` reports `Apache Maven 3.9.15`
- [ ] CI green on this PR
- [ ] After merge, rebase #2589 and confirm its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)