### PR TITLE
[concurrency] Dispose Javalin-owned executors on stop

### DIFF
--- a/javalin/src/main/java/io/javalin/config/ConcurrencyConfig.kt
+++ b/javalin/src/main/java/io/javalin/config/ConcurrencyConfig.kt
@@ -9,7 +9,11 @@ import io.javalin.http.util.AsyncExecutor
 import io.javalin.util.ConcurrencyUtil
 import io.javalin.util.javalinLazy
 
-class ConcurrencyConfig {
+class ConcurrencyConfig(private val cfg: JavalinState) {
     @JvmField var useVirtualThreads = false
-    @JvmField var executor = javalinLazy { AsyncExecutor(ConcurrencyUtil.executorService("JavalinDefaultAsyncThreadPool", useVirtualThreads)) }
+    @JvmField var executor = javalinLazy {
+        AsyncExecutor(
+            cfg.registerOwnedExecutor(ConcurrencyUtil.executorService("JavalinDefaultAsyncThreadPool", useVirtualThreads))
+        )
+    }
 }

--- a/javalin/src/main/java/io/javalin/config/JavalinState.kt
+++ b/javalin/src/main/java/io/javalin/config/JavalinState.kt
@@ -19,6 +19,7 @@ import io.javalin.http.servlet.TaskInitializer
 import io.javalin.http.staticfiles.ResourceHandler
 import io.javalin.http.util.AsyncExecutor.Companion.AsyncExecutorKey
 import io.javalin.jetty.JettyUtil.createJettyServletWithWebsocketsIfAvailable
+import io.javalin.json.JavalinExecutorOwner
 import io.javalin.json.JavalinJackson
 import io.javalin.json.JsonMapper
 import io.javalin.plugin.Plugin
@@ -31,8 +32,11 @@ import io.javalin.util.javalinLazy
 import io.javalin.validation.Validation
 import io.javalin.validation.Validation.Companion.ValidationKey
 import io.javalin.validation.Validation.Companion.addValidationExceptionMapper
+import io.javalin.websocket.PingManager
 import io.javalin.websocket.WsConfig
 import io.javalin.websocket.WsRouter
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutorService
 import java.util.function.Consumer
 
 /**
@@ -45,6 +49,8 @@ import java.util.function.Consumer
  * @see [Javalin.create]
  */
 class JavalinState {
+    private val ownedExecutors = CopyOnWriteArrayList<ExecutorService>()
+
     //@formatter:off
     // CORE CONFIGS - HTTP, routing, and server
     @JvmField val http = HttpConfig()
@@ -65,7 +71,8 @@ class JavalinState {
 
     // MISC SETTINGS - General application-level settings
     @JvmField val startup = StartupConfig()
-    @JvmField val concurrency = ConcurrencyConfig()
+    @JvmField val concurrency = ConcurrencyConfig(this)
+    @JvmField val pingManager = PingManager()
 
     // INTERNAL CONFIG API
     @JvmField val eventManager = EventManager()
@@ -98,6 +105,20 @@ class JavalinState {
     fun <CFG> registerPlugin(plugin: Plugin<CFG>): Plugin<CFG> = plugin.also { pluginManager.register(plugin) }
     fun <T : Any?> appData(key: Key<T>, value: T) = appDataManager.register(key, value)
 
+    internal fun registerOwnedExecutor(executor: ExecutorService): ExecutorService {
+        ownedExecutors.add(executor)
+        return executor
+    }
+
+    internal fun disposeOwnedExecutors() {
+        ownedExecutors.forEach { it.shutdownNow() }
+        ownedExecutors.clear()
+        pingManager.shutdown()
+        if (jsonMapper.isInitialized()) {
+            (jsonMapper.value as? JavalinExecutorOwner)?.shutdownExecutors()
+        }
+    }
+
     companion object {
         @JvmStatic
         fun applyUserConfig(cfg: JavalinState, userConfig: Consumer<JavalinConfig>) {
@@ -108,6 +129,7 @@ class JavalinState {
             cfg.pluginManager.startPlugins()
             cfg.appDataManager.registerIfAbsent(ContextResolverKey, cfg.contextResolver)
             cfg.appDataManager.registerIfAbsent(AsyncExecutorKey, cfg.concurrency.executor.value)
+            cfg.appDataManager.registerIfAbsent(PingManager.Key, cfg.pingManager)
             cfg.appDataManager.registerIfAbsent(ValidationKey, Validation(cfg.validation))
             cfg.appDataManager.registerIfAbsent(FileRendererKey, NotImplementedRenderer())
             cfg.appDataManager.registerIfAbsent(MaxRequestSizeKey, cfg.http.maxRequestSize)

--- a/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyServer.kt
@@ -141,6 +141,7 @@ class JettyServer(private val cfg: JavalinState) {
         }
         JavalinLogger.info("Javalin has stopped")
         eventManager.fireEvent(JavalinLifecycleEvent.SERVER_STOPPED)
+        cfg.disposeOwnedExecutors()
     }
 
     private fun Handler?.attachHandler(servletContextHandler: ServletContextHandler) = when {

--- a/javalin/src/main/java/io/javalin/json/JavalinGson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinGson.kt
@@ -18,7 +18,7 @@ import java.util.stream.Stream
 open class JavalinGson(
     private val gson: Gson = Gson(),
     private val useVirtualThreads: Boolean = false,
-) : JsonMapper {
+) : JsonMapper, JavalinExecutorOwner {
 
     private val pipedStreamExecutor: PipedStreamExecutor by javalinLazy { PipedStreamExecutor(useVirtualThreads) }
 
@@ -66,5 +66,7 @@ open class JavalinGson(
 
     override fun <T : Any> fromJsonStream(json: InputStream, targetType: Type): T =
         gson.fromJson(InputStreamReader(json), targetType)
+
+    override fun shutdownExecutors() = pipedStreamExecutor.shutdown()
 
 }

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -23,7 +23,7 @@ import java.util.stream.Stream
 class JavalinJackson(
     private var objectMapper: ObjectMapper? = null,
     private val useVirtualThreads: Boolean = false,
-) : JsonMapper {
+) : JsonMapper, JavalinExecutorOwner {
 
     private val pipedStreamExecutor: PipedStreamExecutor by javalinLazy { PipedStreamExecutor(useVirtualThreads) }
 
@@ -69,6 +69,8 @@ class JavalinJackson(
 
     override fun <T : Any> fromJsonStream(json: InputStream, targetType: Type): T =
         mapper.readValue(json, mapper.typeFactory.constructType(targetType))
+
+    override fun shutdownExecutors() = pipedStreamExecutor.shutdown()
 
     /** Update the current mapper and return self for easy chaining */
     fun updateMapper(updateFunction: Consumer<ObjectMapper>): JavalinJackson {

--- a/javalin/src/main/java/io/javalin/json/JavalinJackson3.kt
+++ b/javalin/src/main/java/io/javalin/json/JavalinJackson3.kt
@@ -26,7 +26,7 @@ import tools.jackson.databind.json.JsonMapper as Jackson3Mapper
 class JavalinJackson3(
     private var jsonMapper: Jackson3Mapper? = null,
     private val useVirtualThreads: Boolean = false,
-) : JsonMapper {
+) : JsonMapper, JavalinExecutorOwner {
 
     private var mapperInstance: Jackson3Mapper? = null
 
@@ -74,6 +74,8 @@ class JavalinJackson3(
 
     override fun <T : Any> fromJsonStream(json: InputStream, targetType: Type): T =
         mapper.readValue(json, mapper.typeFactory.constructType(targetType))
+
+    override fun shutdownExecutors() = pipedStreamExecutor.shutdown()
 
     /** Update the current mapper and return self for easy chaining */
     fun updateMapper(updateFunction: Consumer<Jackson3Mapper.Builder>): JavalinJackson3 {

--- a/javalin/src/main/java/io/javalin/json/PipedStreamUtil.kt
+++ b/javalin/src/main/java/io/javalin/json/PipedStreamUtil.kt
@@ -7,9 +7,13 @@ import java.io.InputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
+internal fun interface JavalinExecutorOwner {
+    fun shutdownExecutors()
+}
+
 class PipedStreamExecutor(useVirtualThreads: Boolean) {
 
-    private val executorService by javalinLazy { ConcurrencyUtil.executorService("JavalinPipedStreamingThreadPool", useVirtualThreads) }
+    private val executorService = javalinLazy { ConcurrencyUtil.executorService("JavalinPipedStreamingThreadPool", useVirtualThreads) }
 
     fun getInputStream(userCallback: ThrowingConsumer<PipedOutputStream, Exception>): InputStream {
         val pipedOutputStream = PipedOutputStream()
@@ -17,7 +21,7 @@ class PipedStreamExecutor(useVirtualThreads: Boolean) {
             var exception: Exception? = null // possible exception from child thread
             override fun close() = exception?.let { throw it } ?: super.close()
         }
-        executorService.execute { // start child thread, necessary to prevent deadlock
+        executorService.value.execute { // start child thread, necessary to prevent deadlock
             try {
                 userCallback.accept(pipedOutputStream)
             } catch (userException: Exception) {
@@ -27,6 +31,12 @@ class PipedStreamExecutor(useVirtualThreads: Boolean) {
             }
         }
         return pipedInputStream
+    }
+
+    internal fun shutdown() {
+        if (executorService.isInitialized()) {
+            executorService.value.shutdownNow()
+        }
     }
 
 }

--- a/javalin/src/main/java/io/javalin/plugin/bundled/RateLimitPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/bundled/RateLimitPlugin.kt
@@ -1,6 +1,8 @@
 package io.javalin.plugin.bundled
 
+import io.javalin.config.JavalinState
 import io.javalin.http.Context
+import io.javalin.http.Header
 import io.javalin.http.HttpResponseException
 import io.javalin.http.HttpStatus
 import io.javalin.plugin.ContextPlugin
@@ -10,7 +12,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
-import io.javalin.http.Header
 
 class RateLimitPlugin(userConfig: Consumer<Config>? = null) : ContextPlugin<RateLimitPlugin.Config, RateLimitPlugin.Extension>(userConfig, Config()) {
 
@@ -18,6 +19,10 @@ class RateLimitPlugin(userConfig: Consumer<Config>? = null) : ContextPlugin<Rate
     private val executor: ScheduledExecutorService = ConcurrencyUtil.newSingleThreadScheduledExecutor(pluginConfig.executorName)
 
     override fun createExtension(context: Context): Extension = Extension(context)
+
+    override fun onInitialize(state: JavalinState) {
+        state.registerOwnedExecutor(executor)
+    }
 
     class Config {
         /**

--- a/javalin/src/main/java/io/javalin/websocket/WsAutomaticPing.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsAutomaticPing.kt
@@ -1,27 +1,42 @@
 package io.javalin.websocket
 
+import io.javalin.config.Key
 import io.javalin.util.ConcurrencyUtil
 import io.javalin.util.javalinLazy
-import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-object PingManager {
+class PingManager {
 
-    private val executor: ScheduledExecutorService by javalinLazy { ConcurrencyUtil.newSingleThreadScheduledExecutor("JavalinWebSocketPingThread") }
-    internal val pingFutures: ConcurrentHashMap<WsContext, ScheduledFuture<*>> by javalinLazy { ConcurrentHashMap() }
+    private val executor: Lazy<ScheduledExecutorService> = javalinLazy {
+        ConcurrencyUtil.newSingleThreadScheduledExecutor("JavalinWebSocketPingThread")
+    }
+    internal val pingFutures = ConcurrentHashMap<WsContext, ScheduledFuture<*>>()
 
     fun enableAutomaticPings(ctx: WsContext, interval: Long, unit: TimeUnit) {
         pingFutures.compute(ctx) { _, existing ->
             existing?.cancel(false)
-            executor.scheduleAtFixedRate({ ctx.sendPing() }, interval, interval, unit)
+            executor.value.scheduleAtFixedRate({ ctx.sendPing() }, interval, interval, unit)
         }
     }
 
     fun disableAutomaticPings(ctx: WsContext) {
         pingFutures.remove(ctx)?.cancel(false)
+    }
+
+    internal fun shutdown() {
+        pingFutures.values.forEach { it.cancel(false) }
+        pingFutures.clear()
+        if (executor.isInitialized()) {
+            executor.value.shutdownNow()
+        }
+    }
+
+    companion object {
+        @JvmField
+        val Key = Key<PingManager>("javalin-ws-ping-manager")
     }
 
 }

--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -54,10 +54,11 @@ abstract class WsContext(@JvmSynthetic internal val upgradeCtx: JavalinWsServlet
     fun enableAutomaticPings() = enableAutomaticPings(15, TimeUnit.SECONDS)
 
     /** Enables automatic pings at the specified interval, preventing the connection from timing out */
-    fun enableAutomaticPings(interval: Long, unit: TimeUnit) = PingManager.enableAutomaticPings(this, interval, unit)
+    fun enableAutomaticPings(interval: Long, unit: TimeUnit) =
+        upgradeCtx.appData(PingManager.Key).enableAutomaticPings(this, interval, unit)
 
     /** Disables automatic pings */
-    fun disableAutomaticPings() = PingManager.disableAutomaticPings(this)
+    fun disableAutomaticPings() = upgradeCtx.appData(PingManager.Key).disableAutomaticPings(this)
 
     /** Returns the full query [String], or null if no query is present */
     fun queryString(): String? = upgradeCtx.extractedData.queryString

--- a/javalin/src/test/java/io/javalin/TestExecutorLifecycle.kt
+++ b/javalin/src/test/java/io/javalin/TestExecutorLifecycle.kt
@@ -1,0 +1,100 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.plugin.bundled.RateLimitPlugin
+import io.javalin.testing.HttpUtil
+import io.javalin.testing.SerializableObject
+import io.javalin.testing.TestUtil
+import io.javalin.websocket.WsTestClient
+import io.javalin.websocket.awaitCondition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.SECONDS
+
+/**
+ * Item 3 of #2628: Javalin-owned executors (async / piped / ws-ping / rate-limit)
+ * must be disposed on stop so create/start/stop cycles do not leak threads.
+ * Neighbour: [TestGracefulShutdown].
+ */
+@Timeout(value = 30, unit = SECONDS)
+internal class TestExecutorLifecycle {
+
+    @Test
+    fun `repeated create start stop cycles do not accumulate Javalin executor threads`() = TestUtil.runLogLess {
+        val baseline = javalinOwnedExecutorThreads().toSet()
+        val leftoverPerCycle = mutableListOf<List<Thread>>()
+
+        repeat(CYCLES) {
+            val pings = ConcurrentLinkedQueue<String>()
+            val app = Javalin.create { cfg ->
+                cfg.registerPlugin(RateLimitPlugin())
+                cfg.routes.get("/async") { ctx ->
+                    ctx.async { ctx.result("async-ok") }
+                }
+                cfg.routes.get("/json-stream") { ctx ->
+                    ctx.jsonStream(SerializableObject())
+                }
+                cfg.routes.get("/rate") { ctx ->
+                    ctx.with(RateLimitPlugin::class).requestPerTimeUnit(1_000, TimeUnit.HOURS)
+                    ctx.result("rate-ok")
+                }
+                cfg.routes.ws("/ws") { ws ->
+                    ws.onConnect { it.enableAutomaticPings(5, TimeUnit.MILLISECONDS) }
+                }
+            }
+            app.start(0)
+            val http = HttpUtil(app.port())
+            assertThat(http.getBody("/async")).isEqualTo("async-ok")
+            assertThat(http.getBody("/json-stream")).contains("value1")
+            assertThat(http.getBody("/rate")).isEqualTo("rate-ok")
+
+            val client = WsTestClient(app, "/ws", onPing = { pings.add("ping") })
+            client.connectBlocking()
+            awaitCondition(condition = { pings.isNotEmpty() })
+            client.disconnectBlocking()
+            app.stop()
+
+            leftoverPerCycle += awaitExecutorThreadsBeyond(baseline)
+        }
+
+        leftoverPerCycle.forEach { leftover ->
+            assertThat(leftover.map { it.name })
+                .withFailMessage { "Javalin executor threads still alive after stop(): ${leftover.map { it.name }}" }
+                .isEmpty()
+        }
+    }
+
+    companion object {
+        private const val CYCLES = 5
+        private val EXECUTOR_PREFIXES = listOf(
+            "JavalinDefaultAsyncThreadPool",
+            "JavalinPipedStreamingThreadPool",
+            "JavalinWebSocketPingThread",
+            "JavalinRateLimitExecutor",
+        )
+
+        private fun javalinOwnedExecutorThreads(): List<Thread> =
+            Thread.getAllStackTraces().keys.filter { thread ->
+                thread.isAlive && EXECUTOR_PREFIXES.any { thread.name.startsWith(it) }
+            }
+
+        private fun awaitExecutorThreadsBeyond(baseline: Set<Thread>): List<Thread> {
+            val deadline = System.currentTimeMillis() + 2_000
+            var leftover: List<Thread>
+            do {
+                leftover = javalinOwnedExecutorThreads().filter { it !in baseline }
+                if (leftover.isEmpty()) return leftover
+                Thread.sleep(20)
+            } while (System.currentTimeMillis() < deadline)
+            return leftover
+        }
+    }
+}

--- a/javalin/src/test/java/io/javalin/websocket/TestWebSocket.kt
+++ b/javalin/src/test/java/io/javalin/websocket/TestWebSocket.kt
@@ -280,7 +280,7 @@ class TestWebSocket {
             client.connectBlocking()
             Thread.sleep(50)
             assertThat(log.size).isGreaterThan(0)
-            awaitCondition(condition = { PingManager.pingFutures.isEmpty() }) { client.send("DISABLE_PINGS") }
+            awaitCondition(condition = { app.unsafe.pingManager.pingFutures.isEmpty() }) { client.send("DISABLE_PINGS") }
             Thread.sleep(50)
             assertThat(log.size).isEqualTo(0) // no pings sent during sleep after disabling pings
             client.disconnectBlocking()


### PR DESCRIPTION
## Summary
- Bind Javalin-owned async, piped-stream, WebSocket-ping, and rate-limit executors to the `Javalin` instance (`JavalinState`) and `shutdownNow()` them after `SERVER_STOPPED`.
- Make `PingManager` instance-scoped instead of a JVM-global `object`, so ping futures/threads are not shared across create/start/stop cycles.
- Add an integration test (neighbour: `TestGracefulShutdown`) that exercises all four executors over repeated create/start/stop cycles and asserts no named executor threads remain.

Fixes item 3 of #2628. Remaining tracking items (6, 7, 9, 10, 11, 12) are out of scope.

Daemon-thread part of this issue already landed in #2630; this PR only disposes the pools.

## Test plan
- [x] Wrote the integration test first: `./mvnw test -pl javalin -Dtest=TestExecutorLifecycle` failed before the patch (`JavalinRateLimitExecutor`, `JavalinDefaultAsyncThreadPool`, `JavalinPipedStreamingThreadPool`, `JavalinWebSocketPingThread` still alive after `stop()`).
- [x] Same test passes after the patch (JDK 21).
- [x] `./mvnw test -pl javalin` (JDK 21 Temurin 21.0.12): 1009 tests, 0 failures (22 skipped: existing `@Disabled`/browser gaps).
- [x] Neighbour suites: `TestWebSocket`, `TestRateLimitPlugin`, `TestConcurrencyUtil`, `TestLifecycleEvents`, `TestClose`, `TestJson`.