### PR TITLE
[http] Add an observable request pipeline (TaskObserver)

### DIFF
--- a/javalin/src/main/java/io/javalin/config/JavalinState.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinState.kt
@@ -16,6 +16,7 @@ import io.javalin.http.servlet.JavalinServletContext
 import io.javalin.http.servlet.MaxRequestSize.MaxRequestSizeKey
 import io.javalin.http.servlet.ServletEntry
 import io.javalin.http.servlet.TaskInitializer
+import io.javalin.http.servlet.TaskObserver
 import io.javalin.http.staticfiles.ResourceHandler
 import io.javalin.http.util.AsyncExecutor.Companion.AsyncExecutorKey
 import io.javalin.jetty.JettyUtil.createJettyServletWithWebsocketsIfAvailable
@@ -75,6 +76,7 @@ class JavalinState {
     @JvmField var appDataManager = AppDataManager()
     @JvmField var pluginManager = PluginManager(this)
     @JvmField var httpRequestLoggers: MutableList<RequestLogger> = mutableListOf()
+    @JvmField var servletTaskObservers: MutableList<TaskObserver> = mutableListOf()
     @JvmField var wsRequestLogger: WsConfig? = null
     @JvmField var resourceHandler: ResourceHandler? = null
     @JvmField var singlePageHandler = SinglePageHandler()

--- a/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/DefaultTasks.kt
@@ -15,7 +15,7 @@ object DefaultTasks {
 
     val BEFORE = TaskInitializer<JavalinServletContext> { submitTask, servlet, ctx, requestUri ->
         servlet.router.findHttpHandlerEntries(HandlerType.BEFORE, requestUri).forEach { entry ->
-            submitTask(LAST, Task(skipOnExceptionAndRedirect = true) { entry.handle(ctx, requestUri) })
+            submitTask(LAST, Task(label = labelName(entry), skipOnExceptionAndRedirect = true) { entry.handle(ctx, requestUri) })
         }
     }
 
@@ -35,7 +35,7 @@ object DefaultTasks {
             if (willMatch) {
                 val httpHandler = httpHandlerOrNull
                 httpHandler?.let { ctx.endpoints().matchedHttpEndpointInternal = it.endpoint }
-                submitTask(LAST, Task(skipOnExceptionAndRedirect = true) {
+                submitTask(LAST, Task(label = labelName(entry), skipOnExceptionAndRedirect = true) {
                     if (httpHandler != null && !entry.endpoint.hasPathParams() && httpHandler.endpoint.hasPathParams()) {
                         entry.handleWithPathParams(ctx, httpHandler.extractPathParams(requestUri))
                     } else {
@@ -51,7 +51,7 @@ object DefaultTasks {
         if (entry != null) {
             submitTask(
                 LAST,
-                Task {
+                Task(label = labelName(entry)) {
                     val roles = entry.endpoint.metadata(Roles::class.java)?.roles ?: emptySet()
                     ctx.setRouteRoles(roles)
                     entry.handle(ctx, requestUri)
@@ -59,7 +59,7 @@ object DefaultTasks {
             )
             return@TaskInitializer
         }
-        submitTask(LAST, Task {
+        submitTask(LAST, Task(label = NO_MATCH_LABEL) {
             if (ctx.method() == HEAD && servlet.router.hasHttpHandlerEntry(GET, requestUri)) { // return 200, there is a get handler
                 return@Task
             }
@@ -81,18 +81,18 @@ object DefaultTasks {
         val didMatch by javalinLazy { ctx.cachedWillMatch { servlet.willMatch(ctx, requestUri) } }
         servlet.router.findHttpHandlerEntries(HandlerType.AFTER_MATCHED, requestUri).forEach { entry ->
             if (didMatch) {
-                submitTask(LAST, Task(skipOnExceptionAndRedirect = false) { entry.handle(ctx, requestUri) })
+                submitTask(LAST, Task(label = labelName(entry), skipOnExceptionAndRedirect = false) { entry.handle(ctx, requestUri) })
             }
         }
     }
 
     val ERROR = TaskInitializer<JavalinServletContext> { submitTask, servlet, ctx, _ ->
-        submitTask(LAST, Task(skipOnExceptionAndRedirect = false) { servlet.router.handleHttpError(ctx.statusCode(), ctx) })
+        submitTask(LAST, Task(label = ERROR_MAPPING_LABEL, skipOnExceptionAndRedirect = false) { servlet.router.handleHttpError(ctx.statusCode(), ctx) })
     }
 
     val AFTER = TaskInitializer<JavalinServletContext> { submitTask, servlet, ctx, requestUri ->
         servlet.router.findHttpHandlerEntries(HandlerType.AFTER, requestUri).forEach { entry ->
-            submitTask(LAST, Task(skipOnExceptionAndRedirect = false) { entry.handle(ctx, requestUri) })
+            submitTask(LAST, Task(label = labelName(entry), skipOnExceptionAndRedirect = false) { entry.handle(ctx, requestUri) })
         }
     }
 

--- a/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/JavalinServlet.kt
@@ -15,7 +15,9 @@ import io.javalin.http.servlet.SubmitOrder.LAST
 import io.javalin.http.util.AsyncUtil.isAsync
 import io.javalin.http.util.AsyncUtil.newAsyncListener
 import io.javalin.http.util.ETagGenerator
+import io.javalin.util.JavalinLogger
 import io.javalin.util.javalinLazy
+import kotlin.time.measureTimedValue
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -32,6 +34,7 @@ class JavalinServlet(val cfg: JavalinState) : HttpServlet() {
 
     val requestLifecycle = cfg.servletRequestLifecycle.toList()
     val router = cfg.internalRouter
+    private val taskObservers get() = cfg.servletTaskObservers
     private val servletContextConfig by javalinLazy { JavalinServletContextConfig.of(cfg) }
 
     override fun service(request: HttpServletRequest, response: HttpServletResponse) {
@@ -69,7 +72,17 @@ class JavalinServlet(val cfg: JavalinState) : HttpServlet() {
             if (exceptionOccurred && task.skipOnExceptionAndRedirect) {
                 continue
             }
-            handleTask(task.handler)
+            if (taskObservers.isEmpty()) {
+                handleTask(task.handler)
+            } else {
+                val (result, elapsed) = measureTimedValue { runCatching { task.handler.handle() } }
+                val thrown = result.exceptionOrNull()?.also { onTaskException(it) }
+                taskObservers.forEach { observer ->
+                    // a misbehaving observer must never break the request it is observing
+                    try { observer.onTaskCompleted(this, task, elapsed.inWholeNanoseconds, thrown) }
+                    catch (e: Exception) { JavalinLogger.warn("A TaskObserver threw and was ignored", e) }
+                }
+            }
         }
         when {
             userFutureSupplier != null -> handleUserFuture()
@@ -107,11 +120,16 @@ class JavalinServlet(val cfg: JavalinState) : HttpServlet() {
         try {
             handler.handle()
         } catch (throwable: Throwable) {
-            exceptionOccurred = true
-            userFutureSupplier = null
-            tasks.offerFirst(Task(skipOnExceptionAndRedirect = false) { router.handleHttpException(this, throwable) })
+            onTaskException(throwable)
             null
         }
+
+    /** A task threw: flip the exception flag and queue the exception-handling task to run next. */
+    private fun JavalinServletContext.onTaskException(throwable: Throwable) {
+        exceptionOccurred = true
+        userFutureSupplier = null
+        tasks.offerFirst(Task(label = exceptionLabel(throwable), skipOnExceptionAndRedirect = false) { router.handleHttpException(this, throwable) })
+    }
 
     private fun JavalinServletContext.writeResponseAndLog() {
         try {

--- a/javalin/src/main/java/io/javalin/http/servlet/Task.kt
+++ b/javalin/src/main/java/io/javalin/http/servlet/Task.kt
@@ -1,6 +1,8 @@
 package io.javalin.http.servlet
 
 import io.javalin.http.Context
+import io.javalin.http.HandlerType
+import io.javalin.router.ParsedEndpoint
 
 enum class SubmitOrder {
     FIRST,
@@ -12,6 +14,7 @@ fun interface TaskInitializer<CTX : Context> {
 }
 
 class Task(
+    val label: String = "task", // what this task does, e.g. "before /*" or "GET /users/{id}"
     val skipOnExceptionAndRedirect: Boolean = true, // skipped when exception occurs or redirect called from before/beforeMatched
     val handler: TaskHandler<Unit>
 )
@@ -19,3 +22,38 @@ class Task(
 fun interface TaskHandler<R> {
     fun handle(): R
 }
+
+/**
+ * Observes each task in the request pipeline as it completes. Registered via
+ * [io.javalin.config.JavalinState.servletTaskObservers] - register observers before the server starts.
+ *
+ * Observers are invoked on the request thread (and, for async requests, the future-completion thread), so an
+ * observer must be thread-safe: concurrent requests call it in parallel. [throwable] is non-null if the task
+ * threw. [durationNanos] is the task's synchronous execution time, not end-to-end request latency (an async
+ * handler returns as soon as it hands off its future). An exception thrown by an observer is caught and logged,
+ * so it never affects the request.
+ */
+fun interface TaskObserver {
+    fun onTaskCompleted(ctx: Context, task: Task, durationNanos: Long, throwable: Throwable?)
+}
+
+// Canonical [Task.label] values, shared by the producers (DefaultTasks/JavalinServlet) and any consumer
+// (e.g. the DevTools plugin maps handler labels back to source locations), so the two can't drift.
+internal const val NO_MATCH_LABEL = "no-match (static/404/405)"
+internal const val ERROR_MAPPING_LABEL = "error-mapping"
+internal const val EXCEPTION_LABEL_PREFIX = "exception:"
+
+/** The [Task.label] for a handler entry, e.g. a before-handler on `/`, or `GET /users/{id}`. */
+internal fun labelName(entry: ParsedEndpoint): String = labelName(entry.endpoint.method, entry.endpoint.path)
+
+/** Primitive form for callers that only have a method + path (e.g. the handlerAdded event's HandlerMetaInfo). */
+internal fun labelName(type: HandlerType, path: String): String = when (type) {
+    HandlerType.BEFORE -> "before $path"
+    HandlerType.BEFORE_MATCHED -> "beforeMatched $path"
+    HandlerType.AFTER_MATCHED -> "afterMatched $path"
+    HandlerType.AFTER -> "after $path"
+    else -> "${type.name} $path"
+}
+
+/** The [Task.label] for the task that handles a thrown exception, e.g. "exception:IllegalStateException". */
+internal fun exceptionLabel(throwable: Throwable): String = "$EXCEPTION_LABEL_PREFIX${throwable.javaClass.simpleName}"

--- a/javalin/src/test/java/io/javalin/TestTaskObserver.kt
+++ b/javalin/src/test/java/io/javalin/TestTaskObserver.kt
@@ -1,0 +1,64 @@
+package io.javalin
+
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TestTaskObserver {
+
+    @Test
+    fun `observers see the pipeline tasks in order, with timing`() = TestUtil.test { app, http ->
+        val seen = mutableListOf<String>()
+        val durations = mutableListOf<Long>()
+        app.unsafe.servletTaskObservers.add { _, task, durationNanos, _ ->
+            seen.add(task.label)
+            durations.add(durationNanos)
+        }
+        app.unsafe.routes.before("/*") {}
+        app.unsafe.routes.get("/hello") { it.result("hi") }
+        app.unsafe.routes.after("/*") {}
+
+        http.get("/hello")
+        assertThat(seen).containsSubsequence("before /*", "GET /hello", "after /*")
+        assertThat(durations).isNotEmpty.allMatch { it >= 0 }
+    }
+
+    @Test
+    fun `observers are told which task threw, and see the exception-handling task`() = TestUtil.test { app, http ->
+        var thrownLabel: String? = null
+        val labels = mutableListOf<String>()
+        app.unsafe.servletTaskObservers.add { _, task, _, throwable ->
+            labels.add(task.label)
+            if (throwable != null) thrownLabel = task.label
+        }
+        app.unsafe.routes.get("/boom") { throw IllegalStateException("nope") }
+
+        http.get("/boom")
+        assertThat(thrownLabel).isEqualTo("GET /boom")
+        assertThat(labels).contains("exception:IllegalStateException")
+    }
+
+    @Test
+    fun `all registered observers are notified`() = TestUtil.test { app, http ->
+        val a = mutableListOf<String>()
+        val b = mutableListOf<String>()
+        app.unsafe.servletTaskObservers.add { _, task, _, _ -> a.add(task.label) }
+        app.unsafe.servletTaskObservers.add { _, task, _, _ -> b.add(task.label) }
+        app.unsafe.routes.get("/hi") { it.result("hi") }
+
+        http.get("/hi")
+        assertThat(a).contains("GET /hi")
+        assertThat(b).contains("GET /hi")
+    }
+
+    @Test
+    fun `a throwing observer does not break the request`() = TestUtil.test { app, http ->
+        app.unsafe.servletTaskObservers.add { _, _, _, _ -> throw RuntimeException("observer bug") }
+        app.unsafe.routes.get("/ok") { it.result("still works") }
+
+        val res = http.get("/ok")
+        assertThat(res.status).isEqualTo(200)
+        assertThat(res.body).isEqualTo("still works")
+    }
+
+}


### PR DESCRIPTION
Each pipeline `Task` now carries a human-readable `label` (`"before /*"`, `"GET /users/{id}"`, `"no-match (static/404/405)"`, `"exception:IllegalStateException"`, …), and `JavalinServlet` notifies a list of `TaskObserver` (`JavalinState.servletTaskObservers`, registered via `app.unsafe` before start) around each task in `handleSync` with the task, its synchronous duration, and any throwable that task raised.

This makes the request lifecycle observable to plugins (debuggers, metrics, tracing) without wrapping handlers.

### Cost / behavior

When no observers are registered the servlet keeps the original fast path — no timing, no per-task callback. The only always-on cost is building a short `label` string per `Task`. A misbehaving observer is isolated: an exception it throws is caught and logged, never affecting the request.

### API note

`Task` gains `label` as its first constructor parameter (defaulted to `"task"`). Named-argument and trailing-lambda usage (`Task { … }`, `Task(skipOnExceptionAndRedirect = false) { … }`) stay source-compatible; any positional `Task(bool) { … }` caller would need updating.