### PR TITLE
[validation] Don't run checks on a null value

### DIFF
--- a/javalin/src/main/java/io/javalin/validation/Validator.kt
+++ b/javalin/src/main/java/io/javalin/validation/Validator.kt
@@ -44,7 +44,9 @@ open class Validator<T> internal constructor(internal val params: Params, intern
             return@javalinLazy mapOf(fieldName to listOf(ValidationError(conversionErrorMessage, value = params.stringValue, exception = e)))
         }
         val errors = mutableMapOf<String, MutableList<ValidationError<Any?>>>()
-        rules.filter { !it.check(typedValue) }.forEach { failedRule ->
+        // A null value can't satisfy a typed check (and would NPE a non-null-safe one), so skip
+        // checks and let get()/required() surface it as NULLCHECK_FAILED instead.
+        rules.filter { typedValue != null && !it.check(typedValue) }.forEach { failedRule ->
             errors.computeIfAbsent(failedRule.fieldName) { mutableListOf() }
             errors[failedRule.fieldName]!!.add(failedRule.error.also { it.value = typedValue })
         }

--- a/javalin/src/test/java/io/javalin/TestValidation.kt
+++ b/javalin/src/test/java/io/javalin/TestValidation.kt
@@ -244,6 +244,16 @@ class TestValidation {
     }
 
     @Test
+    fun `checks are not run on a null value`() = TestUtil.test { app, http ->
+        app.unsafe.routes.get("/") { ctx ->
+            ctx.queryParamAsClass<String>("my-qp").required()
+                .check({ it.length > 5 }, "too short") // would NPE if run on the missing (null) value
+                .get()
+        }
+        assertThat(http.get("/").httpCode()).isEqualTo(BAD_REQUEST) // NULLCHECK_FAILED, not a 500 NPE
+    }
+
+    @Test
     fun `multiple checks and named fields work when validating class`() = TestUtil.test { app, http ->
         app.unsafe.routes.post("/json") { ctx ->
             val obj = ctx.bodyValidator<SerializableObject>()


### PR DESCRIPTION
A non-null-safe check on a null value threw an NPE (500) instead of the intended NULLCHECK_FAILED (400). Skip checks when the value is null.

Closes #2642.