### PR TITLE
[http] Return 501 for unroutable request method tokens

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -97,8 +97,16 @@ interface Context {
     /** Gets the request content type, or null. */
     fun contentType(): String? = req().contentType
 
-    /** Gets the request method. */
-    fun method(): HandlerType = HandlerType.findOrCreate(header(Header.X_HTTP_METHOD_OVERRIDE) ?: req().method)
+    /**
+     * Gets the request method.
+     * Throws [NotImplementedResponse] (501, as per RFC 9110 section 9.1) if the
+     * method token cannot be represented as a [HandlerType] (e.g. "M-SEARCH").
+     */
+    fun method(): HandlerType = try {
+        HandlerType.findOrCreate(header(Header.X_HTTP_METHOD_OVERRIDE) ?: req().method)
+    } catch (ignored: IllegalArgumentException) {
+        throw NotImplementedResponse("Unrecognized HTTP method")
+    }
 
     /** Gets the request path. */
     fun path(): String = req().requestURI

--- a/javalin/src/main/java/io/javalin/router/exception/ExceptionMapper.kt
+++ b/javalin/src/main/java/io/javalin/router/exception/ExceptionMapper.kt
@@ -61,6 +61,7 @@ class ExceptionMapper(private val routerConfig: RouterConfig, private val jettyC
         res.status = INTERNAL_SERVER_ERROR.code
         when {
             throwable is Error -> routerConfig.javaLangErrorHandler.handle(res, throwable)
+            throwable is HttpResponseException -> logDebugAndSetError(throwable, res, HttpStatus.forStatus(throwable.status))
             isClientAbortException(throwable) -> logDebugAndSetError(throwable, res, HttpStatus.forStatus(jettyConfig.clientAbortStatus))
             isJettyTimeoutException(throwable) -> logDebugAndSetError(throwable, res, HttpStatus.forStatus(jettyConfig.timeoutStatus))
             else -> JavalinLogger.error("Exception occurred while servicing http-request", throwable)

--- a/javalin/src/test/java/io/javalin/http/TestCustomHttpMethods.kt
+++ b/javalin/src/test/java/io/javalin/http/TestCustomHttpMethods.kt
@@ -114,4 +114,30 @@ class TestCustomHttpMethods {
             HandlerType.PATCH, HandlerType.HEAD, HandlerType.OPTIONS, HandlerType.TRACE
         )
     }
+
+    // The two tests below use the JDK HttpClient rather than Unirest, since
+    // HttpMethod.valueOf would permanently add the token to HttpMethod.all(),
+    // which TestRouting's mapped/unmapped verb tests iterate over.
+
+    @Test
+    fun `requests with unroutable method tokens get 501 instead of 500`() = TestUtil.test { _, http ->
+        // M-SEARCH is a valid HTTP token, but contains a character outside A-Z so it
+        // cannot be represented as a HandlerType - should be 501 (RFC 9110 section 9.1), not a 500
+        assertThat(rawStatus(http.origin, "M-SEARCH")).isEqualTo(501)
+    }
+
+    @Test
+    fun `well-formed unknown methods still return 404`() = TestUtil.test { _, http ->
+        assertThat(rawStatus(http.origin, "FOOBAR")).isEqualTo(404)
+    }
+
+    private fun rawStatus(origin: String, method: String): Int {
+        val request = java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create("$origin/"))
+            .method(method, java.net.http.HttpRequest.BodyPublishers.noBody())
+            .build()
+        return java.net.http.HttpClient.newHttpClient()
+            .send(request, java.net.http.HttpResponse.BodyHandlers.discarding())
+            .statusCode()
+    }
 }


### PR DESCRIPTION
Fixes #2607

## Problem

Request-time method resolution (`Context.method()`) goes through `HandlerType.findOrCreate`, whose strict A-Z validation was designed for registration-time input (custom methods, #2331). A request with a syntactically valid but unrepresentable method token — `M-SEARCH` (sent constantly by SSDP scanners to internet-facing apps), `VERSION-CONTROL`, lowercase tokens — throws `IllegalArgumentException` during task creation, escapes to `handleUnexpectedThrowable`, and produces a **500** plus an ERROR-level stack trace per request. Javalin 6 returned a quiet 404 for the same input.

## Changes

1. **`Context.method()`** catches the `IllegalArgumentException` and throws `NotImplementedResponse` instead — 501 is the RFC 9110 §9.1 response for an unrecognized request method. This also covers an unroutable `X-HTTP-Method-Override` header value.
2. **`ExceptionMapper.handleUnexpectedThrowable`** now respects `HttpResponseException`: it sets the exception's own status and logs at DEBUG, instead of mislabelling it an unexpected 500 with an ERROR log. (Without this, the `NotImplementedResponse` thrown during task creation would still have surfaced as a 500; it also fixes the general case of any `HttpResponseException` reaching the outer servlet catch.)

## Behaviour

| Request method | Before | After |
|---|---|---|
| `GET` etc. | normal | unchanged |
| `FOOBAR` (well-formed, unknown) | 404 | 404 (unchanged) |
| `M-SEARCH`, `propfind`, `VERSION-CONTROL` | **500 + ERROR stack trace** | **501**, DEBUG log |

## Testing

Two tests added to `TestCustomHttpMethods` (501 for `M-SEARCH`, 404 still for `FOOBAR`); full `javalin` module test suite passes.
