### PR TITLE
[static-files] Send Content-Length for streamed static files

### DIFF
--- a/javalin/src/main/java/io/javalin/compression/CompressedStream.kt
+++ b/javalin/src/main/java/io/javalin/compression/CompressedStream.kt
@@ -25,6 +25,7 @@ internal class CompressedOutputStream(
                 compression.findMatchingCompressor(ctx.header(Header.ACCEPT_ENCODING) ?: "")?.also {
                     this.compressedStream = it.compress(originStream)
                     ctx.header(Header.CONTENT_ENCODING, it.encoding())
+                    ctx.res().setHeader(Header.CONTENT_LENGTH, null) // compressed size is unknown, drop any preset length
                 }
             }
             isCompressionDecisionMade = true

--- a/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/StaticFileHandler.kt
@@ -16,6 +16,7 @@ class StaticFileHandler(val config: StaticFileConfig) {
         val resource = getResource(resourcePath) ?: return false
         resolveContentType(resource, resourcePath)?.let { ctx.contentType(it) }
         if (tryHandleEtag(resource, ctx)) return true
+        resource.length().takeIf { it > 0 }?.let { ctx.header(Header.CONTENT_LENGTH, it.toString()) }
         ctx.result(resource.newInputStream())
         return true
     }

--- a/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyResourceHandler.kt
@@ -89,6 +89,7 @@ open class ConfigurableHandler(val config: StaticFileConfig, jettyServer: Server
         val resource = getResource(resourcePath) ?: return false
         resolveContentType(resource, resourcePath)?.let { ctx.contentType(it) }
         if (isEtags && tryHandleAsEtags(resource, ctx)) return true
+        resource.length().takeIf { it > 0 }?.let { ctx.header(Header.CONTENT_LENGTH, it.toString()) }
         ctx.result(resource.newInputStream())
         return true
     }

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFiles.kt
@@ -130,6 +130,12 @@ class TestStaticFiles {
     }
 
     @Test
+    fun `static files are served with a Content-Length header`() = testStaticFiles(defaultStaticResourceApp) { _, http ->
+        val response = http.get("/html.html", mapOf(Header.ACCEPT_ENCODING to "null")) // no compression, so length is exact
+        assertThat(response.headers.getFirst(Header.CONTENT_LENGTH)).isEqualTo(response.body.toByteArray().size.toString())
+    }
+
+    @Test
     fun `static files are streamed, not read into memory`() = testStaticFiles(defaultStaticResourceApp) { app, http ->
         var streamed = false
         app.unsafe.routes.after("/html.html") { streamed = it.resultInputStream() !is ByteArrayInputStream }

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesPrecompressor.kt
@@ -54,15 +54,17 @@ class TestStaticFilesPrecompressor {
     }
 
     @Test
-    fun `content-length unavailable for large files if precompression not enabled`() = testStaticFiles({ cfg ->
+    fun `content-length is set for large files even if precompression not enabled`() = testStaticFiles({ cfg ->
         cfg.staticFiles.enableWebjars()
     }) { _, http ->
+        // compressible JS gets gzipped on the fly, so it's chunked without a Content-Length
         assertThat(http.getFile("$swaggerBasePath/swagger-ui-bundle.js", "gzip"))
             .extracting({ it.code }, { it.contentLength() })
             .containsExactly(HttpStatus.OK.code, null)
+        // already-compressed .gz is served as-is and now carries a Content-Length
         assertThat(http.getFile("$swaggerBasePath/swagger-ui.js.gz", "gzip"))
-            .extracting({ it.code }, { it.contentLength() })
-            .containsExactly(HttpStatus.OK.code, null)
+            .extracting({ it.code }, { it.contentLength() != null })
+            .containsExactly(HttpStatus.OK.code, true)
     }
 
     @Test


### PR DESCRIPTION
Static files are streamed, so they went out without a `Content-Length` and clients couldn't show download progress (you'd see `20MB / 0B`). This just sets it from the resource length, in both the Jetty and the Javalin resource handler.

The annoying part is compression. The length is for the uncompressed file, but if we gzip on the fly the body is smaller, so the header would lie - and http2 is strict about that and 500s (which shows up as a hang on some clients). So the compressor now drops the `Content-Length` when it actually kicks in, and lets Jetty figure out the compressed length itself.

Checked it with curl over http1 and http2: plain files get a correct length, gzipped ones stay chunked, no more 500s. Also flipped an old test that was asserting the missing header.

This is only the `Content-Length` half of #2639, `Content-Disposition` is a separate thing.