### PR TITLE
[handlebars] Preserve render API with upgraded loader

### DIFF
--- a/javalin-utils/javalin-rendering/javalin-rendering-handlebars/src/main/java/io/javalin/rendering/template/JavalinHandlebars.kt
+++ b/javalin-utils/javalin-rendering/javalin-rendering-handlebars/src/main/java/io/javalin/rendering/template/JavalinHandlebars.kt
@@ -16,12 +16,18 @@ class JavalinHandlebars @JvmOverloads constructor(
 ) : FileRenderer {
 
     override fun render(filePath: String, model: Map<String, Any?>, context: Context): String {
-        val template = handlebars.compile(filePath)
+        val template = handlebars.compile(normalizeTemplatePath(filePath))
         return template.apply(model)
     }
 
     companion object {
-        fun defaultHandlebars(): Handlebars = Handlebars(ClassPathTemplateLoader("/", ""))
+        private const val TEMPLATE_PREFIX = "/templates/handlebars/"
+        private const val TEMPLATE_SUFFIX = ".hbs"
+
+        fun defaultHandlebars(): Handlebars = Handlebars(ClassPathTemplateLoader(TEMPLATE_PREFIX, TEMPLATE_SUFFIX))
+
+        private fun normalizeTemplatePath(filePath: String): String =
+            filePath.removePrefix(TEMPLATE_PREFIX).removeSuffix(TEMPLATE_SUFFIX)
     }
 
 }

--- a/javalin-utils/javalin-rendering/javalin-rendering-handlebars/src/main/java/io/javalin/rendering/template/JavalinHandlebars.kt
+++ b/javalin-utils/javalin-rendering/javalin-rendering-handlebars/src/main/java/io/javalin/rendering/template/JavalinHandlebars.kt
@@ -16,7 +16,7 @@ class JavalinHandlebars @JvmOverloads constructor(
 ) : FileRenderer {
 
     override fun render(filePath: String, model: Map<String, Any?>, context: Context): String {
-        val template = handlebars.compile(normalizeTemplatePath(filePath))
+        val template = handlebars.compile(filePath)
         return template.apply(model)
     }
 
@@ -24,10 +24,14 @@ class JavalinHandlebars @JvmOverloads constructor(
         private const val TEMPLATE_PREFIX = "/templates/handlebars/"
         private const val TEMPLATE_SUFFIX = ".hbs"
 
-        fun defaultHandlebars(): Handlebars = Handlebars(ClassPathTemplateLoader(TEMPLATE_PREFIX, TEMPLATE_SUFFIX))
+        fun defaultHandlebars(): Handlebars = Handlebars(JavalinTemplateLoader())
+    }
 
-        private fun normalizeTemplatePath(filePath: String): String =
-            filePath.removePrefix(TEMPLATE_PREFIX).removeSuffix(TEMPLATE_SUFFIX)
+    private class JavalinTemplateLoader : ClassPathTemplateLoader(TEMPLATE_PREFIX, TEMPLATE_SUFFIX) {
+        override fun normalize(location: String): String {
+            val normalizedLocation = location.removePrefix(TEMPLATE_PREFIX).removeSuffix(TEMPLATE_SUFFIX)
+            return super.normalize(normalizedLocation)
+        }
     }
 
 }

--- a/javalin-utils/javalin-rendering/javalin-rendering-handlebars/src/test/java/io/javalin/TestHandlebars.kt
+++ b/javalin-utils/javalin-rendering/javalin-rendering-handlebars/src/test/java/io/javalin/TestHandlebars.kt
@@ -18,7 +18,9 @@ class TestHandlebars {
     fun `handlebars templates work`() = JavalinTest.test(Javalin.create { config ->
         config.fileRenderer(JavalinHandlebars())
         config.routes.get("/hello") { it.render("/templates/handlebars/test.hbs", mapOf("message" to "Hello Handlebars!")) }
+        config.routes.get("/hello-short") { it.render("test", mapOf("message" to "Hello Handlebars!")) }
     }) { app, http ->
         assertThat(http.get("/hello").body?.string()?.trim()).isEqualTo("<h1>Hello Handlebars!</h1>")
+        assertThat(http.get("/hello-short").body?.string()?.trim()).isEqualTo("<h1>Hello Handlebars!</h1>")
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <freemarker.version>2.3.34</freemarker.version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
         <mustache.version>0.9.14</mustache.version>
-        <handlebars.version>4.5.1</handlebars.version>
+        <handlebars.version>4.5.3</handlebars.version>
         <pebble.version>4.1.2</pebble.version>
         <commonmark.version>0.29.0</commonmark.version>
         <jte.version>3.2.3</jte.version>


### PR DESCRIPTION
Fix Handlebars compatibility with the upgraded dependency by switching to a concrete classpath loader and normalizing the existing template path internally.

This keeps the current  render("/templates/handlebars/test.hbs", ...)  API working while satisfying the newer Handlebars loader restrictions.