### PR TITLE
[deps] Bump grouped dependencies (excluding Jetty)

### DIFF
--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -50,24 +50,24 @@ enum class CoreDependency(
 ) : OptionalDependency {
 
     // JSON (Jackson) handling
-    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.21.2"),
-    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.21.2"),
-    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.21.2"),
-    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.21.2"),
+    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.22.0"),
+    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.21.4"),
+    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.21.4"),
+    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.21.4"),
     JACKSON_KTORM("Jackson Ktorm", "org.ktorm.jackson.KtormModule", "org.ktorm", "ktorm-jackson", "3.6.0"),
 
     // JSON (Jackson 3) handling
-    JACKSON3("Jackson3", "tools.jackson.databind.json.JsonMapper", "tools.jackson.core", "jackson-databind", "3.1.3"),
-    JACKSON3_KT("Jackson3Kt", "tools.jackson.module.kotlin.KotlinModule", "tools.jackson.module", "jackson-module-kotlin", "3.1.3"),
-    JACKSON3_ECLIPSE_COLLECTIONS("Jackson3EclipseCollections", "tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "tools.jackson.datatype", "jackson-datatype-eclipse-collections", "3.1.3"),
+    JACKSON3("Jackson3", "tools.jackson.databind.json.JsonMapper", "tools.jackson.core", "jackson-databind", "3.1.4"),
+    JACKSON3_KT("Jackson3Kt", "tools.jackson.module.kotlin.KotlinModule", "tools.jackson.module", "jackson-module-kotlin", "3.1.4"),
+    JACKSON3_ECLIPSE_COLLECTIONS("Jackson3EclipseCollections", "tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "tools.jackson.datatype", "jackson-datatype-eclipse-collections", "3.1.4"),
 
     // JSON (Gson)
-    GSON("Gson", "com.google.gson.Gson", "com.google.code.gson", "gson", "2.13.2"),
+    GSON("Gson", "com.google.gson.Gson", "com.google.code.gson", "gson", "2.14.0"),
 
     // Logging
-    SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "2.0.17"),
+    SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "2.0.18"),
 
     // Compression
-    BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.22.0"),
-    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-7"),
+    BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.23.0"),
+    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-9"),
 }

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,10 @@
         <javadoc.plugin.version>3.6.0</javadoc.plugin.version>
         <gpg.plugin.version>3.2.8</gpg.plugin.version>
         <jar.plugin.version>3.5.0</jar.plugin.version>
-        <surefire.plugin.version>3.5.5</surefire.plugin.version>
+        <surefire.plugin.version>3.5.6</surefire.plugin.version>
         <shade.plugin.version>3.6.2</shade.plugin.version>
         <build-helper.plugin.version>3.6.1</build-helper.plugin.version>
-        <enforcer.plugin.version>3.6.2</enforcer.plugin.version>
+        <enforcer.plugin.version>3.6.3</enforcer.plugin.version>
         <clean.plugin.version>3.5.0</clean.plugin.version>
         <install.plugin.version>3.1.4</install.plugin.version>
         <resources.plugin.version>3.5.0</resources.plugin.version>
@@ -92,7 +92,7 @@
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
         <mustache.version>0.9.14</mustache.version>
         <handlebars.version>4.5.1</handlebars.version>
-        <pebble.version>4.1.1</pebble.version>
+        <pebble.version>4.1.2</pebble.version>
         <commonmark.version>0.28.0</commonmark.version>
         <jte.version>3.2.3</jte.version>
 
@@ -105,13 +105,13 @@
         <jetty.version>12.1.8</jetty.version>
         <annotations.version>26.1.0</annotations.version>
         <jetty.jakarta-api>5.0.2</jetty.jakarta-api>
-        <jackson.version>2.21.3</jackson.version>
-        <jackson3.version>3.1.3</jackson3.version>
-        <jackson.databind.version>2.21.3</jackson.databind.version>
+        <jackson.version>2.21.4</jackson.version>
+        <jackson3.version>3.1.4</jackson3.version>
+        <jackson.databind.version>2.22.0</jackson.databind.version>
         <brotli4j.version>1.23.0</brotli4j.version>
-        <zstd.jni.version>1.5.7-8</zstd.jni.version>
-        <logback.version>1.5.32</logback.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <zstd.jni.version>1.5.7-9</zstd.jni.version>
+        <logback.version>1.5.34</logback.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <gson.version>2.14.0</gson.version>
         <okhttp.version>5.3.2</okhttp.version> <!-- Also used for testing in SSL plugin -->
 
@@ -122,10 +122,10 @@
         <assertj.version>3.27.7</assertj.version>
         <moshi.version>1.15.2</moshi.version>
         <java.websocket.version>1.6.0</java.websocket.version>
-        <junit.version>6.0.3</junit.version>
+        <junit.version>6.1.0</junit.version>
         <jmh.version>1.37</jmh.version>
         <mockito.version>5.23.0</mockito.version>
-        <mockk.version>1.14.9</mockk.version>
+        <mockk.version>1.14.11</mockk.version>
         <unirest.version>3.14.5</unirest.version>
         <selenium.chrome.driver.version>4.44.0</selenium.chrome.driver.version>
         <webdrivermanager.version>6.3.4</webdrivermanager.version>


### PR DESCRIPTION
Alternative to #2603 that applies all of the grouped Dependabot bumps **except** the Jetty update — Jetty stays pinned at `12.1.8` (the most recent commit on master reverted Jetty to a working version).

## Bumps applied (`pom.xml`)

| Property | From → To |
|---|---|
| surefire.plugin.version | 3.5.5 → 3.5.6 |
| enforcer.plugin.version | 3.6.2 → 3.6.3 |
| pebble.version | 4.1.1 → 4.1.2 |
| jackson.version | 2.21.3 → 2.21.4 |
| jackson3.version | 3.1.3 → 3.1.4 |
| jackson.databind.version | 2.21.3 → 2.22.0 |
| zstd.jni.version | 1.5.7-8 → 1.5.7-9 |
| logback.version | 1.5.32 → 1.5.34 |
| slf4j.version | 2.0.17 → 2.0.18 |
| junit.version | 6.0.3 → 6.1.0 |
| mockk.version | 1.14.9 → 1.14.11 |

## Skipped
- `jetty.version` stays at **12.1.8** (#2603 bumps it to 12.1.9).

Also syncs the matching versions in `OptionalDependency.kt` (Jackson, Jackson3, slf4j, zstd-jni, gson, brotli4j).

🤖 Generated with [Claude Code](https://claude.com/claude-code)