### PR TITLE
[deps] Bump stable deps and sync OptionalDependency.kt

### DIFF
--- a/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/util/OptionalDependency.kt
@@ -50,16 +50,16 @@ enum class CoreDependency(
 ) : OptionalDependency {
 
     // JSON (Jackson) handling
-    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.22.0"),
-    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.21.4"),
-    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.21.4"),
-    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.21.4"),
+    JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.22.1"),
+    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.22.1"),
+    JACKSON_JSR_310("JacksonJsr310", "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", "2.22.1"),
+    JACKSON_ECLIPSE_COLLECTIONS("JacksonEclipseCollections", "com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "com.fasterxml.jackson.datatype", "jackson-datatype-eclipse-collections", "2.22.1"),
     JACKSON_KTORM("Jackson Ktorm", "org.ktorm.jackson.KtormModule", "org.ktorm", "ktorm-jackson", "3.6.0"),
 
     // JSON (Jackson 3) handling
-    JACKSON3("Jackson3", "tools.jackson.databind.json.JsonMapper", "tools.jackson.core", "jackson-databind", "3.1.4"),
-    JACKSON3_KT("Jackson3Kt", "tools.jackson.module.kotlin.KotlinModule", "tools.jackson.module", "jackson-module-kotlin", "3.1.4"),
-    JACKSON3_ECLIPSE_COLLECTIONS("Jackson3EclipseCollections", "tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "tools.jackson.datatype", "jackson-datatype-eclipse-collections", "3.1.4"),
+    JACKSON3("Jackson3", "tools.jackson.databind.json.JsonMapper", "tools.jackson.core", "jackson-databind", "3.2.1"),
+    JACKSON3_KT("Jackson3Kt", "tools.jackson.module.kotlin.KotlinModule", "tools.jackson.module", "jackson-module-kotlin", "3.2.1"),
+    JACKSON3_ECLIPSE_COLLECTIONS("Jackson3EclipseCollections", "tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule", "tools.jackson.datatype", "jackson-datatype-eclipse-collections", "3.2.1"),
 
     // JSON (Gson)
     GSON("Gson", "com.google.gson.Gson", "com.google.code.gson", "gson", "2.14.0"),
@@ -69,5 +69,5 @@ enum class CoreDependency(
 
     // Compression
     BROTLI4J("Brotli4j", "com.aayushatharva.brotli4j.Brotli4jLoader", "com.aayushatharva.brotli4j", "brotli4j", "1.23.0"),
-    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-9"),
+    ZSTD_JNI("Zstd-jni", "com.github.luben.zstd.Zstd", "com.github.luben", "zstd-jni", "1.5.7-13"),
 }

--- a/pom.xml
+++ b/pom.xml
@@ -102,15 +102,15 @@
         <git-commit-id.plugin.version>10.0.0</git-commit-id.plugin.version>
 
         <!-- DEPENDENCIES -->
-        <jetty.version>12.1.11</jetty.version>
+        <jetty.version>12.1.12</jetty.version>
         <annotations.version>26.1.0</annotations.version>
         <jetty.jakarta-api>5.0.2</jetty.jakarta-api>
         <jackson.version>2.22.1</jackson.version>
         <jackson3.version>3.2.1</jackson3.version>
         <jackson.databind.version>2.22.1</jackson.databind.version>
         <brotli4j.version>1.23.0</brotli4j.version>
-        <zstd.jni.version>1.5.7-12</zstd.jni.version>
-        <logback.version>1.6.1</logback.version>
+        <zstd.jni.version>1.5.7-13</zstd.jni.version>
+        <logback.version>1.6.2</logback.version>
         <slf4j.version>2.0.18</slf4j.version>
         <gson.version>2.14.0</gson.version>
         <okhttp.version>5.4.0</okhttp.version> <!-- Also used for testing in SSL plugin -->
@@ -122,7 +122,7 @@
         <assertj.version>3.27.7</assertj.version>
         <moshi.version>1.15.2</moshi.version>
         <java.websocket.version>1.6.0</java.websocket.version>
-        <junit.version>6.1.2</junit.version>
+        <junit.version>6.1.3</junit.version>
         <jmh.version>1.37</jmh.version>
         <mockito.version>5.23.0</mockito.version>
         <mockk.version>1.14.11</mockk.version>


### PR DESCRIPTION
Bump jetty (12.1.11 -> 12.1.12), logback (1.6.1 -> 1.6.2), junit (6.1.2 -> 6.1.3) and zstd-jni (1.5.7-12 -> 1.5.7-13).

Sync OptionalDependency.kt to the Jackson (2.22.1 / 3.2.1) and zstd-jni (1.5.7-13) versions already declared in the pom.