### PR TITLE
[http] Add problem+json and problem+xml content types

### DIFF
--- a/javalin/src/main/java/io/javalin/http/ContentType.kt
+++ b/javalin/src/main/java/io/javalin/http/ContentType.kt
@@ -79,6 +79,8 @@ enum class ContentType(
     APPLICATION_EPUB("application/epub+zip", false, "epub"),
     APPLICATION_GZ("application/gzip", false, "gz"),
     APPLICATION_JSON("application/json", true, "json"),
+    APPLICATION_PROBLEM_JSON("application/problem+json", true),
+    APPLICATION_PROBLEM_XML("application/problem+xml", true),
     APPLICATION_MPKG("application/vnd.apple.installer+xml", false, "mpkg"),
     APPLICATION_JAR("application/java-archive", false, "jar"),
     APPLICATION_PDF("application/pdf", true, "pdf"),
@@ -112,6 +114,8 @@ enum class ContentType(
         const val OCTET_STREAM = "application/octet-stream"
         const val JAVASCRIPT = "text/javascript"
         const val JSON = "application/json"
+        const val PROBLEM_JSON = "application/problem+json"
+        const val PROBLEM_XML = "application/problem+xml"
         const val FORM_DATA = "multipart/form-data"
 
         @JvmStatic


### PR DESCRIPTION
To address #2637, added APPLICATION_PROBLEM_JSON and APPLICATION_PROBLEM_XML enums, and PROBLEM_JSON and PROBLEM_XML companion objects to ContentType. No additional unit tests were added since ContentTypeTest already validates the registry generically by iterating over every enum value and asserting ContentType.contentType(it.mimeType) resolves correctly. 
I can also take a look at the related #2638 if it is ok to move forward. 