### PR TITLE
[http] Return 404 for unrecognized request methods instead of 500

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -97,8 +97,8 @@ interface Context {
     /** Gets the request content type, or null. */
     fun contentType(): String? = req().contentType
 
-    /** Gets the request method. */
-    fun method(): HandlerType = HandlerType.findOrCreate(header(Header.X_HTTP_METHOD_OVERRIDE) ?: req().method)
+    /** Gets the request method. Unrecognized methods resolve to a non-matching [HandlerType] (404) rather than throwing. */
+    fun method(): HandlerType = HandlerType.findOrDefault(header(Header.X_HTTP_METHOD_OVERRIDE) ?: req().method)
 
     /** Gets the request path. */
     fun path(): String = req().requestURI

--- a/javalin/src/main/java/io/javalin/http/HandlerType.java
+++ b/javalin/src/main/java/io/javalin/http/HandlerType.java
@@ -79,6 +79,12 @@ public record HandlerType(String name, boolean isHttpMethod) {
         return METHOD_MAP.computeIfAbsent(name, key -> new HandlerType(key, true));
     }
 
+    /** Lenient lookup for untrusted request methods: known constant, else a transient miss (404). Never throws or mutates METHOD_MAP. */
+    public static HandlerType findOrDefault(String name) {
+        HandlerType existing = METHOD_MAP.get(name);
+        return existing != null ? existing : new HandlerType(name, true);
+    }
+
     /**
      * Returns all standard HandlerType values (equivalent to enum values()).
      * Does not include dynamically created custom methods.

--- a/javalin/src/test/java/io/javalin/http/TestCustomHttpMethods.kt
+++ b/javalin/src/test/java/io/javalin/http/TestCustomHttpMethods.kt
@@ -2,14 +2,28 @@ package io.javalin.http
 
 import io.javalin.http.HandlerType.GET
 import io.javalin.security.RouteRole
+import io.javalin.testing.HttpUtil
 import io.javalin.testing.TestUtil
 
 import kong.unirest.HttpMethod
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
 
 class TestCustomHttpMethods {
+
+    // JDK client, not Unirest: HttpMethod.valueOf(...) leaks tokens into Unirest's global method list.
+    private fun rawRequestStatus(http: HttpUtil, method: String, path: String): Int =
+        HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder(URI.create(http.origin + path))
+                .method(method, HttpRequest.BodyPublishers.noBody())
+                .build(),
+            BodyHandlers.ofString()
+        ).statusCode()
 
     val PROPFIND = HandlerType.findOrCreate("PROPFIND")
 
@@ -104,6 +118,24 @@ class TestCustomHttpMethods {
 
         val response = http.call(HttpMethod.valueOf("MKCOL"), "/webdav/collections")
         assertThat(response.body).isEqualTo("Collection created with roles: [ADMIN, USER]")
+    }
+
+    @Test
+    fun `unrecognized request methods return 404 instead of 500`() = TestUtil.test { app, http ->
+        app.unsafe.routes.get("/") { ctx -> ctx.result("GET works") }
+        // hyphenated and lowercase tokens must miss the router quietly, not throw (issue #2607)
+        listOf("M-SEARCH", "VERSION-CONTROL", "get", "propfind", "FOOBAR").forEach { method ->
+            assertThat(rawRequestStatus(http, method, "/")).`as`("method '$method'").isEqualTo(404)
+        }
+    }
+
+    @Test
+    fun `findOrDefault is lenient and does not pollute METHOD_MAP`() {
+        assertThat(HandlerType.findOrDefault("GET")).isSameAs(GET)
+        val unknown = HandlerType.findOrDefault("m-search")
+        assertThat(unknown.name()).isEqualTo("m-search")
+        // not cached, unlike findOrCreate, so untrusted tokens can't grow METHOD_MAP
+        assertThat(HandlerType.findOrDefault("m-search")).isNotSameAs(unknown)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2607. Alternative approach to #2608.

### Problem
Unrecognized HTTP request methods — hyphenated (`M-SEARCH`, `VERSION-CONTROL`) and lowercase (`get`, `propfind`) — caused an `IllegalArgumentException` to escape all the way to the last-resort handler, producing a **500 + ERROR stack trace** instead of a clean response.

### Root cause
`HandlerType.findOrCreate` serves two trust levels:
- **Registration-time** (`app.get(...)`, custom methods) — strict `A-Z` validation is correct here; it catches developer typos.
- **Request-time** via `Context.method()` — this is **untrusted, attacker-controlled** input, so it must never throw or log on a syntactically odd token.

### Fix
Add a lenient `HandlerType.findOrDefault` for the request-time path and point `Context.method()` at it. It returns the shared constant for known methods and a transient `HandlerType` for anything else, so an unrecognized method simply **misses the router → 404**, identical to any other unregistered method (e.g. `FOOBAR` today). It never throws and never caches request tokens into `METHOD_MAP`.

`findOrCreate` is left untouched, so registration-time typo protection is intact.

### Why 404 and not 501 (vs #2608)
An unknown verb is just an unknown verb — there's no reason to special-case it. Routing it to the existing not-found path means no new branch, no change to the exception mapper, and parity with how unmatched methods already behave. It also fixes **both** halves of the issue (hyphens *and* lowercase); relaxing validation to "allow dashes" would leave lowercase tokens still 500ing.

### Tests
Added to `TestCustomHttpMethods`:
- `M-SEARCH`, `VERSION-CONTROL`, `get`, `propfind`, `FOOBAR` all → 404 (raw JDK `HttpClient`, since Unirest's `HttpMethod.valueOf` leaks tokens into a global list).
- `findOrDefault` returns the shared constant for known methods and a non-cached transient instance for unknown ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)