### PR TITLE
[github] Clean up stale docs and CI/dependabot config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,6 @@ Always reference these instructions first and fallback to search or bash command
 ## Working Effectively
 
 ### Bootstrap and Build
-- **REQUIREMENT**: Always run `./mvnw package` before `./mvnw test` to avoid OSGI dependency errors
 - Build without tests: `./mvnw package -DskipTests --batch-mode` -- takes 60 seconds. NEVER CANCEL. Set timeout to 120+ seconds.
 - Build with tests: `./mvnw package --batch-mode` -- takes 3+ minutes. NEVER CANCEL. Set timeout to 300+ seconds.
 - **CRITICAL**: Browser tests fail in CI environment due to missing WebDriver - this is expected and normal
@@ -21,11 +20,11 @@ Always reference these instructions first and fallback to search or bash command
 - Non-browser tests pass reliably and provide good validation coverage
 
 ### Project Structure
-- **Root**: Multi-module Maven project with 11 modules
+- **Root**: Multi-module Maven project
 - **Main module**: `javalin/` - Core framework implementation
 - **Key modules**:
   - `javalin-testtools/` - Testing utilities
-  - `javalin-rendering/` - Template engine plugins
+  - `javalin-utils/javalin-rendering/` - Template engine plugins
   - `javalin-ssl/` - SSL/TLS helpers
   - `javalin-bundle/` - All-in-one bundle
 
@@ -72,7 +71,7 @@ javalin/
 │   │   └── websocket/      # WebSocket support
 │   └── src/test/java/      # Core tests
 ├── javalin-testtools/      # Testing utilities
-├── javalin-rendering/      # Template engines
+├── javalin-utils/          # Shared utils (incl. javalin-rendering template engines)
 ├── javalin-ssl/           # SSL helpers
 └── .github/workflows/     # CI configuration
 ```
@@ -134,9 +133,7 @@ Follow the repository's strict commit message format:
 - **NEVER CANCEL** long-running builds - they will complete successfully
 
 ### Known Issues and Workarounds
-- **OSGI Error**: Always run `package` before `test` 
 - **Browser Test Failures**: Expected in CI - missing WebDriver dependencies
-- **Profile Warning**: CI uses `-P dev` but profile doesn't exist (safely ignored)
 - **Multiple SLF4J Bindings**: Warning is normal (both logback and slf4j-simple present)
 
 ## Quick Start Validation
@@ -172,7 +169,7 @@ Javalin uses the consumer pattern extensively for configuration. This allows for
 var app = Javalin.create(config -> {
     config.http.asyncTimeout = 10_000L;
     config.staticFiles.add("/public");
-    config.useVirtualThreads = true;
+    config.concurrency.useVirtualThreads = true;
 });
 
 // AVOID: Don't try to configure after creation
@@ -477,7 +474,7 @@ Javalin.create(config -> {
     }));
     
     // SSL Plugin
-    config.registerPlugin(new SSLPlugin(ssl -> {
+    config.registerPlugin(new SslPlugin(ssl -> {
         ssl.pemFromPath("/path/to/cert.pem", "/path/to/key.pem");
     }));
 });
@@ -658,7 +655,7 @@ Enable virtual threads for better async performance:
 
 ```java
 Javalin.create(config -> {
-    config.useVirtualThreads = true;
+    config.concurrency.useVirtualThreads = true;
 }).start(7070);
 ```
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,15 @@ updates:
     labels:
       - "dependencies"
     target-branch: "master"
+    # Split runtime and test/build dependencies into separate grouped PRs, so a
+    # broken production bump can't block test-dependency updates (and vice versa).
     groups:
-      dependencies:
+      production-dependencies:
+        dependency-type: "production"
+        patterns:
+        - "*"
+      development-dependencies:
+        dependency-type: "development"
         patterns:
         - "*"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,12 @@ name: Test all JDKs on all OSes
 
 on: [push, pull_request]
 
+# Cancel superseded runs; the shared group also dedupes the push + pull_request
+# events that both fire for a branch with an open PR (head_ref matches ref).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -56,7 +62,7 @@ jobs:
       - name: Make Maven Wrapper executable
         run: chmod +x ./mvnw
       - name: Build with Maven
-        run: ./mvnw -P dev -DRunningOnCi=true clean verify --file pom.xml --batch-mode
+        run: ./mvnw -DRunningOnCi=true clean verify --file pom.xml --batch-mode
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ jte-classes/
 
 # ignore flatten-maven-plugin output
 .flattened-pom.xml
+
+# ignore macOS junk
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,17 +10,11 @@ cd javalin
 ./mvnw test      #(or `mvn test` if you have maven installed)
 ```
 
-If you run `test` before `package`, you will get an error in the OSGI artifact:
-
-```
-[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:2.8:unpack-dependencies (unpack-everything) on project javalin-osgi: Artifact has not been packaged yet. When used on reactor artifact, unpack should be executed after packaging: see MDEP-98. -> [Help 1]
-```
-
 ## Running maven commands
 We have Maven wrapper included in the project, which means that
 you can run Maven commands without having Maven installed on your system.
 Simply replace any `mvn goal` command with `./mvnw goal`.
 
 ## Deploy
-The `sonatype-oss-release` profile is used for releasing the project artifacts to Sonatype OSSRH (OSS Repository Hosting). 
+The `sonatype-oss-release` profile is used for releasing the project artifacts to the [Maven Central Portal](https://central.sonatype.com). 
 This is only used by tipsy to release the project.


### PR DESCRIPTION
- main.yml: drop non-existent `-P dev` profile from coverage job and add a concurrency group that cancels superseded runs and dedupes the push + pull_request double-runs on PR branches
- dependabot.yml: split Maven updates into production/development groups so a broken runtime bump can't block test-dependency updates
- README.md: remove obsolete OSGI note (module no longer exists) and point the release section at the Maven Central Portal instead of OSSRH
- copilot-instructions.md: drop stale OSGI/-P dev notes, fix module layout, and correct APIs (config.concurrency.useVirtualThreads, SslPlugin)
- gitignore: ignore .DS_Store